### PR TITLE
Add `Ui::plot_lines_fn` and `Ui::plot_histogram_fn`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -7,6 +7,8 @@
 ### Added
 
 - `Io::peek_input_characters`
+- `Ui::plot_lines_fn`
+- `Ui::plot_histogram_fn`
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ pub use self::input_widget::{
 pub use self::io::*;
 pub use self::layout::*;
 pub use self::legacy::*;
-pub use self::plothistogram::PlotHistogram;
-pub use self::plotlines::PlotLines;
+pub use self::plothistogram::{PlotHistogram, PlotHistogramFn};
+pub use self::plotlines::{PlotLines, PlotLinesFn};
 pub use self::popup_modal::PopupModal;
 pub use self::render::draw_data::*;
 pub use self::render::renderer::*;
@@ -412,6 +412,16 @@ impl<'ui> Ui<'ui> {
     pub fn plot_lines<'p>(&self, label: &'p ImStr, values: &'p [f32]) -> PlotLines<'ui, 'p> {
         PlotLines::new(self, label, values)
     }
+
+    pub fn plot_lines_fn<'p, T>(
+        &self,
+        label: &'p ImStr,
+        values_getter: fn(&mut T, usize) -> f32,
+        data: &'p mut T,
+        values_count: usize,
+    ) -> PlotLinesFn<'ui, 'p, T> {
+        PlotLinesFn::new(self, label, values_getter, data, values_count)
+    }
 }
 
 impl<'ui> Ui<'ui> {
@@ -421,6 +431,16 @@ impl<'ui> Ui<'ui> {
         values: &'p [f32],
     ) -> PlotHistogram<'ui, 'p> {
         PlotHistogram::new(self, label, values)
+    }
+
+    pub fn plot_histogram_fn<'p, T>(
+        &self,
+        label: &'p ImStr,
+        values_getter: fn(&mut T, usize) -> f32,
+        data: &'p mut T,
+        values_count: usize,
+    ) -> PlotHistogramFn<'ui, 'p, T> {
+        PlotHistogramFn::new(self, label, values_getter, data, values_count)
     }
 }
 

--- a/src/plothistogram.rs
+++ b/src/plothistogram.rs
@@ -76,3 +76,97 @@ impl<'ui, 'p> PlotHistogram<'ui, 'p> {
         }
     }
 }
+
+#[must_use]
+pub struct PlotHistogramFn<'ui, 'p, T> {
+    label: &'p ImStr,
+    values_getter: fn(&mut T, usize) -> f32,
+    data: &'p mut T,
+    values_count: usize,
+    values_offset: usize,
+    overlay_text: Option<&'p ImStr>,
+    scale_min: f32,
+    scale_max: f32,
+    graph_size: [f32; 2],
+    _phantom: PhantomData<&'ui Ui<'ui>>,
+}
+
+impl<'ui, 'p, T: 'p> PlotHistogramFn<'ui, 'p, T> {
+    pub fn new(
+        _: &Ui<'ui>,
+        label: &'p ImStr,
+        values_getter: fn(&mut T, usize) -> f32,
+        data: &'p mut T,
+        values_count: usize,
+    ) -> Self {
+        PlotHistogramFn {
+            label,
+            values_getter,
+            data,
+            values_count,
+            values_offset: 0usize,
+            overlay_text: None,
+            scale_min: f32::MAX,
+            scale_max: f32::MAX,
+            graph_size: [0.0, 0.0],
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn values_offset(mut self, values_offset: usize) -> Self {
+        self.values_offset = values_offset;
+        self
+    }
+
+    #[inline]
+    pub fn overlay_text(mut self, overlay_text: &'p ImStr) -> Self {
+        self.overlay_text = Some(overlay_text);
+        self
+    }
+
+    #[inline]
+    pub fn scale_min(mut self, scale_min: f32) -> Self {
+        self.scale_min = scale_min;
+        self
+    }
+
+    #[inline]
+    pub fn scale_max(mut self, scale_max: f32) -> Self {
+        self.scale_max = scale_max;
+        self
+    }
+
+    #[inline]
+    pub fn graph_size(mut self, graph_size: [f32; 2]) -> Self {
+        self.graph_size = graph_size;
+        self
+    }
+
+    pub fn build(mut self) {
+        // see https://stackoverflow.com/questions/34691267/why-would-it-be-necessary-to-perform-two-casts-to-a-mutable-raw-pointer-in-a-row
+        let self_ptr = &mut self as *mut _ as *mut _;
+        unsafe {
+            sys::igPlotHistogramFnFloatPtr(
+                self.label.as_ptr(),
+                Some(Self::internal_callback),
+                self_ptr,
+                self.values_count as i32,
+                self.values_offset as i32,
+                self.overlay_text.map(|x| x.as_ptr()).unwrap_or(ptr::null()),
+                self.scale_min,
+                self.scale_max,
+                self.graph_size.into(),
+            );
+        }
+    }
+
+    extern "C" fn internal_callback(
+        data: *mut ::std::os::raw::c_void,
+        idx: ::std::os::raw::c_int,
+    ) -> f32 {
+        // see https://stackoverflow.com/questions/24191249/working-with-c-void-in-an-ffi
+        let self_ref: &mut Self = unsafe { &mut *(data as *mut _) };
+        (self_ref.values_getter)(self_ref.data, idx as usize)
+    }
+}

--- a/src/plotlines.rs
+++ b/src/plotlines.rs
@@ -76,3 +76,97 @@ impl<'ui, 'p> PlotLines<'ui, 'p> {
         }
     }
 }
+
+#[must_use]
+pub struct PlotLinesFn<'ui, 'p, T> {
+    label: &'p ImStr,
+    values_getter: fn(&mut T, usize) -> f32,
+    data: &'p mut T,
+    values_count: usize,
+    values_offset: usize,
+    overlay_text: Option<&'p ImStr>,
+    scale_min: f32,
+    scale_max: f32,
+    graph_size: [f32; 2],
+    _phantom: PhantomData<&'ui Ui<'ui>>,
+}
+
+impl<'ui, 'p, T: 'p> PlotLinesFn<'ui, 'p, T> {
+    pub fn new(
+        _: &Ui<'ui>,
+        label: &'p ImStr,
+        values_getter: fn(&mut T, usize) -> f32,
+        data: &'p mut T,
+        values_count: usize,
+    ) -> Self {
+        PlotLinesFn {
+            label,
+            values_getter,
+            data,
+            values_count,
+            values_offset: 0usize,
+            overlay_text: None,
+            scale_min: f32::MAX,
+            scale_max: f32::MAX,
+            graph_size: [0.0, 0.0],
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn values_offset(mut self, values_offset: usize) -> Self {
+        self.values_offset = values_offset;
+        self
+    }
+
+    #[inline]
+    pub fn overlay_text(mut self, overlay_text: &'p ImStr) -> Self {
+        self.overlay_text = Some(overlay_text);
+        self
+    }
+
+    #[inline]
+    pub fn scale_min(mut self, scale_min: f32) -> Self {
+        self.scale_min = scale_min;
+        self
+    }
+
+    #[inline]
+    pub fn scale_max(mut self, scale_max: f32) -> Self {
+        self.scale_max = scale_max;
+        self
+    }
+
+    #[inline]
+    pub fn graph_size(mut self, graph_size: [f32; 2]) -> Self {
+        self.graph_size = graph_size;
+        self
+    }
+
+    pub fn build(mut self) {
+        // see https://stackoverflow.com/questions/34691267/why-would-it-be-necessary-to-perform-two-casts-to-a-mutable-raw-pointer-in-a-row
+        let self_ptr = &mut self as *mut _ as *mut _;
+        unsafe {
+            sys::igPlotLinesFnFloatPtr(
+                self.label.as_ptr(),
+                Some(Self::internal_callback),
+                self_ptr,
+                self.values_count as i32,
+                self.values_offset as i32,
+                self.overlay_text.map(|x| x.as_ptr()).unwrap_or(ptr::null()),
+                self.scale_min,
+                self.scale_max,
+                self.graph_size.into(),
+            );
+        }
+    }
+
+    extern "C" fn internal_callback(
+        data: *mut ::std::os::raw::c_void,
+        idx: ::std::os::raw::c_int,
+    ) -> f32 {
+        // see https://stackoverflow.com/questions/24191249/working-with-c-void-in-an-ffi
+        let self_ref: &mut Self = unsafe { &mut *(data as *mut Self) };
+        (self_ref.values_getter)(self_ref.data, idx as usize)
+    }
+}


### PR DESCRIPTION
Adds `Ui::plot_lines_fn` and  `Ui::plot_histogram_fn` alongside  the existing `Ui::plot_lines` and  `Ui::plot_histogram`.

The `_fn` variants uses a `value_getter` callback and user data to get the data to plot.

Some heavy pointer casting is happening.