### PR TITLE
Updates for ownership transfer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "imgui"
 version = "0.6.0"
 edition = "2018"
-authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
+authors = ["The imgui-rs Developers"]
 description = "High-level Rust bindings to dear imgui"
-homepage = "https://github.com/Gekkio/imgui-rs"
-repository = "https://github.com/Gekkio/imgui-rs"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
 license = "MIT/Apache-2.0"
 categories = ["gui", "api-bindings"]
 readme = "README.markdown"

--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ Minimum Rust version: 1.43
 
 Wrapped Dear ImGui version: 1.79
 
-[![Build Status](https://github.com/Gekkio/imgui-rs/workflows/ci/badge.svg)](https://github.com/Gekkio/imgui-rs/actions)
+[![Build Status](https://github.com/imgui-rs/imgui-rs/workflows/ci/badge.svg)](https://github.com/imgui-rs/imgui-rs/actions)
 [![Latest release on crates.io](https://meritbadge.herokuapp.com/imgui)](https://crates.io/crates/imgui)
 [![Documentation on docs.rs](https://docs.rs/imgui/badge.svg)](https://docs.rs/imgui)
 

--- a/imgui-examples/Cargo.toml
+++ b/imgui-examples/Cargo.toml
@@ -2,10 +2,10 @@
 name = "imgui-examples"
 version = "0.0.0"
 edition = "2018"
-authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
+authors = ["The imgui-rs Developers"]
 description = "imgui crate examples using Glium backend"
-homepage = "https://github.com/Gekkio/imgui-rs"
-repository = "https://github.com/Gekkio/imgui-rs"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
 license = "MIT/Apache-2.0"
 publish = false
 

--- a/imgui-gfx-examples/Cargo.toml
+++ b/imgui-gfx-examples/Cargo.toml
@@ -2,10 +2,10 @@
 name = "imgui-gfx-examples"
 version = "0.0.0"
 edition = "2018"
-authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
+authors = ["The imgui-rs Developers"]
 description = "imgui crate examples"
-homepage = "https://github.com/Gekkio/imgui-rs"
-repository = "https://github.com/Gekkio/imgui-rs"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
 license = "MIT/Apache-2.0"
 publish = false
 

--- a/imgui-gfx-renderer/Cargo.toml
+++ b/imgui-gfx-renderer/Cargo.toml
@@ -2,10 +2,10 @@
 name = "imgui-gfx-renderer"
 version = "0.6.0"
 edition = "2018"
-authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
+authors = ["The imgui-rs Developers"]
 description = "gfx renderer for the imgui crate"
-homepage = "https://github.com/Gekkio/imgui-rs"
-repository = "https://github.com/Gekkio/imgui-rs"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
 license = "MIT/Apache-2.0"
 categories = ["gui", "rendering"]
 

--- a/imgui-glium-renderer/Cargo.toml
+++ b/imgui-glium-renderer/Cargo.toml
@@ -2,10 +2,10 @@
 name = "imgui-glium-renderer"
 version = "0.6.0"
 edition = "2018"
-authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
+authors = ["The imgui-rs Developers"]
 description = "Glium renderer for the imgui crate"
-homepage = "https://github.com/Gekkio/imgui-rs"
-repository = "https://github.com/Gekkio/imgui-rs"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
 license = "MIT/Apache-2.0"
 categories = ["gui", "rendering"]
 

--- a/imgui-sys-bindgen/Cargo.toml
+++ b/imgui-sys-bindgen/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "imgui-sys-bindgen"
 version = "0.0.0"
-authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
+authors = ["The imgui-rs Developers"]
 edition = "2018"
 description = "imgui-sys bindings updater"
-homepage = "https://github.com/Gekkio/imgui-rs"
-repository = "https://github.com/Gekkio/imgui-rs"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
 license = "MIT/Apache-2.0"
 publish = false
 

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -2,10 +2,10 @@
 name = "imgui-sys"
 version = "0.6.0"
 edition = "2018"
-authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
+authors = ["The imgui-rs Developers"]
 description = "Raw FFI bindings to dear imgui"
-homepage = "https://github.com/Gekkio/imgui-rs"
-repository = "https://github.com/Gekkio/imgui-rs"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
 license = "MIT/Apache-2.0"
 categories = ["gui", "external-ffi-bindings"]
 build = "build.rs"

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -2,10 +2,10 @@
 name = "imgui-winit-support"
 version = "0.6.0"
 edition = "2018"
-authors = ["Joonas Javanainen <joonas.javanainen@gmail.com>", "imgui-rs contributors"]
+authors = ["The imgui-rs Developers"]
 description = "winit support code for the imgui crate"
-homepage = "https://github.com/Gekkio/imgui-rs"
-repository = "https://github.com/Gekkio/imgui-rs"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
 license = "MIT/Apache-2.0"
 categories = ["gui"]
 


### PR DESCRIPTION
- Various links now point at the new imgui-rs/imgui-rs github repo.
- As discussed, the `authors` entry in Cargo.toml now uses same text
  that appears in `LICENSE-MIT`, and doesn't list anybody directly.

(This PR also kinda smoke-tests that CI still functions)