### PR TITLE
Add initial bindings for docking branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "imgui-sys/third-party/cimgui"]
 	path = imgui-sys/third-party/cimgui
 	url = https://github.com/Extrawurst/cimgui.git
+	branch = "docking"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "imgui-sys/third-party/cimgui"]
 	path = imgui-sys/third-party/cimgui
 	url = https://github.com/Extrawurst/cimgui.git
-	branch = "docking"
+	branch = "1.77dock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "Gekkio/imgui-rs" }
 bitflags = "1.0"
 glium = { version = "0.25", default-features = false, optional = true }
 gfx = { version = "0.18", optional = true }
-imgui-sys = { version = "0.2", path = "imgui-sys" }
+imgui-sys = { version = "0.2.1", path = "imgui-sys" }
 lazy_static = "1.1"
 parking_lot = "0.9"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ imgui-sys = { version = "0.2.1", path = "imgui-sys" }
 lazy_static = "1.1"
 parking_lot = "0.9"
 
+[features]
+default = ["docking"]
+docking = []
+
 [dev-dependencies]
 memoffset = "0.5"
 

--- a/imgui-sys/src/bindings.rs
+++ b/imgui-sys/src/bindings.rs
@@ -160,6 +160,7 @@ pub type ImGuiBackendFlags = ::std::os::raw::c_int;
 pub type ImGuiColorEditFlags = ::std::os::raw::c_int;
 pub type ImGuiConfigFlags = ::std::os::raw::c_int;
 pub type ImGuiComboFlags = ::std::os::raw::c_int;
+pub type ImGuiDockNodeFlags = ::std::os::raw::c_int;
 pub type ImGuiDragDropFlags = ::std::os::raw::c_int;
 pub type ImGuiFocusedFlags = ::std::os::raw::c_int;
 pub type ImGuiHoveredFlags = ::std::os::raw::c_int;
@@ -168,6 +169,7 @@ pub type ImGuiSelectableFlags = ::std::os::raw::c_int;
 pub type ImGuiTabBarFlags = ::std::os::raw::c_int;
 pub type ImGuiTabItemFlags = ::std::os::raw::c_int;
 pub type ImGuiTreeNodeFlags = ::std::os::raw::c_int;
+pub type ImGuiViewportFlags = ::std::os::raw::c_int;
 pub type ImGuiWindowFlags = ::std::os::raw::c_int;
 pub type ImGuiInputTextCallback = ::std::option::Option<
     unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> ::std::os::raw::c_int,
@@ -175,6 +177,7 @@ pub type ImGuiInputTextCallback = ::std::option::Option<
 pub type ImGuiSizeCallback =
     ::std::option::Option<unsafe extern "C" fn(data: *mut ImGuiSizeCallbackData)>;
 pub type ImU32 = ::std::os::raw::c_uint;
+pub type ImU64 = u64;
 pub type ImDrawCallback = ::std::option::Option<
     unsafe extern "C" fn(parent_list: *const ImDrawList, cmd: *const ImDrawCmd),
 >;
@@ -851,6 +854,124 @@ impl Default for ImVector_ImFontConfig {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct ImVector_ImGuiPlatformMonitor {
+    pub Size: ::std::os::raw::c_int,
+    pub Capacity: ::std::os::raw::c_int,
+    pub Data: *mut ImGuiPlatformMonitor,
+}
+#[test]
+fn bindgen_test_layout_ImVector_ImGuiPlatformMonitor() {
+    assert_eq!(
+        ::std::mem::size_of::<ImVector_ImGuiPlatformMonitor>(),
+        16usize,
+        concat!("Size of: ", stringify!(ImVector_ImGuiPlatformMonitor))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ImVector_ImGuiPlatformMonitor>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ImVector_ImGuiPlatformMonitor))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImVector_ImGuiPlatformMonitor>())).Size as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImVector_ImGuiPlatformMonitor),
+            "::",
+            stringify!(Size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImVector_ImGuiPlatformMonitor>())).Capacity as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImVector_ImGuiPlatformMonitor),
+            "::",
+            stringify!(Capacity)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImVector_ImGuiPlatformMonitor>())).Data as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImVector_ImGuiPlatformMonitor),
+            "::",
+            stringify!(Data)
+        )
+    );
+}
+impl Default for ImVector_ImGuiPlatformMonitor {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct ImVector_ImGuiViewportPtr {
+    pub Size: ::std::os::raw::c_int,
+    pub Capacity: ::std::os::raw::c_int,
+    pub Data: *mut *mut ImGuiViewport,
+}
+#[test]
+fn bindgen_test_layout_ImVector_ImGuiViewportPtr() {
+    assert_eq!(
+        ::std::mem::size_of::<ImVector_ImGuiViewportPtr>(),
+        16usize,
+        concat!("Size of: ", stringify!(ImVector_ImGuiViewportPtr))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ImVector_ImGuiViewportPtr>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ImVector_ImGuiViewportPtr))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImVector_ImGuiViewportPtr>())).Size as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImVector_ImGuiViewportPtr),
+            "::",
+            stringify!(Size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImVector_ImGuiViewportPtr>())).Capacity as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImVector_ImGuiViewportPtr),
+            "::",
+            stringify!(Capacity)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImVector_ImGuiViewportPtr>())).Data as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImVector_ImGuiViewportPtr),
+            "::",
+            stringify!(Data)
+        )
+    );
+}
+impl Default for ImVector_ImGuiViewportPtr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontPtr {
     pub Size: ::std::os::raw::c_int,
     pub Capacity: ::std::os::raw::c_int,
@@ -1215,6 +1336,7 @@ pub const ImGuiWindowFlags_AlwaysUseWindowPadding: ImGuiWindowFlags_ = 65536;
 pub const ImGuiWindowFlags_NoNavInputs: ImGuiWindowFlags_ = 262144;
 pub const ImGuiWindowFlags_NoNavFocus: ImGuiWindowFlags_ = 524288;
 pub const ImGuiWindowFlags_UnsavedDocument: ImGuiWindowFlags_ = 1048576;
+pub const ImGuiWindowFlags_NoDocking: ImGuiWindowFlags_ = 2097152;
 pub const ImGuiWindowFlags_NoNav: ImGuiWindowFlags_ = 786432;
 pub const ImGuiWindowFlags_NoDecoration: ImGuiWindowFlags_ = 43;
 pub const ImGuiWindowFlags_NoInputs: ImGuiWindowFlags_ = 786944;
@@ -1224,6 +1346,7 @@ pub const ImGuiWindowFlags_Tooltip: ImGuiWindowFlags_ = 33554432;
 pub const ImGuiWindowFlags_Popup: ImGuiWindowFlags_ = 67108864;
 pub const ImGuiWindowFlags_Modal: ImGuiWindowFlags_ = 134217728;
 pub const ImGuiWindowFlags_ChildMenu: ImGuiWindowFlags_ = 268435456;
+pub const ImGuiWindowFlags_DockNodeHost: ImGuiWindowFlags_ = 536870912;
 pub type ImGuiWindowFlags_ = u32;
 pub const ImGuiInputTextFlags_None: ImGuiInputTextFlags_ = 0;
 pub const ImGuiInputTextFlags_CharsDecimal: ImGuiInputTextFlags_ = 1;
@@ -1260,6 +1383,8 @@ pub const ImGuiTreeNodeFlags_OpenOnArrow: ImGuiTreeNodeFlags_ = 128;
 pub const ImGuiTreeNodeFlags_Leaf: ImGuiTreeNodeFlags_ = 256;
 pub const ImGuiTreeNodeFlags_Bullet: ImGuiTreeNodeFlags_ = 512;
 pub const ImGuiTreeNodeFlags_FramePadding: ImGuiTreeNodeFlags_ = 1024;
+pub const ImGuiTreeNodeFlags_SpanAvailWidth: ImGuiTreeNodeFlags_ = 2048;
+pub const ImGuiTreeNodeFlags_SpanFullWidth: ImGuiTreeNodeFlags_ = 4096;
 pub const ImGuiTreeNodeFlags_NavLeftJumpsBackHere: ImGuiTreeNodeFlags_ = 8192;
 pub const ImGuiTreeNodeFlags_CollapsingHeader: ImGuiTreeNodeFlags_ = 26;
 pub type ImGuiTreeNodeFlags_ = u32;
@@ -1268,6 +1393,7 @@ pub const ImGuiSelectableFlags_DontClosePopups: ImGuiSelectableFlags_ = 1;
 pub const ImGuiSelectableFlags_SpanAllColumns: ImGuiSelectableFlags_ = 2;
 pub const ImGuiSelectableFlags_AllowDoubleClick: ImGuiSelectableFlags_ = 4;
 pub const ImGuiSelectableFlags_Disabled: ImGuiSelectableFlags_ = 8;
+pub const ImGuiSelectableFlags_AllowItemOverlap: ImGuiSelectableFlags_ = 16;
 pub type ImGuiSelectableFlags_ = u32;
 pub const ImGuiComboFlags_None: ImGuiComboFlags_ = 0;
 pub const ImGuiComboFlags_PopupAlignLeft: ImGuiComboFlags_ = 1;
@@ -1314,6 +1440,14 @@ pub const ImGuiHoveredFlags_AllowWhenDisabled: ImGuiHoveredFlags_ = 128;
 pub const ImGuiHoveredFlags_RectOnly: ImGuiHoveredFlags_ = 104;
 pub const ImGuiHoveredFlags_RootAndChildWindows: ImGuiHoveredFlags_ = 3;
 pub type ImGuiHoveredFlags_ = u32;
+pub const ImGuiDockNodeFlags_None: ImGuiDockNodeFlags_ = 0;
+pub const ImGuiDockNodeFlags_KeepAliveOnly: ImGuiDockNodeFlags_ = 1;
+pub const ImGuiDockNodeFlags_NoDockingInCentralNode: ImGuiDockNodeFlags_ = 4;
+pub const ImGuiDockNodeFlags_PassthruCentralNode: ImGuiDockNodeFlags_ = 8;
+pub const ImGuiDockNodeFlags_NoSplit: ImGuiDockNodeFlags_ = 16;
+pub const ImGuiDockNodeFlags_NoResize: ImGuiDockNodeFlags_ = 32;
+pub const ImGuiDockNodeFlags_AutoHideTabBar: ImGuiDockNodeFlags_ = 64;
+pub type ImGuiDockNodeFlags_ = u32;
 pub const ImGuiDragDropFlags_None: ImGuiDragDropFlags_ = 0;
 pub const ImGuiDragDropFlags_SourceNoPreviewTooltip: ImGuiDragDropFlags_ = 1;
 pub const ImGuiDragDropFlags_SourceNoDisableHover: ImGuiDragDropFlags_ = 2;
@@ -1386,12 +1520,11 @@ pub const ImGuiNavInput_FocusNext: ImGuiNavInput_ = 13;
 pub const ImGuiNavInput_TweakSlow: ImGuiNavInput_ = 14;
 pub const ImGuiNavInput_TweakFast: ImGuiNavInput_ = 15;
 pub const ImGuiNavInput_KeyMenu_: ImGuiNavInput_ = 16;
-pub const ImGuiNavInput_KeyTab_: ImGuiNavInput_ = 17;
-pub const ImGuiNavInput_KeyLeft_: ImGuiNavInput_ = 18;
-pub const ImGuiNavInput_KeyRight_: ImGuiNavInput_ = 19;
-pub const ImGuiNavInput_KeyUp_: ImGuiNavInput_ = 20;
-pub const ImGuiNavInput_KeyDown_: ImGuiNavInput_ = 21;
-pub const ImGuiNavInput_COUNT: ImGuiNavInput_ = 22;
+pub const ImGuiNavInput_KeyLeft_: ImGuiNavInput_ = 17;
+pub const ImGuiNavInput_KeyRight_: ImGuiNavInput_ = 18;
+pub const ImGuiNavInput_KeyUp_: ImGuiNavInput_ = 19;
+pub const ImGuiNavInput_KeyDown_: ImGuiNavInput_ = 20;
+pub const ImGuiNavInput_COUNT: ImGuiNavInput_ = 21;
 pub const ImGuiNavInput_InternalStart_: ImGuiNavInput_ = 16;
 pub type ImGuiNavInput_ = u32;
 pub const ImGuiConfigFlags_None: ImGuiConfigFlags_ = 0;
@@ -1401,6 +1534,10 @@ pub const ImGuiConfigFlags_NavEnableSetMousePos: ImGuiConfigFlags_ = 4;
 pub const ImGuiConfigFlags_NavNoCaptureKeyboard: ImGuiConfigFlags_ = 8;
 pub const ImGuiConfigFlags_NoMouse: ImGuiConfigFlags_ = 16;
 pub const ImGuiConfigFlags_NoMouseCursorChange: ImGuiConfigFlags_ = 32;
+pub const ImGuiConfigFlags_DockingEnable: ImGuiConfigFlags_ = 64;
+pub const ImGuiConfigFlags_ViewportsEnable: ImGuiConfigFlags_ = 1024;
+pub const ImGuiConfigFlags_DpiEnableScaleViewports: ImGuiConfigFlags_ = 16384;
+pub const ImGuiConfigFlags_DpiEnableScaleFonts: ImGuiConfigFlags_ = 32768;
 pub const ImGuiConfigFlags_IsSRGB: ImGuiConfigFlags_ = 1048576;
 pub const ImGuiConfigFlags_IsTouchScreen: ImGuiConfigFlags_ = 2097152;
 pub type ImGuiConfigFlags_ = u32;
@@ -1409,6 +1546,9 @@ pub const ImGuiBackendFlags_HasGamepad: ImGuiBackendFlags_ = 1;
 pub const ImGuiBackendFlags_HasMouseCursors: ImGuiBackendFlags_ = 2;
 pub const ImGuiBackendFlags_HasSetMousePos: ImGuiBackendFlags_ = 4;
 pub const ImGuiBackendFlags_RendererHasVtxOffset: ImGuiBackendFlags_ = 8;
+pub const ImGuiBackendFlags_PlatformHasViewports: ImGuiBackendFlags_ = 1024;
+pub const ImGuiBackendFlags_HasMouseHoveredViewport: ImGuiBackendFlags_ = 2048;
+pub const ImGuiBackendFlags_RendererHasViewports: ImGuiBackendFlags_ = 4096;
 pub type ImGuiBackendFlags_ = u32;
 pub const ImGuiCol_Text: ImGuiCol_ = 0;
 pub const ImGuiCol_TextDisabled: ImGuiCol_ = 1;
@@ -1448,17 +1588,19 @@ pub const ImGuiCol_TabHovered: ImGuiCol_ = 34;
 pub const ImGuiCol_TabActive: ImGuiCol_ = 35;
 pub const ImGuiCol_TabUnfocused: ImGuiCol_ = 36;
 pub const ImGuiCol_TabUnfocusedActive: ImGuiCol_ = 37;
-pub const ImGuiCol_PlotLines: ImGuiCol_ = 38;
-pub const ImGuiCol_PlotLinesHovered: ImGuiCol_ = 39;
-pub const ImGuiCol_PlotHistogram: ImGuiCol_ = 40;
-pub const ImGuiCol_PlotHistogramHovered: ImGuiCol_ = 41;
-pub const ImGuiCol_TextSelectedBg: ImGuiCol_ = 42;
-pub const ImGuiCol_DragDropTarget: ImGuiCol_ = 43;
-pub const ImGuiCol_NavHighlight: ImGuiCol_ = 44;
-pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 45;
-pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 46;
-pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 47;
-pub const ImGuiCol_COUNT: ImGuiCol_ = 48;
+pub const ImGuiCol_DockingPreview: ImGuiCol_ = 38;
+pub const ImGuiCol_DockingEmptyBg: ImGuiCol_ = 39;
+pub const ImGuiCol_PlotLines: ImGuiCol_ = 40;
+pub const ImGuiCol_PlotLinesHovered: ImGuiCol_ = 41;
+pub const ImGuiCol_PlotHistogram: ImGuiCol_ = 42;
+pub const ImGuiCol_PlotHistogramHovered: ImGuiCol_ = 43;
+pub const ImGuiCol_TextSelectedBg: ImGuiCol_ = 44;
+pub const ImGuiCol_DragDropTarget: ImGuiCol_ = 45;
+pub const ImGuiCol_NavHighlight: ImGuiCol_ = 46;
+pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 47;
+pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 48;
+pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 49;
+pub const ImGuiCol_COUNT: ImGuiCol_ = 50;
 pub type ImGuiCol_ = u32;
 pub const ImGuiStyleVar_Alpha: ImGuiStyleVar_ = 0;
 pub const ImGuiStyleVar_WindowPadding: ImGuiStyleVar_ = 1;
@@ -1567,13 +1709,13 @@ pub struct ImGuiStyle {
     pub AntiAliasedLines: bool,
     pub AntiAliasedFill: bool,
     pub CurveTessellationTol: f32,
-    pub Colors: [ImVec4; 48usize],
+    pub Colors: [ImVec4; 50usize],
 }
 #[test]
 fn bindgen_test_layout_ImGuiStyle() {
     assert_eq!(
         ::std::mem::size_of::<ImGuiStyle>(),
-        944usize,
+        976usize,
         concat!("Size of: ", stringify!(ImGuiStyle))
     );
     assert_eq!(
@@ -1968,11 +2110,20 @@ pub struct ImGuiIO {
     pub FontAllowUserScaling: bool,
     pub FontDefault: *mut ImFont,
     pub DisplayFramebufferScale: ImVec2,
+    pub ConfigDockingNoSplit: bool,
+    pub ConfigDockingWithShift: bool,
+    pub ConfigDockingAlwaysTabBar: bool,
+    pub ConfigDockingTransparentPayload: bool,
+    pub ConfigViewportsNoAutoMerge: bool,
+    pub ConfigViewportsNoTaskBarIcon: bool,
+    pub ConfigViewportsNoDecoration: bool,
+    pub ConfigViewportsNoDefaultParent: bool,
     pub MouseDrawCursor: bool,
     pub ConfigMacOSXBehaviors: bool,
     pub ConfigInputTextCursorBlink: bool,
     pub ConfigWindowsResizeFromEdges: bool,
     pub ConfigWindowsMoveFromTitleBarOnly: bool,
+    pub ConfigWindowsMemoryCompactTimer: f32,
     pub BackendPlatformName: *const ::std::os::raw::c_char,
     pub BackendRendererName: *const ::std::os::raw::c_char,
     pub BackendPlatformUserData: *mut ::std::os::raw::c_void,
@@ -1990,21 +2141,18 @@ pub struct ImGuiIO {
         ),
     >,
     pub ClipboardUserData: *mut ::std::os::raw::c_void,
-    pub ImeSetInputScreenPosFn: ::std::option::Option<
-        unsafe extern "C" fn(x: ::std::os::raw::c_int, y: ::std::os::raw::c_int),
-    >,
-    pub ImeWindowHandle: *mut ::std::os::raw::c_void,
     pub RenderDrawListsFnUnused: *mut ::std::os::raw::c_void,
     pub MousePos: ImVec2,
     pub MouseDown: [bool; 5usize],
     pub MouseWheel: f32,
     pub MouseWheelH: f32,
+    pub MouseHoveredViewport: ImGuiID,
     pub KeyCtrl: bool,
     pub KeyShift: bool,
     pub KeyAlt: bool,
     pub KeySuper: bool,
     pub KeysDown: [bool; 512usize],
-    pub NavInputs: [f32; 22usize],
+    pub NavInputs: [f32; 21usize],
     pub WantCaptureMouse: bool,
     pub WantCaptureKeyboard: bool,
     pub WantTextInput: bool,
@@ -2033,15 +2181,15 @@ pub struct ImGuiIO {
     pub MouseDragMaxDistanceSqr: [f32; 5usize],
     pub KeysDownDuration: [f32; 512usize],
     pub KeysDownDurationPrev: [f32; 512usize],
-    pub NavInputsDownDuration: [f32; 22usize],
-    pub NavInputsDownDurationPrev: [f32; 22usize],
+    pub NavInputsDownDuration: [f32; 21usize],
+    pub NavInputsDownDurationPrev: [f32; 21usize],
     pub InputQueueCharacters: ImVector_ImWchar,
 }
 #[test]
 fn bindgen_test_layout_ImGuiIO() {
     assert_eq!(
         ::std::mem::size_of::<ImGuiIO>(),
-        5464usize,
+        5456usize,
         concat!("Size of: ", stringify!(ImGuiIO))
     );
     assert_eq!(
@@ -2240,8 +2388,100 @@ fn bindgen_test_layout_ImGuiIO() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ImGuiIO>())).MouseDrawCursor as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<ImGuiIO>())).ConfigDockingNoSplit as *const _ as usize },
         192usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(ConfigDockingNoSplit)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiIO>())).ConfigDockingWithShift as *const _ as usize },
+        193usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(ConfigDockingWithShift)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiIO>())).ConfigDockingAlwaysTabBar as *const _ as usize
+        },
+        194usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(ConfigDockingAlwaysTabBar)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiIO>())).ConfigDockingTransparentPayload as *const _ as usize
+        },
+        195usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(ConfigDockingTransparentPayload)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiIO>())).ConfigViewportsNoAutoMerge as *const _ as usize
+        },
+        196usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(ConfigViewportsNoAutoMerge)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiIO>())).ConfigViewportsNoTaskBarIcon as *const _ as usize
+        },
+        197usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(ConfigViewportsNoTaskBarIcon)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiIO>())).ConfigViewportsNoDecoration as *const _ as usize
+        },
+        198usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(ConfigViewportsNoDecoration)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiIO>())).ConfigViewportsNoDefaultParent as *const _ as usize
+        },
+        199usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(ConfigViewportsNoDefaultParent)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiIO>())).MouseDrawCursor as *const _ as usize },
+        200usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2251,7 +2491,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).ConfigMacOSXBehaviors as *const _ as usize },
-        193usize,
+        201usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2263,7 +2503,7 @@ fn bindgen_test_layout_ImGuiIO() {
         unsafe {
             &(*(::std::ptr::null::<ImGuiIO>())).ConfigInputTextCursorBlink as *const _ as usize
         },
-        194usize,
+        202usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2275,7 +2515,7 @@ fn bindgen_test_layout_ImGuiIO() {
         unsafe {
             &(*(::std::ptr::null::<ImGuiIO>())).ConfigWindowsResizeFromEdges as *const _ as usize
         },
-        195usize,
+        203usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2288,7 +2528,7 @@ fn bindgen_test_layout_ImGuiIO() {
             &(*(::std::ptr::null::<ImGuiIO>())).ConfigWindowsMoveFromTitleBarOnly as *const _
                 as usize
         },
-        196usize,
+        204usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2297,8 +2537,20 @@ fn bindgen_test_layout_ImGuiIO() {
         )
     );
     assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiIO>())).ConfigWindowsMemoryCompactTimer as *const _ as usize
+        },
+        208usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(ConfigWindowsMemoryCompactTimer)
+        )
+    );
+    assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).BackendPlatformName as *const _ as usize },
-        200usize,
+        216usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2308,7 +2560,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).BackendRendererName as *const _ as usize },
-        208usize,
+        224usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2318,7 +2570,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).BackendPlatformUserData as *const _ as usize },
-        216usize,
+        232usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2328,7 +2580,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).BackendRendererUserData as *const _ as usize },
-        224usize,
+        240usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2338,7 +2590,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).BackendLanguageUserData as *const _ as usize },
-        232usize,
+        248usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2348,7 +2600,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).GetClipboardTextFn as *const _ as usize },
-        240usize,
+        256usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2358,7 +2610,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).SetClipboardTextFn as *const _ as usize },
-        248usize,
+        264usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2368,32 +2620,12 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).ClipboardUserData as *const _ as usize },
-        256usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ImGuiIO),
-            "::",
-            stringify!(ClipboardUserData)
-        )
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ImGuiIO>())).ImeSetInputScreenPosFn as *const _ as usize },
-        264usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ImGuiIO),
-            "::",
-            stringify!(ImeSetInputScreenPosFn)
-        )
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ImGuiIO>())).ImeWindowHandle as *const _ as usize },
         272usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
             "::",
-            stringify!(ImeWindowHandle)
+            stringify!(ClipboardUserData)
         )
     );
     assert_eq!(
@@ -2447,8 +2679,18 @@ fn bindgen_test_layout_ImGuiIO() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ImGuiIO>())).KeyCtrl as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<ImGuiIO>())).MouseHoveredViewport as *const _ as usize },
         312usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiIO),
+            "::",
+            stringify!(MouseHoveredViewport)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiIO>())).KeyCtrl as *const _ as usize },
+        316usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2458,7 +2700,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).KeyShift as *const _ as usize },
-        313usize,
+        317usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2468,7 +2710,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).KeyAlt as *const _ as usize },
-        314usize,
+        318usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2478,7 +2720,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).KeySuper as *const _ as usize },
-        315usize,
+        319usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2488,7 +2730,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).KeysDown as *const _ as usize },
-        316usize,
+        320usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2498,7 +2740,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).NavInputs as *const _ as usize },
-        828usize,
+        832usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2802,7 +3044,7 @@ fn bindgen_test_layout_ImGuiIO() {
         unsafe {
             &(*(::std::ptr::null::<ImGuiIO>())).NavInputsDownDurationPrev as *const _ as usize
         },
-        5360usize,
+        5356usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2812,7 +3054,7 @@ fn bindgen_test_layout_ImGuiIO() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImGuiIO>())).InputQueueCharacters as *const _ as usize },
-        5448usize,
+        5440usize,
         concat!(
             "Offset of field: ",
             stringify!(ImGuiIO),
@@ -2828,7 +3070,7 @@ impl Default for ImGuiIO {
 }
 impl ::std::fmt::Debug for ImGuiIO {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write ! ( f , "ImGuiIO {{ ConfigFlags: {:?}, BackendFlags: {:?}, DisplaySize: {:?}, DeltaTime: {:?}, IniSavingRate: {:?}, IniFilename: {:?}, LogFilename: {:?}, MouseDoubleClickTime: {:?}, MouseDoubleClickMaxDist: {:?}, MouseDragThreshold: {:?}, KeyMap: {:?}, KeyRepeatDelay: {:?}, KeyRepeatRate: {:?}, UserData: {:?}, Fonts: {:?}, FontGlobalScale: {:?}, FontAllowUserScaling: {:?}, FontDefault: {:?}, DisplayFramebufferScale: {:?}, MouseDrawCursor: {:?}, ConfigMacOSXBehaviors: {:?}, ConfigInputTextCursorBlink: {:?}, ConfigWindowsResizeFromEdges: {:?}, ConfigWindowsMoveFromTitleBarOnly: {:?}, BackendPlatformName: {:?}, BackendRendererName: {:?}, BackendPlatformUserData: {:?}, BackendRendererUserData: {:?}, BackendLanguageUserData: {:?}, GetClipboardTextFn: {:?}, SetClipboardTextFn: {:?}, ClipboardUserData: {:?}, ImeSetInputScreenPosFn: {:?}, ImeWindowHandle: {:?}, RenderDrawListsFnUnused: {:?}, MousePos: {:?}, MouseDown: {:?}, MouseWheel: {:?}, MouseWheelH: {:?}, KeyCtrl: {:?}, KeyShift: {:?}, KeyAlt: {:?}, KeySuper: {:?}, KeysDown: [{}], NavInputs: {:?}, WantCaptureMouse: {:?}, WantCaptureKeyboard: {:?}, WantTextInput: {:?}, WantSetMousePos: {:?}, WantSaveIniSettings: {:?}, NavActive: {:?}, NavVisible: {:?}, Framerate: {:?}, MetricsRenderVertices: {:?}, MetricsRenderIndices: {:?}, MetricsRenderWindows: {:?}, MetricsActiveWindows: {:?}, MetricsActiveAllocations: {:?}, MouseDelta: {:?}, MousePosPrev: {:?}, MouseClickedPos: {:?}, MouseClickedTime: {:?}, MouseClicked: {:?}, MouseDoubleClicked: {:?}, MouseReleased: {:?}, MouseDownOwned: {:?}, MouseDownWasDoubleClick: {:?}, MouseDownDuration: {:?}, MouseDownDurationPrev: {:?}, MouseDragMaxDistanceAbs: {:?}, MouseDragMaxDistanceSqr: {:?}, KeysDownDuration: [{}], KeysDownDurationPrev: [{}], NavInputsDownDuration: {:?}, NavInputsDownDurationPrev: {:?}, InputQueueCharacters: {:?} }}" , self . ConfigFlags , self . BackendFlags , self . DisplaySize , self . DeltaTime , self . IniSavingRate , self . IniFilename , self . LogFilename , self . MouseDoubleClickTime , self . MouseDoubleClickMaxDist , self . MouseDragThreshold , self . KeyMap , self . KeyRepeatDelay , self . KeyRepeatRate , self . UserData , self . Fonts , self . FontGlobalScale , self . FontAllowUserScaling , self . FontDefault , self . DisplayFramebufferScale , self . MouseDrawCursor , self . ConfigMacOSXBehaviors , self . ConfigInputTextCursorBlink , self . ConfigWindowsResizeFromEdges , self . ConfigWindowsMoveFromTitleBarOnly , self . BackendPlatformName , self . BackendRendererName , self . BackendPlatformUserData , self . BackendRendererUserData , self . BackendLanguageUserData , self . GetClipboardTextFn , self . SetClipboardTextFn , self . ClipboardUserData , self . ImeSetInputScreenPosFn , self . ImeWindowHandle , self . RenderDrawListsFnUnused , self . MousePos , self . MouseDown , self . MouseWheel , self . MouseWheelH , self . KeyCtrl , self . KeyShift , self . KeyAlt , self . KeySuper , self . KeysDown . iter ( ) . enumerate ( ) . map ( | ( i , v ) | format ! ( "{}{:?}" , if i > 0 { ", " } else { "" } , v ) ) . collect :: < String > ( ) , self . NavInputs , self . WantCaptureMouse , self . WantCaptureKeyboard , self . WantTextInput , self . WantSetMousePos , self . WantSaveIniSettings , self . NavActive , self . NavVisible , self . Framerate , self . MetricsRenderVertices , self . MetricsRenderIndices , self . MetricsRenderWindows , self . MetricsActiveWindows , self . MetricsActiveAllocations , self . MouseDelta , self . MousePosPrev , self . MouseClickedPos , self . MouseClickedTime , self . MouseClicked , self . MouseDoubleClicked , self . MouseReleased , self . MouseDownOwned , self . MouseDownWasDoubleClick , self . MouseDownDuration , self . MouseDownDurationPrev , self . MouseDragMaxDistanceAbs , self . MouseDragMaxDistanceSqr , self . KeysDownDuration . iter ( ) . enumerate ( ) . map ( | ( i , v ) | format ! ( "{}{:?}" , if i > 0 { ", " } else { "" } , v ) ) . collect :: < String > ( ) , self . KeysDownDurationPrev . iter ( ) . enumerate ( ) . map ( | ( i , v ) | format ! ( "{}{:?}" , if i > 0 { ", " } else { "" } , v ) ) . collect :: < String > ( ) , self . NavInputsDownDuration , self . NavInputsDownDurationPrev , self . InputQueueCharacters )
+        write ! ( f , "ImGuiIO {{ ConfigFlags: {:?}, BackendFlags: {:?}, DisplaySize: {:?}, DeltaTime: {:?}, IniSavingRate: {:?}, IniFilename: {:?}, LogFilename: {:?}, MouseDoubleClickTime: {:?}, MouseDoubleClickMaxDist: {:?}, MouseDragThreshold: {:?}, KeyMap: {:?}, KeyRepeatDelay: {:?}, KeyRepeatRate: {:?}, UserData: {:?}, Fonts: {:?}, FontGlobalScale: {:?}, FontAllowUserScaling: {:?}, FontDefault: {:?}, DisplayFramebufferScale: {:?}, ConfigDockingNoSplit: {:?}, ConfigDockingWithShift: {:?}, ConfigDockingAlwaysTabBar: {:?}, ConfigDockingTransparentPayload: {:?}, ConfigViewportsNoAutoMerge: {:?}, ConfigViewportsNoTaskBarIcon: {:?}, ConfigViewportsNoDecoration: {:?}, ConfigViewportsNoDefaultParent: {:?}, MouseDrawCursor: {:?}, ConfigMacOSXBehaviors: {:?}, ConfigInputTextCursorBlink: {:?}, ConfigWindowsResizeFromEdges: {:?}, ConfigWindowsMoveFromTitleBarOnly: {:?}, ConfigWindowsMemoryCompactTimer: {:?}, BackendPlatformName: {:?}, BackendRendererName: {:?}, BackendPlatformUserData: {:?}, BackendRendererUserData: {:?}, BackendLanguageUserData: {:?}, GetClipboardTextFn: {:?}, SetClipboardTextFn: {:?}, ClipboardUserData: {:?}, RenderDrawListsFnUnused: {:?}, MousePos: {:?}, MouseDown: {:?}, MouseWheel: {:?}, MouseWheelH: {:?}, MouseHoveredViewport: {:?}, KeyCtrl: {:?}, KeyShift: {:?}, KeyAlt: {:?}, KeySuper: {:?}, KeysDown: [{}], NavInputs: {:?}, WantCaptureMouse: {:?}, WantCaptureKeyboard: {:?}, WantTextInput: {:?}, WantSetMousePos: {:?}, WantSaveIniSettings: {:?}, NavActive: {:?}, NavVisible: {:?}, Framerate: {:?}, MetricsRenderVertices: {:?}, MetricsRenderIndices: {:?}, MetricsRenderWindows: {:?}, MetricsActiveWindows: {:?}, MetricsActiveAllocations: {:?}, MouseDelta: {:?}, MousePosPrev: {:?}, MouseClickedPos: {:?}, MouseClickedTime: {:?}, MouseClicked: {:?}, MouseDoubleClicked: {:?}, MouseReleased: {:?}, MouseDownOwned: {:?}, MouseDownWasDoubleClick: {:?}, MouseDownDuration: {:?}, MouseDownDurationPrev: {:?}, MouseDragMaxDistanceAbs: {:?}, MouseDragMaxDistanceSqr: {:?}, KeysDownDuration: [{}], KeysDownDurationPrev: [{}], NavInputsDownDuration: {:?}, NavInputsDownDurationPrev: {:?}, InputQueueCharacters: {:?} }}" , self . ConfigFlags , self . BackendFlags , self . DisplaySize , self . DeltaTime , self . IniSavingRate , self . IniFilename , self . LogFilename , self . MouseDoubleClickTime , self . MouseDoubleClickMaxDist , self . MouseDragThreshold , self . KeyMap , self . KeyRepeatDelay , self . KeyRepeatRate , self . UserData , self . Fonts , self . FontGlobalScale , self . FontAllowUserScaling , self . FontDefault , self . DisplayFramebufferScale , self . ConfigDockingNoSplit , self . ConfigDockingWithShift , self . ConfigDockingAlwaysTabBar , self . ConfigDockingTransparentPayload , self . ConfigViewportsNoAutoMerge , self . ConfigViewportsNoTaskBarIcon , self . ConfigViewportsNoDecoration , self . ConfigViewportsNoDefaultParent , self . MouseDrawCursor , self . ConfigMacOSXBehaviors , self . ConfigInputTextCursorBlink , self . ConfigWindowsResizeFromEdges , self . ConfigWindowsMoveFromTitleBarOnly , self . ConfigWindowsMemoryCompactTimer , self . BackendPlatformName , self . BackendRendererName , self . BackendPlatformUserData , self . BackendRendererUserData , self . BackendLanguageUserData , self . GetClipboardTextFn , self . SetClipboardTextFn , self . ClipboardUserData , self . RenderDrawListsFnUnused , self . MousePos , self . MouseDown , self . MouseWheel , self . MouseWheelH , self . MouseHoveredViewport , self . KeyCtrl , self . KeyShift , self . KeyAlt , self . KeySuper , self . KeysDown . iter ( ) . enumerate ( ) . map ( | ( i , v ) | format ! ( "{}{:?}" , if i > 0 { ", " } else { "" } , v ) ) . collect :: < String > ( ) , self . NavInputs , self . WantCaptureMouse , self . WantCaptureKeyboard , self . WantTextInput , self . WantSetMousePos , self . WantSaveIniSettings , self . NavActive , self . NavVisible , self . Framerate , self . MetricsRenderVertices , self . MetricsRenderIndices , self . MetricsRenderWindows , self . MetricsActiveWindows , self . MetricsActiveAllocations , self . MouseDelta , self . MousePosPrev , self . MouseClickedPos , self . MouseClickedTime , self . MouseClicked , self . MouseDoubleClicked , self . MouseReleased , self . MouseDownOwned , self . MouseDownWasDoubleClick , self . MouseDownDuration , self . MouseDownDurationPrev , self . MouseDragMaxDistanceAbs , self . MouseDragMaxDistanceSqr , self . KeysDownDuration . iter ( ) . enumerate ( ) . map ( | ( i , v ) | format ! ( "{}{:?}" , if i > 0 { ", " } else { "" } , v ) ) . collect :: < String > ( ) , self . KeysDownDurationPrev . iter ( ) . enumerate ( ) . map ( | ( i , v ) | format ! ( "{}{:?}" , if i > 0 { ", " } else { "" } , v ) ) . collect :: < String > ( ) , self . NavInputsDownDuration , self . NavInputsDownDurationPrev , self . InputQueueCharacters )
     }
 }
 #[repr(C)]
@@ -3077,6 +3319,101 @@ impl Default for ImGuiSizeCallbackData {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct ImGuiWindowClass {
+    pub ClassId: ImGuiID,
+    pub ParentViewportId: ImGuiID,
+    pub ViewportFlagsOverrideSet: ImGuiViewportFlags,
+    pub ViewportFlagsOverrideClear: ImGuiViewportFlags,
+    pub DockingAlwaysTabBar: bool,
+    pub DockingAllowUnclassed: bool,
+}
+#[test]
+fn bindgen_test_layout_ImGuiWindowClass() {
+    assert_eq!(
+        ::std::mem::size_of::<ImGuiWindowClass>(),
+        20usize,
+        concat!("Size of: ", stringify!(ImGuiWindowClass))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ImGuiWindowClass>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ImGuiWindowClass))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiWindowClass>())).ClassId as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiWindowClass),
+            "::",
+            stringify!(ClassId)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiWindowClass>())).ParentViewportId as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiWindowClass),
+            "::",
+            stringify!(ParentViewportId)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiWindowClass>())).ViewportFlagsOverrideSet as *const _
+                as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiWindowClass),
+            "::",
+            stringify!(ViewportFlagsOverrideSet)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiWindowClass>())).ViewportFlagsOverrideClear as *const _
+                as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiWindowClass),
+            "::",
+            stringify!(ViewportFlagsOverrideClear)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiWindowClass>())).DockingAlwaysTabBar as *const _ as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiWindowClass),
+            "::",
+            stringify!(DockingAlwaysTabBar)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiWindowClass>())).DockingAllowUnclassed as *const _ as usize
+        },
+        17usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiWindowClass),
+            "::",
+            stringify!(DockingAllowUnclassed)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3919,12 +4256,13 @@ pub struct ImDrawData {
     pub DisplayPos: ImVec2,
     pub DisplaySize: ImVec2,
     pub FramebufferScale: ImVec2,
+    pub OwnerViewport: *mut ImGuiViewport,
 }
 #[test]
 fn bindgen_test_layout_ImDrawData() {
     assert_eq!(
         ::std::mem::size_of::<ImDrawData>(),
-        56usize,
+        64usize,
         concat!("Size of: ", stringify!(ImDrawData))
     );
     assert_eq!(
@@ -4012,6 +4350,16 @@ fn bindgen_test_layout_ImDrawData() {
             stringify!(FramebufferScale)
         )
     );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImDrawData>())).OwnerViewport as *const _ as usize },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImDrawData),
+            "::",
+            stringify!(OwnerViewport)
+        )
+    );
 }
 impl Default for ImDrawData {
     fn default() -> Self {
@@ -4037,6 +4385,7 @@ pub struct ImFontConfig {
     pub MergeMode: bool,
     pub RasterizerFlags: ::std::os::raw::c_uint,
     pub RasterizerMultiply: f32,
+    pub EllipsisChar: ImWchar,
     pub Name: [::std::os::raw::c_char; 40usize],
     pub DstFont: *mut ImFont,
 }
@@ -4215,8 +4564,18 @@ fn bindgen_test_layout_ImFontConfig() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ImFontConfig>())).Name as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<ImFontConfig>())).EllipsisChar as *const _ as usize },
         84usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImFontConfig),
+            "::",
+            stringify!(EllipsisChar)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImFontConfig>())).Name as *const _ as usize },
+        86usize,
         concat!(
             "Offset of field: ",
             stringify!(ImFontConfig),
@@ -4242,7 +4601,7 @@ impl Default for ImFontConfig {
 }
 impl ::std::fmt::Debug for ImFontConfig {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write ! ( f , "ImFontConfig {{ FontData: {:?}, FontDataSize: {:?}, FontDataOwnedByAtlas: {:?}, FontNo: {:?}, SizePixels: {:?}, OversampleH: {:?}, OversampleV: {:?}, PixelSnapH: {:?}, GlyphExtraSpacing: {:?}, GlyphOffset: {:?}, GlyphRanges: {:?}, GlyphMinAdvanceX: {:?}, GlyphMaxAdvanceX: {:?}, MergeMode: {:?}, RasterizerFlags: {:?}, RasterizerMultiply: {:?}, Name: [{}], DstFont: {:?} }}" , self . FontData , self . FontDataSize , self . FontDataOwnedByAtlas , self . FontNo , self . SizePixels , self . OversampleH , self . OversampleV , self . PixelSnapH , self . GlyphExtraSpacing , self . GlyphOffset , self . GlyphRanges , self . GlyphMinAdvanceX , self . GlyphMaxAdvanceX , self . MergeMode , self . RasterizerFlags , self . RasterizerMultiply , self . Name . iter ( ) . enumerate ( ) . map ( | ( i , v ) | format ! ( "{}{:?}" , if i > 0 { ", " } else { "" } , v ) ) . collect :: < String > ( ) , self . DstFont )
+        write ! ( f , "ImFontConfig {{ FontData: {:?}, FontDataSize: {:?}, FontDataOwnedByAtlas: {:?}, FontNo: {:?}, SizePixels: {:?}, OversampleH: {:?}, OversampleV: {:?}, PixelSnapH: {:?}, GlyphExtraSpacing: {:?}, GlyphOffset: {:?}, GlyphRanges: {:?}, GlyphMinAdvanceX: {:?}, GlyphMaxAdvanceX: {:?}, MergeMode: {:?}, RasterizerFlags: {:?}, RasterizerMultiply: {:?}, EllipsisChar: {:?}, Name: [{}], DstFont: {:?} }}" , self . FontData , self . FontDataSize , self . FontDataOwnedByAtlas , self . FontNo , self . SizePixels , self . OversampleH , self . OversampleV , self . PixelSnapH , self . GlyphExtraSpacing , self . GlyphOffset , self . GlyphRanges , self . GlyphMinAdvanceX , self . GlyphMaxAdvanceX , self . MergeMode , self . RasterizerFlags , self . RasterizerMultiply , self . EllipsisChar , self . Name . iter ( ) . enumerate ( ) . map ( | ( i , v ) | format ! ( "{}{:?}" , if i > 0 { ", " } else { "" } , v ) ) . collect :: < String > ( ) , self . DstFont )
     }
 }
 #[repr(C)]
@@ -4726,6 +5085,7 @@ pub struct ImFont {
     pub ConfigData: *const ImFontConfig,
     pub ConfigDataCount: ::std::os::raw::c_short,
     pub FallbackChar: ImWchar,
+    pub EllipsisChar: ImWchar,
     pub Scale: f32,
     pub Ascent: f32,
     pub Descent: f32,
@@ -4736,7 +5096,7 @@ pub struct ImFont {
 fn bindgen_test_layout_ImFont() {
     assert_eq!(
         ::std::mem::size_of::<ImFont>(),
-        112usize,
+        120usize,
         concat!("Size of: ", stringify!(ImFont))
     );
     assert_eq!(
@@ -4855,8 +5215,18 @@ fn bindgen_test_layout_ImFont() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ImFont>())).Scale as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<ImFont>())).EllipsisChar as *const _ as usize },
         92usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImFont),
+            "::",
+            stringify!(EllipsisChar)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImFont>())).Scale as *const _ as usize },
+        96usize,
         concat!(
             "Offset of field: ",
             stringify!(ImFont),
@@ -4866,7 +5236,7 @@ fn bindgen_test_layout_ImFont() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImFont>())).Ascent as *const _ as usize },
-        96usize,
+        100usize,
         concat!(
             "Offset of field: ",
             stringify!(ImFont),
@@ -4876,7 +5246,7 @@ fn bindgen_test_layout_ImFont() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImFont>())).Descent as *const _ as usize },
-        100usize,
+        104usize,
         concat!(
             "Offset of field: ",
             stringify!(ImFont),
@@ -4886,7 +5256,7 @@ fn bindgen_test_layout_ImFont() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImFont>())).MetricsTotalSurface as *const _ as usize },
-        104usize,
+        108usize,
         concat!(
             "Offset of field: ",
             stringify!(ImFont),
@@ -4896,7 +5266,7 @@ fn bindgen_test_layout_ImFont() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<ImFont>())).DirtyLookupTables as *const _ as usize },
-        108usize,
+        112usize,
         concat!(
             "Offset of field: ",
             stringify!(ImFont),
@@ -4906,6 +5276,672 @@ fn bindgen_test_layout_ImFont() {
     );
 }
 impl Default for ImFont {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct ImGuiPlatformMonitor {
+    pub MainPos: ImVec2,
+    pub MainSize: ImVec2,
+    pub WorkPos: ImVec2,
+    pub WorkSize: ImVec2,
+    pub DpiScale: f32,
+}
+#[test]
+fn bindgen_test_layout_ImGuiPlatformMonitor() {
+    assert_eq!(
+        ::std::mem::size_of::<ImGuiPlatformMonitor>(),
+        36usize,
+        concat!("Size of: ", stringify!(ImGuiPlatformMonitor))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ImGuiPlatformMonitor>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ImGuiPlatformMonitor))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiPlatformMonitor>())).MainPos as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformMonitor),
+            "::",
+            stringify!(MainPos)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiPlatformMonitor>())).MainSize as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformMonitor),
+            "::",
+            stringify!(MainSize)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiPlatformMonitor>())).WorkPos as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformMonitor),
+            "::",
+            stringify!(WorkPos)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiPlatformMonitor>())).WorkSize as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformMonitor),
+            "::",
+            stringify!(WorkSize)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiPlatformMonitor>())).DpiScale as *const _ as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformMonitor),
+            "::",
+            stringify!(DpiScale)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct ImGuiPlatformIO {
+    pub Platform_CreateWindow: ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
+    pub Platform_DestroyWindow: ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
+    pub Platform_ShowWindow: ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
+    pub Platform_SetWindowPos:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, pos: ImVec2)>,
+    pub Platform_GetWindowPos:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> ImVec2>,
+    pub Platform_SetWindowSize:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, size: ImVec2)>,
+    pub Platform_GetWindowSize:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> ImVec2>,
+    pub Platform_SetWindowFocus:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
+    pub Platform_GetWindowFocus:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> bool>,
+    pub Platform_GetWindowMinimized:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> bool>,
+    pub Platform_SetWindowTitle: ::std::option::Option<
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, title: *const ::std::os::raw::c_char),
+    >,
+    pub Platform_SetWindowAlpha:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, alpha: f32)>,
+    pub Platform_UpdateWindow: ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
+    pub Platform_RenderWindow: ::std::option::Option<
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut ::std::os::raw::c_void),
+    >,
+    pub Platform_SwapBuffers: ::std::option::Option<
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut ::std::os::raw::c_void),
+    >,
+    pub Platform_GetWindowDpiScale:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> f32>,
+    pub Platform_OnChangedViewport:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
+    pub Platform_SetImeInputPos:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, pos: ImVec2)>,
+    pub Platform_CreateVkSurface: ::std::option::Option<
+        unsafe extern "C" fn(
+            vp: *mut ImGuiViewport,
+            vk_inst: ImU64,
+            vk_allocators: *const ::std::os::raw::c_void,
+            out_vk_surface: *mut ImU64,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub Renderer_CreateWindow: ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
+    pub Renderer_DestroyWindow: ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
+    pub Renderer_SetWindowSize:
+        ::std::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, size: ImVec2)>,
+    pub Renderer_RenderWindow: ::std::option::Option<
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut ::std::os::raw::c_void),
+    >,
+    pub Renderer_SwapBuffers: ::std::option::Option<
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut ::std::os::raw::c_void),
+    >,
+    pub Monitors: ImVector_ImGuiPlatformMonitor,
+    pub MainViewport: *mut ImGuiViewport,
+    pub Viewports: ImVector_ImGuiViewportPtr,
+}
+#[test]
+fn bindgen_test_layout_ImGuiPlatformIO() {
+    assert_eq!(
+        ::std::mem::size_of::<ImGuiPlatformIO>(),
+        232usize,
+        concat!("Size of: ", stringify!(ImGuiPlatformIO))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ImGuiPlatformIO>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ImGuiPlatformIO))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_CreateWindow as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_CreateWindow)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_DestroyWindow as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_DestroyWindow)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_ShowWindow as *const _ as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_ShowWindow)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_SetWindowPos as *const _ as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_SetWindowPos)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_GetWindowPos as *const _ as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_GetWindowPos)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_SetWindowSize as *const _ as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_SetWindowSize)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_GetWindowSize as *const _ as usize
+        },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_GetWindowSize)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_SetWindowFocus as *const _ as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_SetWindowFocus)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_GetWindowFocus as *const _ as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_GetWindowFocus)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_GetWindowMinimized as *const _
+                as usize
+        },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_GetWindowMinimized)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_SetWindowTitle as *const _ as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_SetWindowTitle)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_SetWindowAlpha as *const _ as usize
+        },
+        88usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_SetWindowAlpha)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_UpdateWindow as *const _ as usize
+        },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_UpdateWindow)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_RenderWindow as *const _ as usize
+        },
+        104usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_RenderWindow)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_SwapBuffers as *const _ as usize
+        },
+        112usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_SwapBuffers)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_GetWindowDpiScale as *const _
+                as usize
+        },
+        120usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_GetWindowDpiScale)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_OnChangedViewport as *const _
+                as usize
+        },
+        128usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_OnChangedViewport)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_SetImeInputPos as *const _ as usize
+        },
+        136usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_SetImeInputPos)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Platform_CreateVkSurface as *const _
+                as usize
+        },
+        144usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Platform_CreateVkSurface)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Renderer_CreateWindow as *const _ as usize
+        },
+        152usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Renderer_CreateWindow)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Renderer_DestroyWindow as *const _ as usize
+        },
+        160usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Renderer_DestroyWindow)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Renderer_SetWindowSize as *const _ as usize
+        },
+        168usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Renderer_SetWindowSize)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Renderer_RenderWindow as *const _ as usize
+        },
+        176usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Renderer_RenderWindow)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiPlatformIO>())).Renderer_SwapBuffers as *const _ as usize
+        },
+        184usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Renderer_SwapBuffers)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiPlatformIO>())).Monitors as *const _ as usize },
+        192usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Monitors)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiPlatformIO>())).MainViewport as *const _ as usize },
+        208usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(MainViewport)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiPlatformIO>())).Viewports as *const _ as usize },
+        216usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiPlatformIO),
+            "::",
+            stringify!(Viewports)
+        )
+    );
+}
+impl Default for ImGuiPlatformIO {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub const ImGuiViewportFlags_None: ImGuiViewportFlags_ = 0;
+pub const ImGuiViewportFlags_NoDecoration: ImGuiViewportFlags_ = 1;
+pub const ImGuiViewportFlags_NoTaskBarIcon: ImGuiViewportFlags_ = 2;
+pub const ImGuiViewportFlags_NoFocusOnAppearing: ImGuiViewportFlags_ = 4;
+pub const ImGuiViewportFlags_NoFocusOnClick: ImGuiViewportFlags_ = 8;
+pub const ImGuiViewportFlags_NoInputs: ImGuiViewportFlags_ = 16;
+pub const ImGuiViewportFlags_NoRendererClear: ImGuiViewportFlags_ = 32;
+pub const ImGuiViewportFlags_TopMost: ImGuiViewportFlags_ = 64;
+pub const ImGuiViewportFlags_Minimized: ImGuiViewportFlags_ = 128;
+pub const ImGuiViewportFlags_NoAutoMerge: ImGuiViewportFlags_ = 256;
+pub const ImGuiViewportFlags_CanHostOtherWindows: ImGuiViewportFlags_ = 512;
+pub type ImGuiViewportFlags_ = u32;
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct ImGuiViewport {
+    pub ID: ImGuiID,
+    pub Flags: ImGuiViewportFlags,
+    pub Pos: ImVec2,
+    pub Size: ImVec2,
+    pub DpiScale: f32,
+    pub DrawData: *mut ImDrawData,
+    pub ParentViewportId: ImGuiID,
+    pub RendererUserData: *mut ::std::os::raw::c_void,
+    pub PlatformUserData: *mut ::std::os::raw::c_void,
+    pub PlatformHandle: *mut ::std::os::raw::c_void,
+    pub PlatformHandleRaw: *mut ::std::os::raw::c_void,
+    pub PlatformRequestClose: bool,
+    pub PlatformRequestMove: bool,
+    pub PlatformRequestResize: bool,
+}
+#[test]
+fn bindgen_test_layout_ImGuiViewport() {
+    assert_eq!(
+        ::std::mem::size_of::<ImGuiViewport>(),
+        88usize,
+        concat!("Size of: ", stringify!(ImGuiViewport))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ImGuiViewport>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ImGuiViewport))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).ID as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(ID)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).Flags as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(Flags)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).Pos as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(Pos)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).Size as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(Size)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).DpiScale as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(DpiScale)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).DrawData as *const _ as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(DrawData)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).ParentViewportId as *const _ as usize },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(ParentViewportId)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).RendererUserData as *const _ as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(RendererUserData)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).PlatformUserData as *const _ as usize },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(PlatformUserData)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).PlatformHandle as *const _ as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(PlatformHandle)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<ImGuiViewport>())).PlatformHandleRaw as *const _ as usize },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(PlatformHandleRaw)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiViewport>())).PlatformRequestClose as *const _ as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(PlatformRequestClose)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiViewport>())).PlatformRequestMove as *const _ as usize
+        },
+        81usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(PlatformRequestMove)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<ImGuiViewport>())).PlatformRequestResize as *const _ as usize
+        },
+        82usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ImGuiViewport),
+            "::",
+            stringify!(PlatformRequestResize)
+        )
+    );
+}
+impl Default for ImGuiViewport {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
@@ -5197,6 +6233,12 @@ extern "C" {
     pub fn igGetWindowDrawList() -> *mut ImDrawList;
 }
 extern "C" {
+    pub fn igGetWindowDpiScale() -> f32;
+}
+extern "C" {
+    pub fn igGetWindowViewport() -> *mut ImGuiViewport;
+}
+extern "C" {
     pub fn igGetWindowWidth() -> f32;
 }
 extern "C" {
@@ -5227,6 +6269,9 @@ extern "C" {
 }
 extern "C" {
     pub fn igSetNextWindowBgAlpha(alpha: f32);
+}
+extern "C" {
+    pub fn igSetNextWindowViewport(viewport_id: ImGuiID);
 }
 extern "C" {
     pub fn igSetWindowPosVec2(pos: ImVec2, cond: ImGuiCond);
@@ -5697,10 +6742,10 @@ extern "C" {
     pub fn igDragScalar(
         label: *const ::std::os::raw::c_char,
         data_type: ImGuiDataType,
-        v: *mut ::std::os::raw::c_void,
+        p_data: *mut ::std::os::raw::c_void,
         v_speed: f32,
-        v_min: *const ::std::os::raw::c_void,
-        v_max: *const ::std::os::raw::c_void,
+        p_min: *const ::std::os::raw::c_void,
+        p_max: *const ::std::os::raw::c_void,
         format: *const ::std::os::raw::c_char,
         power: f32,
     ) -> bool;
@@ -5709,11 +6754,11 @@ extern "C" {
     pub fn igDragScalarN(
         label: *const ::std::os::raw::c_char,
         data_type: ImGuiDataType,
-        v: *mut ::std::os::raw::c_void,
+        p_data: *mut ::std::os::raw::c_void,
         components: ::std::os::raw::c_int,
         v_speed: f32,
-        v_min: *const ::std::os::raw::c_void,
-        v_max: *const ::std::os::raw::c_void,
+        p_min: *const ::std::os::raw::c_void,
+        p_max: *const ::std::os::raw::c_void,
         format: *const ::std::os::raw::c_char,
         power: f32,
     ) -> bool;
@@ -5807,9 +6852,9 @@ extern "C" {
     pub fn igSliderScalar(
         label: *const ::std::os::raw::c_char,
         data_type: ImGuiDataType,
-        v: *mut ::std::os::raw::c_void,
-        v_min: *const ::std::os::raw::c_void,
-        v_max: *const ::std::os::raw::c_void,
+        p_data: *mut ::std::os::raw::c_void,
+        p_min: *const ::std::os::raw::c_void,
+        p_max: *const ::std::os::raw::c_void,
         format: *const ::std::os::raw::c_char,
         power: f32,
     ) -> bool;
@@ -5818,10 +6863,10 @@ extern "C" {
     pub fn igSliderScalarN(
         label: *const ::std::os::raw::c_char,
         data_type: ImGuiDataType,
-        v: *mut ::std::os::raw::c_void,
+        p_data: *mut ::std::os::raw::c_void,
         components: ::std::os::raw::c_int,
-        v_min: *const ::std::os::raw::c_void,
-        v_max: *const ::std::os::raw::c_void,
+        p_min: *const ::std::os::raw::c_void,
+        p_max: *const ::std::os::raw::c_void,
         format: *const ::std::os::raw::c_char,
         power: f32,
     ) -> bool;
@@ -5852,9 +6897,9 @@ extern "C" {
         label: *const ::std::os::raw::c_char,
         size: ImVec2,
         data_type: ImGuiDataType,
-        v: *mut ::std::os::raw::c_void,
-        v_min: *const ::std::os::raw::c_void,
-        v_max: *const ::std::os::raw::c_void,
+        p_data: *mut ::std::os::raw::c_void,
+        p_min: *const ::std::os::raw::c_void,
+        p_max: *const ::std::os::raw::c_void,
         format: *const ::std::os::raw::c_char,
         power: f32,
     ) -> bool;
@@ -5969,9 +7014,9 @@ extern "C" {
     pub fn igInputScalar(
         label: *const ::std::os::raw::c_char,
         data_type: ImGuiDataType,
-        v: *mut ::std::os::raw::c_void,
-        step: *const ::std::os::raw::c_void,
-        step_fast: *const ::std::os::raw::c_void,
+        p_data: *mut ::std::os::raw::c_void,
+        p_step: *const ::std::os::raw::c_void,
+        p_step_fast: *const ::std::os::raw::c_void,
         format: *const ::std::os::raw::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
@@ -5980,10 +7025,10 @@ extern "C" {
     pub fn igInputScalarN(
         label: *const ::std::os::raw::c_char,
         data_type: ImGuiDataType,
-        v: *mut ::std::os::raw::c_void,
+        p_data: *mut ::std::os::raw::c_void,
         components: ::std::os::raw::c_int,
-        step: *const ::std::os::raw::c_void,
-        step_fast: *const ::std::os::raw::c_void,
+        p_step: *const ::std::os::raw::c_void,
+        p_step_fast: *const ::std::os::raw::c_void,
         format: *const ::std::os::raw::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
@@ -6226,16 +7271,16 @@ extern "C" {
     );
 }
 extern "C" {
-    pub fn igBeginMainMenuBar() -> bool;
-}
-extern "C" {
-    pub fn igEndMainMenuBar();
-}
-extern "C" {
     pub fn igBeginMenuBar() -> bool;
 }
 extern "C" {
     pub fn igEndMenuBar();
+}
+extern "C" {
+    pub fn igBeginMainMenuBar() -> bool;
+}
+extern "C" {
+    pub fn igEndMainMenuBar();
 }
 extern "C" {
     pub fn igBeginMenu(label: *const ::std::os::raw::c_char, enabled: bool) -> bool;
@@ -6359,6 +7404,33 @@ extern "C" {
     pub fn igSetTabItemClosed(tab_or_docked_window_label: *const ::std::os::raw::c_char);
 }
 extern "C" {
+    pub fn igDockSpace(
+        id: ImGuiID,
+        size: ImVec2,
+        flags: ImGuiDockNodeFlags,
+        window_class: *const ImGuiWindowClass,
+    );
+}
+extern "C" {
+    pub fn igDockSpaceOverViewport(
+        viewport: *mut ImGuiViewport,
+        flags: ImGuiDockNodeFlags,
+        window_class: *const ImGuiWindowClass,
+    ) -> ImGuiID;
+}
+extern "C" {
+    pub fn igSetNextWindowDockID(dock_id: ImGuiID, cond: ImGuiCond);
+}
+extern "C" {
+    pub fn igSetNextWindowClass(window_class: *const ImGuiWindowClass);
+}
+extern "C" {
+    pub fn igGetWindowDockID() -> ImGuiID;
+}
+extern "C" {
+    pub fn igIsWindowDocked() -> bool;
+}
+extern "C" {
     pub fn igLogToTTY(auto_open_depth: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -6449,6 +7521,9 @@ extern "C" {
     pub fn igIsItemDeactivatedAfterEdit() -> bool;
 }
 extern "C" {
+    pub fn igIsItemToggledOpen() -> bool;
+}
+extern "C" {
     pub fn igIsAnyItemHovered() -> bool;
 }
 extern "C" {
@@ -6477,6 +7552,12 @@ extern "C" {
 }
 extern "C" {
     pub fn igGetForegroundDrawList() -> *mut ImDrawList;
+}
+extern "C" {
+    pub fn igGetBackgroundDrawListViewportPtr(viewport: *mut ImGuiViewport) -> *mut ImDrawList;
+}
+extern "C" {
+    pub fn igGetForegroundDrawListViewportPtr(viewport: *mut ImGuiViewport) -> *mut ImDrawList;
 }
 extern "C" {
     pub fn igGetDrawListSharedData() -> *mut ImDrawListSharedData;
@@ -6607,6 +7688,32 @@ extern "C" {
     pub fn igMemFree(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
+    pub fn igGetPlatformIO() -> *mut ImGuiPlatformIO;
+}
+extern "C" {
+    pub fn igGetMainViewport() -> *mut ImGuiViewport;
+}
+extern "C" {
+    pub fn igUpdatePlatformWindows();
+}
+extern "C" {
+    pub fn igRenderPlatformWindowsDefault(
+        platform_arg: *mut ::std::os::raw::c_void,
+        renderer_arg: *mut ::std::os::raw::c_void,
+    );
+}
+extern "C" {
+    pub fn igDestroyPlatformWindows();
+}
+extern "C" {
+    pub fn igFindViewportByID(id: ImGuiID) -> *mut ImGuiViewport;
+}
+extern "C" {
+    pub fn igFindViewportByPlatformHandle(
+        platform_handle: *mut ::std::os::raw::c_void,
+    ) -> *mut ImGuiViewport;
+}
+extern "C" {
     pub fn ImGuiStyle_ImGuiStyle() -> *mut ImGuiStyle;
 }
 extern "C" {
@@ -6653,6 +7760,12 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiInputTextCallbackData_HasSelection(self_: *mut ImGuiInputTextCallbackData) -> bool;
+}
+extern "C" {
+    pub fn ImGuiWindowClass_ImGuiWindowClass() -> *mut ImGuiWindowClass;
+}
+extern "C" {
+    pub fn ImGuiWindowClass_destroy(self_: *mut ImGuiWindowClass);
 }
 extern "C" {
     pub fn ImGuiPayload_ImGuiPayload() -> *mut ImGuiPayload;
@@ -6973,8 +8086,8 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_AddLine(
         self_: *mut ImDrawList,
-        a: ImVec2,
-        b: ImVec2,
+        p1: ImVec2,
+        p2: ImVec2,
         col: ImU32,
         thickness: f32,
     );
@@ -6982,8 +8095,8 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_AddRect(
         self_: *mut ImDrawList,
-        a: ImVec2,
-        b: ImVec2,
+        p_min: ImVec2,
+        p_max: ImVec2,
         col: ImU32,
         rounding: f32,
         rounding_corners: ImDrawCornerFlags,
@@ -6993,8 +8106,8 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_AddRectFilled(
         self_: *mut ImDrawList,
-        a: ImVec2,
-        b: ImVec2,
+        p_min: ImVec2,
+        p_max: ImVec2,
         col: ImU32,
         rounding: f32,
         rounding_corners: ImDrawCornerFlags,
@@ -7003,8 +8116,8 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_AddRectFilledMultiColor(
         self_: *mut ImDrawList,
-        a: ImVec2,
-        b: ImVec2,
+        p_min: ImVec2,
+        p_max: ImVec2,
         col_upr_left: ImU32,
         col_upr_right: ImU32,
         col_bot_right: ImU32,
@@ -7014,10 +8127,10 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_AddQuad(
         self_: *mut ImDrawList,
-        a: ImVec2,
-        b: ImVec2,
-        c: ImVec2,
-        d: ImVec2,
+        p1: ImVec2,
+        p2: ImVec2,
+        p3: ImVec2,
+        p4: ImVec2,
         col: ImU32,
         thickness: f32,
     );
@@ -7025,19 +8138,19 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_AddQuadFilled(
         self_: *mut ImDrawList,
-        a: ImVec2,
-        b: ImVec2,
-        c: ImVec2,
-        d: ImVec2,
+        p1: ImVec2,
+        p2: ImVec2,
+        p3: ImVec2,
+        p4: ImVec2,
         col: ImU32,
     );
 }
 extern "C" {
     pub fn ImDrawList_AddTriangle(
         self_: *mut ImDrawList,
-        a: ImVec2,
-        b: ImVec2,
-        c: ImVec2,
+        p1: ImVec2,
+        p2: ImVec2,
+        p3: ImVec2,
         col: ImU32,
         thickness: f32,
     );
@@ -7045,16 +8158,16 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_AddTriangleFilled(
         self_: *mut ImDrawList,
-        a: ImVec2,
-        b: ImVec2,
-        c: ImVec2,
+        p1: ImVec2,
+        p2: ImVec2,
+        p3: ImVec2,
         col: ImU32,
     );
 }
 extern "C" {
     pub fn ImDrawList_AddCircle(
         self_: *mut ImDrawList,
-        centre: ImVec2,
+        center: ImVec2,
         radius: f32,
         col: ImU32,
         num_segments: ::std::os::raw::c_int,
@@ -7064,7 +8177,7 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_AddCircleFilled(
         self_: *mut ImDrawList,
-        centre: ImVec2,
+        center: ImVec2,
         radius: f32,
         col: ImU32,
         num_segments: ::std::os::raw::c_int,
@@ -7090,45 +8203,6 @@ extern "C" {
         text_end: *const ::std::os::raw::c_char,
         wrap_width: f32,
         cpu_fine_clip_rect: *const ImVec4,
-    );
-}
-extern "C" {
-    pub fn ImDrawList_AddImage(
-        self_: *mut ImDrawList,
-        user_texture_id: ImTextureID,
-        a: ImVec2,
-        b: ImVec2,
-        uv_a: ImVec2,
-        uv_b: ImVec2,
-        col: ImU32,
-    );
-}
-extern "C" {
-    pub fn ImDrawList_AddImageQuad(
-        self_: *mut ImDrawList,
-        user_texture_id: ImTextureID,
-        a: ImVec2,
-        b: ImVec2,
-        c: ImVec2,
-        d: ImVec2,
-        uv_a: ImVec2,
-        uv_b: ImVec2,
-        uv_c: ImVec2,
-        uv_d: ImVec2,
-        col: ImU32,
-    );
-}
-extern "C" {
-    pub fn ImDrawList_AddImageRounded(
-        self_: *mut ImDrawList,
-        user_texture_id: ImTextureID,
-        a: ImVec2,
-        b: ImVec2,
-        uv_a: ImVec2,
-        uv_b: ImVec2,
-        col: ImU32,
-        rounding: f32,
-        rounding_corners: ImDrawCornerFlags,
     );
 }
 extern "C" {
@@ -7162,6 +8236,45 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn ImDrawList_AddImage(
+        self_: *mut ImDrawList,
+        user_texture_id: ImTextureID,
+        p_min: ImVec2,
+        p_max: ImVec2,
+        uv_min: ImVec2,
+        uv_max: ImVec2,
+        col: ImU32,
+    );
+}
+extern "C" {
+    pub fn ImDrawList_AddImageQuad(
+        self_: *mut ImDrawList,
+        user_texture_id: ImTextureID,
+        p1: ImVec2,
+        p2: ImVec2,
+        p3: ImVec2,
+        p4: ImVec2,
+        uv1: ImVec2,
+        uv2: ImVec2,
+        uv3: ImVec2,
+        uv4: ImVec2,
+        col: ImU32,
+    );
+}
+extern "C" {
+    pub fn ImDrawList_AddImageRounded(
+        self_: *mut ImDrawList,
+        user_texture_id: ImTextureID,
+        p_min: ImVec2,
+        p_max: ImVec2,
+        uv_min: ImVec2,
+        uv_max: ImVec2,
+        col: ImU32,
+        rounding: f32,
+        rounding_corners: ImDrawCornerFlags,
+    );
+}
+extern "C" {
     pub fn ImDrawList_PathClear(self_: *mut ImDrawList);
 }
 extern "C" {
@@ -7179,7 +8292,7 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_PathArcTo(
         self_: *mut ImDrawList,
-        centre: ImVec2,
+        center: ImVec2,
         radius: f32,
         a_min: f32,
         a_max: f32,
@@ -7189,7 +8302,7 @@ extern "C" {
 extern "C" {
     pub fn ImDrawList_PathArcToFast(
         self_: *mut ImDrawList,
-        centre: ImVec2,
+        center: ImVec2,
         radius: f32,
         a_min_of_12: ::std::os::raw::c_int,
         a_max_of_12: ::std::os::raw::c_int,
@@ -7612,6 +8725,24 @@ extern "C" {
     pub fn ImFont_SetFallbackChar(self_: *mut ImFont, c: ImWchar);
 }
 extern "C" {
+    pub fn ImGuiPlatformMonitor_ImGuiPlatformMonitor() -> *mut ImGuiPlatformMonitor;
+}
+extern "C" {
+    pub fn ImGuiPlatformMonitor_destroy(self_: *mut ImGuiPlatformMonitor);
+}
+extern "C" {
+    pub fn ImGuiPlatformIO_ImGuiPlatformIO() -> *mut ImGuiPlatformIO;
+}
+extern "C" {
+    pub fn ImGuiPlatformIO_destroy(self_: *mut ImGuiPlatformIO);
+}
+extern "C" {
+    pub fn ImGuiViewport_ImGuiViewport() -> *mut ImGuiViewport;
+}
+extern "C" {
+    pub fn ImGuiViewport_destroy(self_: *mut ImGuiViewport);
+}
+extern "C" {
     pub fn igGetWindowPos_nonUDT(pOut: *mut ImVec2);
 }
 extern "C" {
@@ -7790,2135 +8921,6 @@ extern "C" {
         text_end: *const ::std::os::raw::c_char,
         remaining: *mut *const ::std::os::raw::c_char,
     ) -> ImVec2_Simple;
-}
-extern "C" {
-    pub fn ImVector_float_ImVector_float() -> *mut ImVector_float;
-}
-extern "C" {
-    pub fn ImVector_float_destroy(self_: *mut ImVector_float);
-}
-extern "C" {
-    pub fn ImVector_ImWchar_ImVector_ImWchar() -> *mut ImVector_ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_destroy(self_: *mut ImVector_ImWchar);
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_ImVector_ImDrawVert() -> *mut ImVector_ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_destroy(self_: *mut ImVector_ImDrawVert);
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_ImVector_ImFontGlyph() -> *mut ImVector_ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_destroy(self_: *mut ImVector_ImFontGlyph);
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_ImVector_ImGuiTextRange() -> *mut ImVector_ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_destroy(self_: *mut ImVector_ImGuiTextRange);
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_ImVector_ImGuiStoragePair() -> *mut ImVector_ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_destroy(self_: *mut ImVector_ImGuiStoragePair);
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_ImVector_ImDrawChannel() -> *mut ImVector_ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_destroy(self_: *mut ImVector_ImDrawChannel);
-}
-extern "C" {
-    pub fn ImVector_char_ImVector_char() -> *mut ImVector_char;
-}
-extern "C" {
-    pub fn ImVector_char_destroy(self_: *mut ImVector_char);
-}
-extern "C" {
-    pub fn ImVector_ImU32_ImVector_ImU32() -> *mut ImVector_ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImU32_destroy(self_: *mut ImVector_ImU32);
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_ImVector_ImFontAtlasCustomRect(
-    ) -> *mut ImVector_ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_destroy(self_: *mut ImVector_ImFontAtlasCustomRect);
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_ImVector_ImTextureID() -> *mut ImVector_ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_destroy(self_: *mut ImVector_ImTextureID);
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_ImVector_ImFontConfig() -> *mut ImVector_ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_destroy(self_: *mut ImVector_ImFontConfig);
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_ImVector_ImFontPtr() -> *mut ImVector_ImFontPtr;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_destroy(self_: *mut ImVector_ImFontPtr);
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_ImVector_ImDrawCmd() -> *mut ImVector_ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_destroy(self_: *mut ImVector_ImDrawCmd);
-}
-extern "C" {
-    pub fn ImVector_ImVec4_ImVector_ImVec4() -> *mut ImVector_ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_destroy(self_: *mut ImVector_ImVec4);
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_ImVector_ImDrawIdx() -> *mut ImVector_ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_destroy(self_: *mut ImVector_ImDrawIdx);
-}
-extern "C" {
-    pub fn ImVector_ImVec2_ImVector_ImVec2() -> *mut ImVector_ImVec2;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_destroy(self_: *mut ImVector_ImVec2);
-}
-extern "C" {
-    pub fn ImVector_float_ImVector_floatVector(src: ImVector_float) -> *mut ImVector_float;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_ImVector_ImWcharVector(src: ImVector_ImWchar) -> *mut ImVector_ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_ImVector_ImDrawVertVector(
-        src: ImVector_ImDrawVert,
-    ) -> *mut ImVector_ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_ImVector_ImFontGlyphVector(
-        src: ImVector_ImFontGlyph,
-    ) -> *mut ImVector_ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_ImVector_ImGuiTextRangeVector(
-        src: ImVector_ImGuiTextRange,
-    ) -> *mut ImVector_ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_ImVector_ImGuiStoragePairVector(
-        src: ImVector_ImGuiStoragePair,
-    ) -> *mut ImVector_ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_ImVector_ImDrawChannelVector(
-        src: ImVector_ImDrawChannel,
-    ) -> *mut ImVector_ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_ImVector_charVector(src: ImVector_char) -> *mut ImVector_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_ImVector_ImU32Vector(src: ImVector_ImU32) -> *mut ImVector_ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_ImVector_ImFontAtlasCustomRectVector(
-        src: ImVector_ImFontAtlasCustomRect,
-    ) -> *mut ImVector_ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_ImVector_ImTextureIDVector(
-        src: ImVector_ImTextureID,
-    ) -> *mut ImVector_ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_ImVector_ImFontConfigVector(
-        src: ImVector_ImFontConfig,
-    ) -> *mut ImVector_ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_ImVector_ImFontPtrVector(
-        src: ImVector_ImFontPtr,
-    ) -> *mut ImVector_ImFontPtr;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_ImVector_ImDrawCmdVector(
-        src: ImVector_ImDrawCmd,
-    ) -> *mut ImVector_ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_ImVector_ImVec4Vector(src: ImVector_ImVec4) -> *mut ImVector_ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_ImVector_ImDrawIdxVector(
-        src: ImVector_ImDrawIdx,
-    ) -> *mut ImVector_ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_ImVector_ImVec2Vector(src: ImVector_ImVec2) -> *mut ImVector_ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_empty(self_: *const ImVector_float) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_empty(self_: *const ImVector_ImWchar) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_empty(self_: *const ImVector_ImDrawVert) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_empty(self_: *const ImVector_ImFontGlyph) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_empty(self_: *const ImVector_ImGuiTextRange) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_empty(self_: *const ImVector_ImGuiStoragePair) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_empty(self_: *const ImVector_ImDrawChannel) -> bool;
-}
-extern "C" {
-    pub fn ImVector_char_empty(self_: *const ImVector_char) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImU32_empty(self_: *const ImVector_ImU32) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_empty(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-    ) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_empty(self_: *const ImVector_ImTextureID) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_empty(self_: *const ImVector_ImFontConfig) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_empty(self_: *const ImVector_ImFontPtr) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_empty(self_: *const ImVector_ImDrawCmd) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_empty(self_: *const ImVector_ImVec4) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_empty(self_: *const ImVector_ImDrawIdx) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_empty(self_: *const ImVector_ImVec2) -> bool;
-}
-extern "C" {
-    pub fn ImVector_float_size(self_: *const ImVector_float) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_size(self_: *const ImVector_ImWchar) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_size(self_: *const ImVector_ImDrawVert) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_size(self_: *const ImVector_ImFontGlyph) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_size(
-        self_: *const ImVector_ImGuiTextRange,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_size(
-        self_: *const ImVector_ImGuiStoragePair,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_size(
-        self_: *const ImVector_ImDrawChannel,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_char_size(self_: *const ImVector_char) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImU32_size(self_: *const ImVector_ImU32) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_size(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_size(self_: *const ImVector_ImTextureID) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_size(self_: *const ImVector_ImFontConfig)
-        -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_size(self_: *const ImVector_ImFontPtr) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_size(self_: *const ImVector_ImDrawCmd) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_size(self_: *const ImVector_ImVec4) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_size(self_: *const ImVector_ImDrawIdx) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_size(self_: *const ImVector_ImVec2) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_float_size_in_bytes(self_: *const ImVector_float) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_size_in_bytes(self_: *const ImVector_ImWchar) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_size_in_bytes(
-        self_: *const ImVector_ImDrawVert,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_size_in_bytes(
-        self_: *const ImVector_ImFontGlyph,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_size_in_bytes(
-        self_: *const ImVector_ImGuiTextRange,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_size_in_bytes(
-        self_: *const ImVector_ImGuiStoragePair,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_size_in_bytes(
-        self_: *const ImVector_ImDrawChannel,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_char_size_in_bytes(self_: *const ImVector_char) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImU32_size_in_bytes(self_: *const ImVector_ImU32) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_size_in_bytes(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_size_in_bytes(
-        self_: *const ImVector_ImTextureID,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_size_in_bytes(
-        self_: *const ImVector_ImFontConfig,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_size_in_bytes(
-        self_: *const ImVector_ImFontPtr,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_size_in_bytes(
-        self_: *const ImVector_ImDrawCmd,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_size_in_bytes(self_: *const ImVector_ImVec4) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_size_in_bytes(
-        self_: *const ImVector_ImDrawIdx,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_size_in_bytes(self_: *const ImVector_ImVec2) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_float_capacity(self_: *const ImVector_float) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_capacity(self_: *const ImVector_ImWchar) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_capacity(self_: *const ImVector_ImDrawVert)
-        -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_capacity(
-        self_: *const ImVector_ImFontGlyph,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_capacity(
-        self_: *const ImVector_ImGuiTextRange,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_capacity(
-        self_: *const ImVector_ImGuiStoragePair,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_capacity(
-        self_: *const ImVector_ImDrawChannel,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_char_capacity(self_: *const ImVector_char) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImU32_capacity(self_: *const ImVector_ImU32) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_capacity(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_capacity(
-        self_: *const ImVector_ImTextureID,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_capacity(
-        self_: *const ImVector_ImFontConfig,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_capacity(self_: *const ImVector_ImFontPtr) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_capacity(self_: *const ImVector_ImDrawCmd) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_capacity(self_: *const ImVector_ImVec4) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_capacity(self_: *const ImVector_ImDrawIdx) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_capacity(self_: *const ImVector_ImVec2) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_float_clear(self_: *mut ImVector_float);
-}
-extern "C" {
-    pub fn ImVector_ImWchar_clear(self_: *mut ImVector_ImWchar);
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_clear(self_: *mut ImVector_ImDrawVert);
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_clear(self_: *mut ImVector_ImFontGlyph);
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_clear(self_: *mut ImVector_ImGuiTextRange);
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_clear(self_: *mut ImVector_ImGuiStoragePair);
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_clear(self_: *mut ImVector_ImDrawChannel);
-}
-extern "C" {
-    pub fn ImVector_char_clear(self_: *mut ImVector_char);
-}
-extern "C" {
-    pub fn ImVector_ImU32_clear(self_: *mut ImVector_ImU32);
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_clear(self_: *mut ImVector_ImFontAtlasCustomRect);
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_clear(self_: *mut ImVector_ImTextureID);
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_clear(self_: *mut ImVector_ImFontConfig);
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_clear(self_: *mut ImVector_ImFontPtr);
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_clear(self_: *mut ImVector_ImDrawCmd);
-}
-extern "C" {
-    pub fn ImVector_ImVec4_clear(self_: *mut ImVector_ImVec4);
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_clear(self_: *mut ImVector_ImDrawIdx);
-}
-extern "C" {
-    pub fn ImVector_ImVec2_clear(self_: *mut ImVector_ImVec2);
-}
-extern "C" {
-    pub fn ImVector_float_begin(self_: *mut ImVector_float) -> *mut f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_begin(self_: *mut ImVector_ImWchar) -> *mut ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_begin(self_: *mut ImVector_ImDrawVert) -> *mut ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_begin(self_: *mut ImVector_ImFontGlyph) -> *mut ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_begin(
-        self_: *mut ImVector_ImGuiTextRange,
-    ) -> *mut ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_begin(
-        self_: *mut ImVector_ImGuiStoragePair,
-    ) -> *mut ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_begin(self_: *mut ImVector_ImDrawChannel) -> *mut ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_begin(self_: *mut ImVector_char) -> *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_begin(self_: *mut ImVector_ImU32) -> *mut ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_begin(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-    ) -> *mut ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_begin(self_: *mut ImVector_ImTextureID) -> *mut ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_begin(self_: *mut ImVector_ImFontConfig) -> *mut ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_begin(self_: *mut ImVector_ImFontPtr) -> *mut *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_begin(self_: *mut ImVector_ImDrawCmd) -> *mut ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_begin(self_: *mut ImVector_ImVec4) -> *mut ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_begin(self_: *mut ImVector_ImDrawIdx) -> *mut ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_begin(self_: *mut ImVector_ImVec2) -> *mut ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_begin_const(self_: *const ImVector_float) -> *const f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_begin_const(self_: *const ImVector_ImWchar) -> *const ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_begin_const(self_: *const ImVector_ImDrawVert) -> *const ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_begin_const(
-        self_: *const ImVector_ImFontGlyph,
-    ) -> *const ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_begin_const(
-        self_: *const ImVector_ImGuiTextRange,
-    ) -> *const ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_begin_const(
-        self_: *const ImVector_ImGuiStoragePair,
-    ) -> *const ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_begin_const(
-        self_: *const ImVector_ImDrawChannel,
-    ) -> *const ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_begin_const(self_: *const ImVector_char) -> *const ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_begin_const(self_: *const ImVector_ImU32) -> *const ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_begin_const(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-    ) -> *const ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_begin_const(
-        self_: *const ImVector_ImTextureID,
-    ) -> *const ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_begin_const(
-        self_: *const ImVector_ImFontConfig,
-    ) -> *const ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_begin_const(self_: *const ImVector_ImFontPtr) -> *const *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_begin_const(self_: *const ImVector_ImDrawCmd) -> *const ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_begin_const(self_: *const ImVector_ImVec4) -> *const ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_begin_const(self_: *const ImVector_ImDrawIdx) -> *const ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_begin_const(self_: *const ImVector_ImVec2) -> *const ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_end(self_: *mut ImVector_float) -> *mut f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_end(self_: *mut ImVector_ImWchar) -> *mut ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_end(self_: *mut ImVector_ImDrawVert) -> *mut ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_end(self_: *mut ImVector_ImFontGlyph) -> *mut ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_end(self_: *mut ImVector_ImGuiTextRange) -> *mut ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_end(
-        self_: *mut ImVector_ImGuiStoragePair,
-    ) -> *mut ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_end(self_: *mut ImVector_ImDrawChannel) -> *mut ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_end(self_: *mut ImVector_char) -> *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_end(self_: *mut ImVector_ImU32) -> *mut ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_end(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-    ) -> *mut ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_end(self_: *mut ImVector_ImTextureID) -> *mut ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_end(self_: *mut ImVector_ImFontConfig) -> *mut ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_end(self_: *mut ImVector_ImFontPtr) -> *mut *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_end(self_: *mut ImVector_ImDrawCmd) -> *mut ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_end(self_: *mut ImVector_ImVec4) -> *mut ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_end(self_: *mut ImVector_ImDrawIdx) -> *mut ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_end(self_: *mut ImVector_ImVec2) -> *mut ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_end_const(self_: *const ImVector_float) -> *const f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_end_const(self_: *const ImVector_ImWchar) -> *const ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_end_const(self_: *const ImVector_ImDrawVert) -> *const ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_end_const(self_: *const ImVector_ImFontGlyph)
-        -> *const ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_end_const(
-        self_: *const ImVector_ImGuiTextRange,
-    ) -> *const ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_end_const(
-        self_: *const ImVector_ImGuiStoragePair,
-    ) -> *const ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_end_const(
-        self_: *const ImVector_ImDrawChannel,
-    ) -> *const ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_end_const(self_: *const ImVector_char) -> *const ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_end_const(self_: *const ImVector_ImU32) -> *const ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_end_const(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-    ) -> *const ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_end_const(self_: *const ImVector_ImTextureID)
-        -> *const ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_end_const(
-        self_: *const ImVector_ImFontConfig,
-    ) -> *const ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_end_const(self_: *const ImVector_ImFontPtr) -> *const *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_end_const(self_: *const ImVector_ImDrawCmd) -> *const ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_end_const(self_: *const ImVector_ImVec4) -> *const ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_end_const(self_: *const ImVector_ImDrawIdx) -> *const ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_end_const(self_: *const ImVector_ImVec2) -> *const ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_front(self_: *mut ImVector_float) -> *mut f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_front(self_: *mut ImVector_ImWchar) -> *mut ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_front(self_: *mut ImVector_ImDrawVert) -> *mut ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_front(self_: *mut ImVector_ImFontGlyph) -> *mut ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_front(
-        self_: *mut ImVector_ImGuiTextRange,
-    ) -> *mut ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_front(
-        self_: *mut ImVector_ImGuiStoragePair,
-    ) -> *mut ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_front(self_: *mut ImVector_ImDrawChannel) -> *mut ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_front(self_: *mut ImVector_char) -> *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_front(self_: *mut ImVector_ImU32) -> *mut ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_front(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-    ) -> *mut ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_front(self_: *mut ImVector_ImTextureID) -> *mut ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_front(self_: *mut ImVector_ImFontConfig) -> *mut ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_front(self_: *mut ImVector_ImFontPtr) -> *mut *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_front(self_: *mut ImVector_ImDrawCmd) -> *mut ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_front(self_: *mut ImVector_ImVec4) -> *mut ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_front(self_: *mut ImVector_ImDrawIdx) -> *mut ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_front(self_: *mut ImVector_ImVec2) -> *mut ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_front_const(self_: *const ImVector_float) -> *const f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_front_const(self_: *const ImVector_ImWchar) -> *const ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_front_const(self_: *const ImVector_ImDrawVert) -> *const ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_front_const(
-        self_: *const ImVector_ImFontGlyph,
-    ) -> *const ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_front_const(
-        self_: *const ImVector_ImGuiTextRange,
-    ) -> *const ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_front_const(
-        self_: *const ImVector_ImGuiStoragePair,
-    ) -> *const ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_front_const(
-        self_: *const ImVector_ImDrawChannel,
-    ) -> *const ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_front_const(self_: *const ImVector_char) -> *const ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_front_const(self_: *const ImVector_ImU32) -> *const ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_front_const(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-    ) -> *const ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_front_const(
-        self_: *const ImVector_ImTextureID,
-    ) -> *const ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_front_const(
-        self_: *const ImVector_ImFontConfig,
-    ) -> *const ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_front_const(self_: *const ImVector_ImFontPtr) -> *const *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_front_const(self_: *const ImVector_ImDrawCmd) -> *const ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_front_const(self_: *const ImVector_ImVec4) -> *const ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_front_const(self_: *const ImVector_ImDrawIdx) -> *const ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_front_const(self_: *const ImVector_ImVec2) -> *const ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_back(self_: *mut ImVector_float) -> *mut f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_back(self_: *mut ImVector_ImWchar) -> *mut ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_back(self_: *mut ImVector_ImDrawVert) -> *mut ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_back(self_: *mut ImVector_ImFontGlyph) -> *mut ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_back(self_: *mut ImVector_ImGuiTextRange)
-        -> *mut ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_back(
-        self_: *mut ImVector_ImGuiStoragePair,
-    ) -> *mut ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_back(self_: *mut ImVector_ImDrawChannel) -> *mut ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_back(self_: *mut ImVector_char) -> *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_back(self_: *mut ImVector_ImU32) -> *mut ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_back(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-    ) -> *mut ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_back(self_: *mut ImVector_ImTextureID) -> *mut ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_back(self_: *mut ImVector_ImFontConfig) -> *mut ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_back(self_: *mut ImVector_ImFontPtr) -> *mut *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_back(self_: *mut ImVector_ImDrawCmd) -> *mut ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_back(self_: *mut ImVector_ImVec4) -> *mut ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_back(self_: *mut ImVector_ImDrawIdx) -> *mut ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_back(self_: *mut ImVector_ImVec2) -> *mut ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_back_const(self_: *const ImVector_float) -> *const f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_back_const(self_: *const ImVector_ImWchar) -> *const ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_back_const(self_: *const ImVector_ImDrawVert) -> *const ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_back_const(
-        self_: *const ImVector_ImFontGlyph,
-    ) -> *const ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_back_const(
-        self_: *const ImVector_ImGuiTextRange,
-    ) -> *const ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_back_const(
-        self_: *const ImVector_ImGuiStoragePair,
-    ) -> *const ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_back_const(
-        self_: *const ImVector_ImDrawChannel,
-    ) -> *const ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_back_const(self_: *const ImVector_char) -> *const ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_back_const(self_: *const ImVector_ImU32) -> *const ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_back_const(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-    ) -> *const ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_back_const(
-        self_: *const ImVector_ImTextureID,
-    ) -> *const ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_back_const(
-        self_: *const ImVector_ImFontConfig,
-    ) -> *const ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_back_const(self_: *const ImVector_ImFontPtr) -> *const *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_back_const(self_: *const ImVector_ImDrawCmd) -> *const ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_back_const(self_: *const ImVector_ImVec4) -> *const ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_back_const(self_: *const ImVector_ImDrawIdx) -> *const ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_back_const(self_: *const ImVector_ImVec2) -> *const ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_swap(self_: *mut ImVector_float, rhs: ImVector_float);
-}
-extern "C" {
-    pub fn ImVector_ImWchar_swap(self_: *mut ImVector_ImWchar, rhs: ImVector_ImWchar);
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_swap(self_: *mut ImVector_ImDrawVert, rhs: ImVector_ImDrawVert);
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_swap(self_: *mut ImVector_ImFontGlyph, rhs: ImVector_ImFontGlyph);
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_swap(
-        self_: *mut ImVector_ImGuiTextRange,
-        rhs: ImVector_ImGuiTextRange,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_swap(
-        self_: *mut ImVector_ImGuiStoragePair,
-        rhs: ImVector_ImGuiStoragePair,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_swap(
-        self_: *mut ImVector_ImDrawChannel,
-        rhs: ImVector_ImDrawChannel,
-    );
-}
-extern "C" {
-    pub fn ImVector_char_swap(self_: *mut ImVector_char, rhs: ImVector_char);
-}
-extern "C" {
-    pub fn ImVector_ImU32_swap(self_: *mut ImVector_ImU32, rhs: ImVector_ImU32);
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_swap(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        rhs: ImVector_ImFontAtlasCustomRect,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_swap(self_: *mut ImVector_ImTextureID, rhs: ImVector_ImTextureID);
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_swap(
-        self_: *mut ImVector_ImFontConfig,
-        rhs: ImVector_ImFontConfig,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_swap(self_: *mut ImVector_ImFontPtr, rhs: ImVector_ImFontPtr);
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_swap(self_: *mut ImVector_ImDrawCmd, rhs: ImVector_ImDrawCmd);
-}
-extern "C" {
-    pub fn ImVector_ImVec4_swap(self_: *mut ImVector_ImVec4, rhs: ImVector_ImVec4);
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_swap(self_: *mut ImVector_ImDrawIdx, rhs: ImVector_ImDrawIdx);
-}
-extern "C" {
-    pub fn ImVector_ImVec2_swap(self_: *mut ImVector_ImVec2, rhs: ImVector_ImVec2);
-}
-extern "C" {
-    pub fn ImVector_float__grow_capacity(
-        self_: *const ImVector_float,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImWchar__grow_capacity(
-        self_: *const ImVector_ImWchar,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert__grow_capacity(
-        self_: *const ImVector_ImDrawVert,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph__grow_capacity(
-        self_: *const ImVector_ImFontGlyph,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange__grow_capacity(
-        self_: *const ImVector_ImGuiTextRange,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair__grow_capacity(
-        self_: *const ImVector_ImGuiStoragePair,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel__grow_capacity(
-        self_: *const ImVector_ImDrawChannel,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_char__grow_capacity(
-        self_: *const ImVector_char,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImU32__grow_capacity(
-        self_: *const ImVector_ImU32,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect__grow_capacity(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID__grow_capacity(
-        self_: *const ImVector_ImTextureID,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig__grow_capacity(
-        self_: *const ImVector_ImFontConfig,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr__grow_capacity(
-        self_: *const ImVector_ImFontPtr,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd__grow_capacity(
-        self_: *const ImVector_ImDrawCmd,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec4__grow_capacity(
-        self_: *const ImVector_ImVec4,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx__grow_capacity(
-        self_: *const ImVector_ImDrawIdx,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec2__grow_capacity(
-        self_: *const ImVector_ImVec2,
-        sz: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_float_resize(self_: *mut ImVector_float, new_size: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn ImVector_ImWchar_resize(self_: *mut ImVector_ImWchar, new_size: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_resize(
-        self_: *mut ImVector_ImDrawVert,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_resize(
-        self_: *mut ImVector_ImFontGlyph,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_resize(
-        self_: *mut ImVector_ImGuiTextRange,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_resize(
-        self_: *mut ImVector_ImGuiStoragePair,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_resize(
-        self_: *mut ImVector_ImDrawChannel,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_char_resize(self_: *mut ImVector_char, new_size: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn ImVector_ImU32_resize(self_: *mut ImVector_ImU32, new_size: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_resize(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_resize(
-        self_: *mut ImVector_ImTextureID,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_resize(
-        self_: *mut ImVector_ImFontConfig,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_resize(
-        self_: *mut ImVector_ImFontPtr,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_resize(
-        self_: *mut ImVector_ImDrawCmd,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImVec4_resize(self_: *mut ImVector_ImVec4, new_size: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_resize(
-        self_: *mut ImVector_ImDrawIdx,
-        new_size: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImVec2_resize(self_: *mut ImVector_ImVec2, new_size: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn ImVector_float_resizeT(
-        self_: *mut ImVector_float,
-        new_size: ::std::os::raw::c_int,
-        v: f32,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImWchar_resizeT(
-        self_: *mut ImVector_ImWchar,
-        new_size: ::std::os::raw::c_int,
-        v: ImWchar,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_resizeT(
-        self_: *mut ImVector_ImDrawVert,
-        new_size: ::std::os::raw::c_int,
-        v: ImDrawVert,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_resizeT(
-        self_: *mut ImVector_ImFontGlyph,
-        new_size: ::std::os::raw::c_int,
-        v: ImFontGlyph,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_resizeT(
-        self_: *mut ImVector_ImGuiTextRange,
-        new_size: ::std::os::raw::c_int,
-        v: ImGuiTextRange,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_resizeT(
-        self_: *mut ImVector_ImGuiStoragePair,
-        new_size: ::std::os::raw::c_int,
-        v: ImGuiStoragePair,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_resizeT(
-        self_: *mut ImVector_ImDrawChannel,
-        new_size: ::std::os::raw::c_int,
-        v: ImDrawChannel,
-    );
-}
-extern "C" {
-    pub fn ImVector_char_resizeT(
-        self_: *mut ImVector_char,
-        new_size: ::std::os::raw::c_int,
-        v: ::std::os::raw::c_char,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImU32_resizeT(
-        self_: *mut ImVector_ImU32,
-        new_size: ::std::os::raw::c_int,
-        v: ImU32,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_resizeT(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        new_size: ::std::os::raw::c_int,
-        v: ImFontAtlasCustomRect,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_resizeT(
-        self_: *mut ImVector_ImTextureID,
-        new_size: ::std::os::raw::c_int,
-        v: ImTextureID,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_resizeT(
-        self_: *mut ImVector_ImFontConfig,
-        new_size: ::std::os::raw::c_int,
-        v: ImFontConfig,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_resizeT(
-        self_: *mut ImVector_ImFontPtr,
-        new_size: ::std::os::raw::c_int,
-        v: *mut ImFont,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_resizeT(
-        self_: *mut ImVector_ImDrawCmd,
-        new_size: ::std::os::raw::c_int,
-        v: ImDrawCmd,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImVec4_resizeT(
-        self_: *mut ImVector_ImVec4,
-        new_size: ::std::os::raw::c_int,
-        v: ImVec4,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_resizeT(
-        self_: *mut ImVector_ImDrawIdx,
-        new_size: ::std::os::raw::c_int,
-        v: ImDrawIdx,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImVec2_resizeT(
-        self_: *mut ImVector_ImVec2,
-        new_size: ::std::os::raw::c_int,
-        v: ImVec2,
-    );
-}
-extern "C" {
-    pub fn ImVector_float_reserve(self_: *mut ImVector_float, new_capacity: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn ImVector_ImWchar_reserve(
-        self_: *mut ImVector_ImWchar,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_reserve(
-        self_: *mut ImVector_ImDrawVert,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_reserve(
-        self_: *mut ImVector_ImFontGlyph,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_reserve(
-        self_: *mut ImVector_ImGuiTextRange,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_reserve(
-        self_: *mut ImVector_ImGuiStoragePair,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_reserve(
-        self_: *mut ImVector_ImDrawChannel,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_char_reserve(self_: *mut ImVector_char, new_capacity: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn ImVector_ImU32_reserve(self_: *mut ImVector_ImU32, new_capacity: ::std::os::raw::c_int);
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_reserve(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_reserve(
-        self_: *mut ImVector_ImTextureID,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_reserve(
-        self_: *mut ImVector_ImFontConfig,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_reserve(
-        self_: *mut ImVector_ImFontPtr,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_reserve(
-        self_: *mut ImVector_ImDrawCmd,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImVec4_reserve(
-        self_: *mut ImVector_ImVec4,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_reserve(
-        self_: *mut ImVector_ImDrawIdx,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImVec2_reserve(
-        self_: *mut ImVector_ImVec2,
-        new_capacity: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn ImVector_float_push_back(self_: *mut ImVector_float, v: f32);
-}
-extern "C" {
-    pub fn ImVector_ImWchar_push_back(self_: *mut ImVector_ImWchar, v: ImWchar);
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_push_back(self_: *mut ImVector_ImDrawVert, v: ImDrawVert);
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_push_back(self_: *mut ImVector_ImFontGlyph, v: ImFontGlyph);
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_push_back(
-        self_: *mut ImVector_ImGuiTextRange,
-        v: ImGuiTextRange,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_push_back(
-        self_: *mut ImVector_ImGuiStoragePair,
-        v: ImGuiStoragePair,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_push_back(self_: *mut ImVector_ImDrawChannel, v: ImDrawChannel);
-}
-extern "C" {
-    pub fn ImVector_char_push_back(self_: *mut ImVector_char, v: ::std::os::raw::c_char);
-}
-extern "C" {
-    pub fn ImVector_ImU32_push_back(self_: *mut ImVector_ImU32, v: ImU32);
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_push_back(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        v: ImFontAtlasCustomRect,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_push_back(self_: *mut ImVector_ImTextureID, v: ImTextureID);
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_push_back(self_: *mut ImVector_ImFontConfig, v: ImFontConfig);
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_push_back(self_: *mut ImVector_ImFontPtr, v: *mut ImFont);
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_push_back(self_: *mut ImVector_ImDrawCmd, v: ImDrawCmd);
-}
-extern "C" {
-    pub fn ImVector_ImVec4_push_back(self_: *mut ImVector_ImVec4, v: ImVec4);
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_push_back(self_: *mut ImVector_ImDrawIdx, v: ImDrawIdx);
-}
-extern "C" {
-    pub fn ImVector_ImVec2_push_back(self_: *mut ImVector_ImVec2, v: ImVec2);
-}
-extern "C" {
-    pub fn ImVector_float_pop_back(self_: *mut ImVector_float);
-}
-extern "C" {
-    pub fn ImVector_ImWchar_pop_back(self_: *mut ImVector_ImWchar);
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_pop_back(self_: *mut ImVector_ImDrawVert);
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_pop_back(self_: *mut ImVector_ImFontGlyph);
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_pop_back(self_: *mut ImVector_ImGuiTextRange);
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_pop_back(self_: *mut ImVector_ImGuiStoragePair);
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_pop_back(self_: *mut ImVector_ImDrawChannel);
-}
-extern "C" {
-    pub fn ImVector_char_pop_back(self_: *mut ImVector_char);
-}
-extern "C" {
-    pub fn ImVector_ImU32_pop_back(self_: *mut ImVector_ImU32);
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_pop_back(self_: *mut ImVector_ImFontAtlasCustomRect);
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_pop_back(self_: *mut ImVector_ImTextureID);
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_pop_back(self_: *mut ImVector_ImFontConfig);
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_pop_back(self_: *mut ImVector_ImFontPtr);
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_pop_back(self_: *mut ImVector_ImDrawCmd);
-}
-extern "C" {
-    pub fn ImVector_ImVec4_pop_back(self_: *mut ImVector_ImVec4);
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_pop_back(self_: *mut ImVector_ImDrawIdx);
-}
-extern "C" {
-    pub fn ImVector_ImVec2_pop_back(self_: *mut ImVector_ImVec2);
-}
-extern "C" {
-    pub fn ImVector_float_push_front(self_: *mut ImVector_float, v: f32);
-}
-extern "C" {
-    pub fn ImVector_ImWchar_push_front(self_: *mut ImVector_ImWchar, v: ImWchar);
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_push_front(self_: *mut ImVector_ImDrawVert, v: ImDrawVert);
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_push_front(self_: *mut ImVector_ImFontGlyph, v: ImFontGlyph);
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_push_front(
-        self_: *mut ImVector_ImGuiTextRange,
-        v: ImGuiTextRange,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_push_front(
-        self_: *mut ImVector_ImGuiStoragePair,
-        v: ImGuiStoragePair,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_push_front(self_: *mut ImVector_ImDrawChannel, v: ImDrawChannel);
-}
-extern "C" {
-    pub fn ImVector_char_push_front(self_: *mut ImVector_char, v: ::std::os::raw::c_char);
-}
-extern "C" {
-    pub fn ImVector_ImU32_push_front(self_: *mut ImVector_ImU32, v: ImU32);
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_push_front(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        v: ImFontAtlasCustomRect,
-    );
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_push_front(self_: *mut ImVector_ImTextureID, v: ImTextureID);
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_push_front(self_: *mut ImVector_ImFontConfig, v: ImFontConfig);
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_push_front(self_: *mut ImVector_ImFontPtr, v: *mut ImFont);
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_push_front(self_: *mut ImVector_ImDrawCmd, v: ImDrawCmd);
-}
-extern "C" {
-    pub fn ImVector_ImVec4_push_front(self_: *mut ImVector_ImVec4, v: ImVec4);
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_push_front(self_: *mut ImVector_ImDrawIdx, v: ImDrawIdx);
-}
-extern "C" {
-    pub fn ImVector_ImVec2_push_front(self_: *mut ImVector_ImVec2, v: ImVec2);
-}
-extern "C" {
-    pub fn ImVector_float_erase(self_: *mut ImVector_float, it: *const f32) -> *mut f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_erase(self_: *mut ImVector_ImWchar, it: *const ImWchar)
-        -> *mut ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_erase(
-        self_: *mut ImVector_ImDrawVert,
-        it: *const ImDrawVert,
-    ) -> *mut ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_erase(
-        self_: *mut ImVector_ImFontGlyph,
-        it: *const ImFontGlyph,
-    ) -> *mut ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_erase(
-        self_: *mut ImVector_ImGuiTextRange,
-        it: *const ImGuiTextRange,
-    ) -> *mut ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_erase(
-        self_: *mut ImVector_ImGuiStoragePair,
-        it: *const ImGuiStoragePair,
-    ) -> *mut ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_erase(
-        self_: *mut ImVector_ImDrawChannel,
-        it: *const ImDrawChannel,
-    ) -> *mut ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_erase(
-        self_: *mut ImVector_char,
-        it: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_erase(self_: *mut ImVector_ImU32, it: *const ImU32) -> *mut ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_erase(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        it: *const ImFontAtlasCustomRect,
-    ) -> *mut ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_erase(
-        self_: *mut ImVector_ImTextureID,
-        it: *const ImTextureID,
-    ) -> *mut ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_erase(
-        self_: *mut ImVector_ImFontConfig,
-        it: *const ImFontConfig,
-    ) -> *mut ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_erase(
-        self_: *mut ImVector_ImFontPtr,
-        it: *const *mut ImFont,
-    ) -> *mut *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_erase(
-        self_: *mut ImVector_ImDrawCmd,
-        it: *const ImDrawCmd,
-    ) -> *mut ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_erase(self_: *mut ImVector_ImVec4, it: *const ImVec4) -> *mut ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_erase(
-        self_: *mut ImVector_ImDrawIdx,
-        it: *const ImDrawIdx,
-    ) -> *mut ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_erase(self_: *mut ImVector_ImVec2, it: *const ImVec2) -> *mut ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_eraseTPtr(
-        self_: *mut ImVector_float,
-        it: *const f32,
-        it_last: *const f32,
-    ) -> *mut f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_eraseTPtr(
-        self_: *mut ImVector_ImWchar,
-        it: *const ImWchar,
-        it_last: *const ImWchar,
-    ) -> *mut ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_eraseTPtr(
-        self_: *mut ImVector_ImDrawVert,
-        it: *const ImDrawVert,
-        it_last: *const ImDrawVert,
-    ) -> *mut ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_eraseTPtr(
-        self_: *mut ImVector_ImFontGlyph,
-        it: *const ImFontGlyph,
-        it_last: *const ImFontGlyph,
-    ) -> *mut ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_eraseTPtr(
-        self_: *mut ImVector_ImGuiTextRange,
-        it: *const ImGuiTextRange,
-        it_last: *const ImGuiTextRange,
-    ) -> *mut ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_eraseTPtr(
-        self_: *mut ImVector_ImGuiStoragePair,
-        it: *const ImGuiStoragePair,
-        it_last: *const ImGuiStoragePair,
-    ) -> *mut ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_eraseTPtr(
-        self_: *mut ImVector_ImDrawChannel,
-        it: *const ImDrawChannel,
-        it_last: *const ImDrawChannel,
-    ) -> *mut ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_eraseTPtr(
-        self_: *mut ImVector_char,
-        it: *const ::std::os::raw::c_char,
-        it_last: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_eraseTPtr(
-        self_: *mut ImVector_ImU32,
-        it: *const ImU32,
-        it_last: *const ImU32,
-    ) -> *mut ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_eraseTPtr(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        it: *const ImFontAtlasCustomRect,
-        it_last: *const ImFontAtlasCustomRect,
-    ) -> *mut ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_eraseTPtr(
-        self_: *mut ImVector_ImTextureID,
-        it: *const ImTextureID,
-        it_last: *const ImTextureID,
-    ) -> *mut ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_eraseTPtr(
-        self_: *mut ImVector_ImFontConfig,
-        it: *const ImFontConfig,
-        it_last: *const ImFontConfig,
-    ) -> *mut ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_eraseTPtr(
-        self_: *mut ImVector_ImFontPtr,
-        it: *const *mut ImFont,
-        it_last: *const *mut ImFont,
-    ) -> *mut *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_eraseTPtr(
-        self_: *mut ImVector_ImDrawCmd,
-        it: *const ImDrawCmd,
-        it_last: *const ImDrawCmd,
-    ) -> *mut ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_eraseTPtr(
-        self_: *mut ImVector_ImVec4,
-        it: *const ImVec4,
-        it_last: *const ImVec4,
-    ) -> *mut ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_eraseTPtr(
-        self_: *mut ImVector_ImDrawIdx,
-        it: *const ImDrawIdx,
-        it_last: *const ImDrawIdx,
-    ) -> *mut ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_eraseTPtr(
-        self_: *mut ImVector_ImVec2,
-        it: *const ImVec2,
-        it_last: *const ImVec2,
-    ) -> *mut ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_erase_unsorted(self_: *mut ImVector_float, it: *const f32) -> *mut f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_erase_unsorted(
-        self_: *mut ImVector_ImWchar,
-        it: *const ImWchar,
-    ) -> *mut ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_erase_unsorted(
-        self_: *mut ImVector_ImDrawVert,
-        it: *const ImDrawVert,
-    ) -> *mut ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_erase_unsorted(
-        self_: *mut ImVector_ImFontGlyph,
-        it: *const ImFontGlyph,
-    ) -> *mut ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_erase_unsorted(
-        self_: *mut ImVector_ImGuiTextRange,
-        it: *const ImGuiTextRange,
-    ) -> *mut ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_erase_unsorted(
-        self_: *mut ImVector_ImGuiStoragePair,
-        it: *const ImGuiStoragePair,
-    ) -> *mut ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_erase_unsorted(
-        self_: *mut ImVector_ImDrawChannel,
-        it: *const ImDrawChannel,
-    ) -> *mut ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_erase_unsorted(
-        self_: *mut ImVector_char,
-        it: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_erase_unsorted(
-        self_: *mut ImVector_ImU32,
-        it: *const ImU32,
-    ) -> *mut ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_erase_unsorted(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        it: *const ImFontAtlasCustomRect,
-    ) -> *mut ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_erase_unsorted(
-        self_: *mut ImVector_ImTextureID,
-        it: *const ImTextureID,
-    ) -> *mut ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_erase_unsorted(
-        self_: *mut ImVector_ImFontConfig,
-        it: *const ImFontConfig,
-    ) -> *mut ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_erase_unsorted(
-        self_: *mut ImVector_ImFontPtr,
-        it: *const *mut ImFont,
-    ) -> *mut *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_erase_unsorted(
-        self_: *mut ImVector_ImDrawCmd,
-        it: *const ImDrawCmd,
-    ) -> *mut ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_erase_unsorted(
-        self_: *mut ImVector_ImVec4,
-        it: *const ImVec4,
-    ) -> *mut ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_erase_unsorted(
-        self_: *mut ImVector_ImDrawIdx,
-        it: *const ImDrawIdx,
-    ) -> *mut ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_erase_unsorted(
-        self_: *mut ImVector_ImVec2,
-        it: *const ImVec2,
-    ) -> *mut ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_insert(self_: *mut ImVector_float, it: *const f32, v: f32) -> *mut f32;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_insert(
-        self_: *mut ImVector_ImWchar,
-        it: *const ImWchar,
-        v: ImWchar,
-    ) -> *mut ImWchar;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_insert(
-        self_: *mut ImVector_ImDrawVert,
-        it: *const ImDrawVert,
-        v: ImDrawVert,
-    ) -> *mut ImDrawVert;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_insert(
-        self_: *mut ImVector_ImFontGlyph,
-        it: *const ImFontGlyph,
-        v: ImFontGlyph,
-    ) -> *mut ImFontGlyph;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_insert(
-        self_: *mut ImVector_ImGuiTextRange,
-        it: *const ImGuiTextRange,
-        v: ImGuiTextRange,
-    ) -> *mut ImGuiTextRange;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_insert(
-        self_: *mut ImVector_ImGuiStoragePair,
-        it: *const ImGuiStoragePair,
-        v: ImGuiStoragePair,
-    ) -> *mut ImGuiStoragePair;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_insert(
-        self_: *mut ImVector_ImDrawChannel,
-        it: *const ImDrawChannel,
-        v: ImDrawChannel,
-    ) -> *mut ImDrawChannel;
-}
-extern "C" {
-    pub fn ImVector_char_insert(
-        self_: *mut ImVector_char,
-        it: *const ::std::os::raw::c_char,
-        v: ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn ImVector_ImU32_insert(
-        self_: *mut ImVector_ImU32,
-        it: *const ImU32,
-        v: ImU32,
-    ) -> *mut ImU32;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_insert(
-        self_: *mut ImVector_ImFontAtlasCustomRect,
-        it: *const ImFontAtlasCustomRect,
-        v: ImFontAtlasCustomRect,
-    ) -> *mut ImFontAtlasCustomRect;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_insert(
-        self_: *mut ImVector_ImTextureID,
-        it: *const ImTextureID,
-        v: ImTextureID,
-    ) -> *mut ImTextureID;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_insert(
-        self_: *mut ImVector_ImFontConfig,
-        it: *const ImFontConfig,
-        v: ImFontConfig,
-    ) -> *mut ImFontConfig;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_insert(
-        self_: *mut ImVector_ImFontPtr,
-        it: *const *mut ImFont,
-        v: *mut ImFont,
-    ) -> *mut *mut ImFont;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_insert(
-        self_: *mut ImVector_ImDrawCmd,
-        it: *const ImDrawCmd,
-        v: ImDrawCmd,
-    ) -> *mut ImDrawCmd;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_insert(
-        self_: *mut ImVector_ImVec4,
-        it: *const ImVec4,
-        v: ImVec4,
-    ) -> *mut ImVec4;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_insert(
-        self_: *mut ImVector_ImDrawIdx,
-        it: *const ImDrawIdx,
-        v: ImDrawIdx,
-    ) -> *mut ImDrawIdx;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_insert(
-        self_: *mut ImVector_ImVec2,
-        it: *const ImVec2,
-        v: ImVec2,
-    ) -> *mut ImVec2;
-}
-extern "C" {
-    pub fn ImVector_float_contains(self_: *const ImVector_float, v: f32) -> bool;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_contains(self_: *const ImVector_ImWchar, v: ImWchar) -> bool;
-}
-extern "C" {
-    pub fn ImVector_char_contains(self_: *const ImVector_char, v: ::std::os::raw::c_char) -> bool;
-}
-extern "C" {
-    pub fn ImVector_float_index_from_ptr(
-        self_: *const ImVector_float,
-        it: *const f32,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImWchar_index_from_ptr(
-        self_: *const ImVector_ImWchar,
-        it: *const ImWchar,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawVert_index_from_ptr(
-        self_: *const ImVector_ImDrawVert,
-        it: *const ImDrawVert,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontGlyph_index_from_ptr(
-        self_: *const ImVector_ImFontGlyph,
-        it: *const ImFontGlyph,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiTextRange_index_from_ptr(
-        self_: *const ImVector_ImGuiTextRange,
-        it: *const ImGuiTextRange,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImGuiStoragePair_index_from_ptr(
-        self_: *const ImVector_ImGuiStoragePair,
-        it: *const ImGuiStoragePair,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawChannel_index_from_ptr(
-        self_: *const ImVector_ImDrawChannel,
-        it: *const ImDrawChannel,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_char_index_from_ptr(
-        self_: *const ImVector_char,
-        it: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImU32_index_from_ptr(
-        self_: *const ImVector_ImU32,
-        it: *const ImU32,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontAtlasCustomRect_index_from_ptr(
-        self_: *const ImVector_ImFontAtlasCustomRect,
-        it: *const ImFontAtlasCustomRect,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImTextureID_index_from_ptr(
-        self_: *const ImVector_ImTextureID,
-        it: *const ImTextureID,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontConfig_index_from_ptr(
-        self_: *const ImVector_ImFontConfig,
-        it: *const ImFontConfig,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImFontPtr_index_from_ptr(
-        self_: *const ImVector_ImFontPtr,
-        it: *const *mut ImFont,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawCmd_index_from_ptr(
-        self_: *const ImVector_ImDrawCmd,
-        it: *const ImDrawCmd,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec4_index_from_ptr(
-        self_: *const ImVector_ImVec4,
-        it: *const ImVec4,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImDrawIdx_index_from_ptr(
-        self_: *const ImVector_ImDrawIdx,
-        it: *const ImDrawIdx,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn ImVector_ImVec2_index_from_ptr(
-        self_: *const ImVector_ImVec2,
-        it: *const ImVec2,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn igLogText(fmt: *const ::std::os::raw::c_char, ...);

--- a/src/fonts/font.rs
+++ b/src/fonts/font.rs
@@ -19,6 +19,7 @@ pub struct Font {
     config_data: *const sys::ImFontConfig,
     pub config_data_count: i16,
     pub fallback_char: sys::ImWchar,
+    pub ellipsis_char: sys::ImWchar,
     pub scale: f32,
     pub ascent: f32,
     pub descent: f32,
@@ -58,6 +59,7 @@ fn test_font_memory_layout() {
     assert_field_offset!(config_data, ConfigData);
     assert_field_offset!(config_data_count, ConfigDataCount);
     assert_field_offset!(fallback_char, FallbackChar);
+    assert_field_offset!(ellipsis_char, EllipsisChar);
     assert_field_offset!(scale, Scale);
     assert_field_offset!(ascent, Ascent);
     assert_field_offset!(descent, Descent);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub fn dear_imgui_version() -> &'static str {
 
 #[test]
 fn test_version() {
-    assert_eq!(dear_imgui_version(), "1.72b");
+    assert_eq!(dear_imgui_version(), "1.74");
 }
 
 impl Context {

--- a/src/render/draw_data.rs
+++ b/src/render/draw_data.rs
@@ -27,6 +27,8 @@ pub struct DrawData {
     /// Based on io.display_frame_buffer_scale. Typically [1.0, 1.0] on normal displays, and
     /// [2.0, 2.0] on Retina displays, but fractional values are also possible.
     pub framebuffer_scale: [f32; 2],
+    /// Viewport carrying the ImDrawData instance, might be of use to the renderer (generally not).
+    pub owner_viewport: *mut sys::ImGuiViewport,
 }
 
 unsafe impl RawCast<sys::ImDrawData> for DrawData {}
@@ -105,6 +107,7 @@ fn test_drawdata_memory_layout() {
     assert_field_offset!(display_pos, DisplayPos);
     assert_field_offset!(display_size, DisplaySize);
     assert_field_offset!(framebuffer_scale, FramebufferScale);
+    assert_field_offset!(owner_viewport, OwnerViewport);
 }
 
 /// Draw command list

--- a/src/style.rs
+++ b/src/style.rs
@@ -124,7 +124,7 @@ pub struct Style {
     /// quality.
     pub curve_tessellation_tol: f32,
     /// Style colors.
-    pub colors: [[f32; 4]; 48],
+    pub colors: [[f32; 4]; 50],
 }
 
 unsafe impl RawCast<sys::ImGuiStyle> for Style {}
@@ -219,6 +219,8 @@ pub enum StyleColor {
     TabActive = sys::ImGuiCol_TabActive,
     TabUnfocused = sys::ImGuiCol_TabUnfocused,
     TabUnfocusedActive = sys::ImGuiCol_TabUnfocusedActive,
+    DockingPreview = sys::ImGuiCol_DockingPreview,
+    DockingEmptyBg = sys::ImGuiCol_DockingEmptyBg,
     PlotLines = sys::ImGuiCol_PlotLines,
     PlotLinesHovered = sys::ImGuiCol_PlotLinesHovered,
     PlotHistogram = sys::ImGuiCol_PlotHistogram,
@@ -276,6 +278,8 @@ impl StyleColor {
         StyleColor::TabActive,
         StyleColor::TabUnfocused,
         StyleColor::TabUnfocusedActive,
+        StyleColor::DockingPreview,
+        StyleColor::DockingEmptyBg,
         StyleColor::PlotLines,
         StyleColor::PlotLinesHovered,
         StyleColor::PlotHistogram,


### PR DESCRIPTION
This PR adds initial support for the Dear Imgui `docking` branch. 

The docking/viewport branch is a long-living branch that will eventually be merged to master and brings many new features to Dear Imgui. While some features can be used almost without changing code (docking), others require extensive support in the backend (viewports). Since it might take a while to correctly implement for viewports in our several backends, I thought we might as well start implementation.

This PR has initial support: it passes cargo test by fixing the layouts, but does not yet wrap new APIs. It was written off v0.2, as 0.3 is still not stable.

*NOTE*: This PR should probably be merged into a new `docking` branch. There's no way for me to target a branch that doesn't exist yet; if somebody creates a `docking` branch, I can change this PR and let it point there.
