### PR TITLE
added new for texture id

### DIFF
--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -6,6 +6,12 @@ use std::collections::HashMap;
 pub struct TextureId(usize);
 
 impl TextureId {
+    /// Creates a new texture id with the given identifier.
+    pub fn new(id: usize) -> Self {
+        Self(id)
+    }
+
+    /// Returns the id of the TextureId.
     pub fn id(self) -> usize {
         self.0
     }


### PR DESCRIPTION
This very small commit adds a constructor for `TextureId`. I have forgotten how to make it for a usize a few times. Now that IDE support is much better in Rust, finding `::new` is generally easier than `From` methods, though obviously, I didn't remove the `From` impls, so those who prefer those are good to go too.