### PR TITLE
Implement `get_*_draw_list` and `DrawList` drawing functions

### DIFF
--- a/imgui-examples/examples/draw_list.rs
+++ b/imgui-examples/examples/draw_list.rs
@@ -1,0 +1,41 @@
+use imgui::*;
+
+mod support;
+
+fn main() {
+    let system = support::init(file!());
+    system.main_loop(|_, ui| {
+        let red = [1.0, 0.0, 0.0];
+        let green = [0.0, 1.0, 0.0];
+        let blue = [0.5, 0.5, 1.0];
+
+        Window::new(im_str!("Hello world"))
+            .size([300.0, 100.0], Condition::FirstUseEver)
+            .build(ui, || {
+                ui.text("Hello world!");
+
+                let mut window_draw_list = ui.get_window_draw_list();
+
+                // in screen space
+                window_draw_list
+                    .add_circle([250.0, 250.0], 50.0, red)
+                    .build();
+                window_draw_list.add_text([160.0, 280.0], red, "window screen space");
+
+                // in window space
+                let p1 = ui.cursor_screen_pos();
+                window_draw_list
+                    .add_line(p1, [p1[0] + 50.0, p1[1] + 50.0], red)
+                    .build();
+                window_draw_list.add_text([p1[0] + 50.0, p1[1] + 50.0], red, "window local");
+            });
+
+        let mut bg_draw_list = ui.get_background_draw_list();
+        bg_draw_list.add_circle([250.0, 250.0], 100.0, blue).build();
+        bg_draw_list.add_text([100.0, 160.0], blue, "background");
+
+        let mut fg_draw_list = ui.get_foreground_draw_list();
+        fg_draw_list.add_circle([250.0, 250.0], 75.0, green).build();
+        fg_draw_list.add_text([100.0, 200.0], green, "foreground");
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use self::widget::selectable::*;
 pub use self::widget::slider::*;
 pub use self::window::child_window::*;
 pub use self::window::*;
-pub use self::window_draw_list::{ChannelsSplit, ImColor, WindowDrawList};
+pub use self::window_draw_list::{BackgroundDrawList, ForegroundDrawList, WindowDrawList};
 use internal::RawCast;
 
 mod clipboard;
@@ -135,7 +135,7 @@ impl<'ui> Ui<'ui> {
         *self.ctx.style()
     }
     /// Renders the frame and returns a reference to the resulting draw data
-    pub fn render(self) -> &'ui DrawData {
+    pub fn render(self) -> &'ui DrawData<'ui> {
         unsafe {
             sys::igRender();
             &*(sys::igGetDrawData() as *mut DrawData)
@@ -503,14 +503,14 @@ impl<'ui> Ui<'ui> {
 
 /// # Draw list for custom drawing
 impl<'ui> Ui<'ui> {
-    /// Get access to drawing API
+    /// Get access to window drawing API
     ///
     /// # Examples
     ///
     /// ```rust,no_run
     /// # use imgui::*;
     /// fn custom_draw(ui: &Ui) {
-    ///     let draw_list = ui.get_window_draw_list();
+    ///     let mut draw_list = ui.get_window_draw_list();
     ///     // Draw a line
     ///     const WHITE: [f32; 3] = [1.0, 1.0, 1.0];
     ///     draw_list.add_line([100.0, 100.0], [200.0, 200.0], WHITE).build();
@@ -534,6 +534,20 @@ impl<'ui> Ui<'ui> {
     /// ```
     pub fn get_window_draw_list(&'ui self) -> WindowDrawList<'ui> {
         WindowDrawList::new(self)
+    }
+
+    /// Get access to foreground drawing API. See [`Self::get_window_draw_list`].
+    ///
+    /// This draw list appears in front of all ImGui windows.
+    pub fn get_foreground_draw_list(&'ui self) -> ForegroundDrawList<'ui> {
+        ForegroundDrawList::new(self)
+    }
+
+    /// Get access to background drawing API. See [`Self::get_window_draw_list`].
+    ///
+    /// This draw list appears behind all ImGui windows.
+    pub fn get_background_draw_list(&'ui self) -> BackgroundDrawList<'ui> {
+        BackgroundDrawList::new(self)
     }
 }
 

--- a/src/render/draw_data.rs
+++ b/src/render/draw_data.rs
@@ -68,12 +68,12 @@ impl<'ui> DrawData<'ui> {
 }
 
 /// Iterator over draw lists
-pub struct DrawListIterator<'a> {
-    iter: std::slice::Iter<'a, DrawList<'a>>,
+pub struct DrawListIterator<'ui, 'a> {
+    iter: std::slice::Iter<'a, DrawList<'ui>>,
 }
 
-impl<'a> Iterator for DrawListIterator<'a> {
-    type Item = &'a DrawList<'a>;
+impl<'ui, 'a> Iterator for DrawListIterator<'ui, 'a> {
+    type Item = &'a DrawList<'ui>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()


### PR DESCRIPTION
Closes #220

- Merge 1imgui::render::DrawList1 with 1imgui::WindowDrawList1
- Rename `WindowDrawList` to `DrawList` and make `[Window|Foreground|Background]DrawList` into a wrapper for `DrawList`
- Add `'ui` lifetime to `DrawData` and `*DrawList`
- Make all `DrawList` methods take `&mut self` instead of `&self`

**Breaks DrawData/DrawList API?**

- [ ] Rename `window_draw_list` to `draw_list`, but for now, this keeps the diff sane.
- [ ] Expose `DrawList`, `ImColor` publicly
- [ ] Path API?