### PR TITLE
Improve imgui-winit-support, CI, and some other smaller changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,28 @@ jobs:
       - uses: hecrj/setup-rust-action@v1
         with:
           components: clippy
+      - name: Cache cargo directories
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo target dirs
+        uses: actions/cache@v2
+        with:
+          path: |
+            target
+            imgui-examples/target
+            imgui-gfx-examples/target
+            imgui-sys-bindgen/target
+          # ... will the hashFiles ever hit?
+          key: ${{ runner.os }}-stable-target-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo clippy --workspace --all-targets
       # excluded crates
-      - run: cargo clippy --manifest-path imgui-examples/Cargo.toml --all-targets
-      - run: cargo clippy --manifest-path imgui-gfx-examples/Cargo.toml --all-targets
+      # ... why do only these two have lockfiles? Oh well, keep them up to date if they're in there...
+      - run: cargo clippy --manifest-path imgui-examples/Cargo.toml --all-targets --locked
+      - run: cargo clippy --manifest-path imgui-gfx-examples/Cargo.toml --all-targets --locked
       - run: cargo clippy --manifest-path imgui-sys-bindgen/Cargo.toml --all-targets
       # supported winit versions
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --all-features --all-targets
@@ -93,6 +111,28 @@ jobs:
           override: true
       - run: sudo apt install libxcb-shape0-dev libxcb-xfixes0-dev
         if: runner.os == 'Linux'
+      # workaround for https://github.com/actions/cache/issues/403
+      - name: Install GNU tar
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install gnu-tar
+          echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
+      - name: Cache cargo directories
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo target dirs
+        uses: actions/cache@v2
+        with:
+          path: |
+            target
+            imgui-examples/target
+            imgui-gfx-examples/target
+            imgui-sys-bindgen/target
+          key: ${{ runner.os }}-${{ matrix.rust }}-target-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo test --all
       - run: cargo test --manifest-path imgui-examples/Cargo.toml
       - run: cargo test --manifest-path imgui-gfx-examples/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,13 @@ on:
   pull_request:
   push:
     branches:
-    - master
+      - master
   schedule:
     - cron: "0 0 * * 1"
 
 jobs:
-  check:
-    name: Run checks
+  clippy:
+    name: Run clippy / linting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,95 +20,47 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: hecrj/setup-rust-action@v1
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
+          components: clippy
+      - run: cargo clippy --workspace
+      # excluded crates
+      - run: cargo clippy --manifest-path imgui-examples/Cargo.toml
+      - run: cargo clippy --manifest-path imgui-gfx-examples/Cargo.toml
+      - run: cargo clippy --manifest-path imgui-sys-bindgen/Cargo.toml
+      # supported winit versions
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23
+      # Ensure we compile with all features
+      - run: cargo check --manifest-path imgui-winit-support/Cargo.toml --all-features
+
+  rustfmt:
+    name: Check rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      # TODO: why not `with: {submodules: true}`
+      - name: Checkout submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+      - uses: hecrj/setup-rust-action@v1
         with:
-          command: check
-      - name: Run cargo check (imgui-examples)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path imgui-examples/Cargo.toml
-      - name: Run cargo check (imgui-gfx-examples)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path imgui-gfx-examples/Cargo.toml
-      - name: Run cargo check (imgui-sys-bindgen)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path imgui-sys-bindgen/Cargo.toml
-      - name: Run cargo check (imgui-winit-support with winit-19)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19
-      - name: Run cargo check (imgui-winit-support with winit-20)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20
-      - name: Run cargo check (imgui-winit-support with winit-22)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22
-      - name: Run cargo check (imgui-winit-support with winit-23)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-      - name: Run cargo fmt (imgui-examples)
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path imgui-examples/Cargo.toml -- --check
-      - name: Run cargo fmt (imgui-gfx-examples)
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path imgui-gfx-examples/Cargo.toml -- --check
-      - name: Run cargo fmt (imgui-sys-bindgen)
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path imgui-sys-bindgen/Cargo.toml -- --check
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all
-      - name: Run cargo clippy (imgui-examples)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path imgui-examples/Cargo.toml
-      - name: Run cargo clippy (imgui-gfx-examples)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path imgui-gfx-examples/Cargo.toml
-      - name: Run cargo clippy (imgui-sys-bindgen)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path imgui-sys-bindgen/Cargo.toml
+          components: rustfmt
+      # workspace
+      - run: cargo fmt --all -- --check
+      # excluded crates
+      - run: cargo fmt --manifest-path imgui-examples/Cargo.toml -- --check
+      - run: cargo fmt --manifest-path imgui-gfx-examples/Cargo.toml -- --check
+      - run: cargo fmt --manifest-path imgui-sys-bindgen/Cargo.toml -- --check
+
   test:
     name: Run tests
-    needs: [check]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -135,52 +87,15 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: Install Ubuntu packages
-        run: sudo apt install libxcb-shape0-dev libxcb-xfixes0-dev
+      - run: sudo apt install libxcb-shape0-dev libxcb-xfixes0-dev
         if: runner.os == 'Linux'
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
-      - name: Run cargo test (imgui-examples)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path imgui-examples/Cargo.toml
-      - name: Run cargo test (imgui-gfx-examples)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path imgui-gfx-examples/Cargo.toml
-      - name: Run cargo test (imgui-sys-bindgen)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path imgui-sys-bindgen/Cargo.toml
-      - name: Run cargo test (imgui-gfx-examples with directx)
-        uses: actions-rs/cargo@v1
+      - run: cargo test --all
+      - run: cargo test --manifest-path imgui-examples/Cargo.toml
+      - run: cargo test --manifest-path imgui-gfx-examples/Cargo.toml
+      - run: cargo test --manifest-path imgui-sys-bindgen/Cargo.toml
+      - run: cargo test --manifest-path imgui-gfx-examples/Cargo.toml --no-default-features --features directx
         if: runner.os == 'Windows'
-        with:
-          command: test
-          args: --manifest-path imgui-gfx-examples/Cargo.toml --no-default-features --features directx
-      - name: Run cargo test (imgui-winit-support with winit-19)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19
-      - name: Run cargo test (imgui-winit-support with winit-20)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20
-      - name: Run cargo test (imgui-winit-support with winit-22)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22
-      - name: Run cargo test (imgui-winit-support with winit-23)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23
+      - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19
+      - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20
+      - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22
+      - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-cargo-
       - name: Cache cargo target dirs
         uses: actions/cache@v2
         with:
@@ -40,8 +43,11 @@ jobs:
             imgui-examples/target
             imgui-gfx-examples/target
             imgui-sys-bindgen/target
-          # ... will the hashFiles ever hit?
-          key: ${{ runner.os }}-stable-target-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-target-stable-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-target-stable-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-target-stable-
+            ${{ runner.os }}-target-
       - run: cargo clippy --workspace --all-targets
       # excluded crates
       # ... why do only these two have lockfiles? Oh well, keep them up to date if they're in there...
@@ -123,7 +129,10 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-cargo-
       - name: Cache cargo target dirs
         uses: actions/cache@v2
         with:
@@ -132,7 +141,11 @@ jobs:
             imgui-examples/target
             imgui-gfx-examples/target
             imgui-sys-bindgen/target
-          key: ${{ runner.os }}-${{ matrix.rust }}-target-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-target-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-target-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-target-${{ matrix.rust }}-
+            ${{ runner.os }}-target-
       - run: cargo test --all
       - run: cargo test --manifest-path imgui-examples/Cargo.toml
       - run: cargo test --manifest-path imgui-gfx-examples/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,10 @@ on:
 
 jobs:
   clippy:
-    name: Run clippy / linting
+    name: Run linter
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,18 +25,17 @@ jobs:
       - uses: hecrj/setup-rust-action@v1
         with:
           components: clippy
-      - run: cargo clippy --workspace
+      - run: cargo clippy --workspace --all-targets
       # excluded crates
-      - run: cargo clippy --manifest-path imgui-examples/Cargo.toml
-      - run: cargo clippy --manifest-path imgui-gfx-examples/Cargo.toml
-      - run: cargo clippy --manifest-path imgui-sys-bindgen/Cargo.toml
+      - run: cargo clippy --manifest-path imgui-examples/Cargo.toml --all-targets
+      - run: cargo clippy --manifest-path imgui-gfx-examples/Cargo.toml --all-targets
+      - run: cargo clippy --manifest-path imgui-sys-bindgen/Cargo.toml --all-targets
       # supported winit versions
-      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19
-      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20
-      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22
-      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23
-      # Ensure we compile with all features
-      - run: cargo check --manifest-path imgui-winit-support/Cargo.toml --all-features
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --all-features --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19 --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20 --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22 --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23 --all-targets
 
   rustfmt:
     name: Check rustfmt
@@ -62,6 +63,9 @@ jobs:
   test:
     name: Run tests
     runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
     strategy:
       matrix:
         rust:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ bitflags = "1.0"
 glium = { version = "0.28", default-features = false, optional = true }
 gfx = { version = "0.18", optional = true }
 imgui-sys = { version = "0.6.0", path = "imgui-sys" }
-lazy_static = "1.1"
 parking_lot = "0.11"
 
 [features]

--- a/imgui-examples/Cargo.lock
+++ b/imgui-examples/Cargo.lock
@@ -615,7 +615,6 @@ dependencies = [
  "bitflags",
  "glium",
  "imgui-sys",
- "lazy_static",
  "parking_lot",
 ]
 

--- a/imgui-examples/examples/support/clipboard.rs
+++ b/imgui-examples/examples/support/clipboard.rs
@@ -4,9 +4,7 @@ use imgui::{ClipboardBackend, ImStr, ImString};
 pub struct ClipboardSupport(ClipboardContext);
 
 pub fn init() -> Option<ClipboardSupport> {
-    ClipboardContext::new()
-        .ok()
-        .map(ClipboardSupport)
+    ClipboardContext::new().ok().map(ClipboardSupport)
 }
 
 impl ClipboardBackend for ClipboardSupport {

--- a/imgui-examples/examples/support/clipboard.rs
+++ b/imgui-examples/examples/support/clipboard.rs
@@ -6,7 +6,7 @@ pub struct ClipboardSupport(ClipboardContext);
 pub fn init() -> Option<ClipboardSupport> {
     ClipboardContext::new()
         .ok()
-        .map(|ctx| ClipboardSupport(ctx))
+        .map(ClipboardSupport)
 }
 
 impl ClipboardBackend for ClipboardSupport {

--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -82,11 +82,11 @@ impl Default for State {
             no_menu: false,
             no_close: false,
             wrap_width: 200.0,
-            buf: buf,
+            buf,
             item: 0,
             item2: 0,
-            text: text,
-            text_multiline: text_multiline,
+            text,
+            text_multiline,
             i0: 123,
             f0: 0.001,
             vec2f: [0.10, 0.20],
@@ -870,9 +870,7 @@ fn show_example_menu_file<'a>(ui: &Ui<'a>, state: &mut FileMenuState) {
         }
         menu.end(ui);
     }
-    if let Some(_) = ui.begin_menu(im_str!("Disabled"), false) {
-        unreachable!();
-    }
+    assert!(ui.begin_menu(im_str!("Disabled"), false).is_none());
     MenuItem::new(im_str!("Checked")).selected(true).build(ui);
     MenuItem::new(im_str!("Quit"))
         .shortcut(im_str!("Alt+F4"))

--- a/imgui-gfx-examples/Cargo.lock
+++ b/imgui-gfx-examples/Cargo.lock
@@ -536,7 +536,6 @@ dependencies = [
  "bitflags",
  "gfx",
  "imgui-sys",
- "lazy_static",
  "parking_lot 0.11.0",
 ]
 

--- a/imgui-gfx-renderer/build.rs
+++ b/imgui-gfx-renderer/build.rs
@@ -77,16 +77,17 @@ mod hlsl_build {
             let mut code: *mut ID3DBlob = ptr::null_mut();
             let mut error_msgs: *mut ID3DBlob = ptr::null_mut();
 
+            let c_entry_point = CString::new(entry_point).unwrap();
+            let c_target = CString::new(target).unwrap();
+            let c_source_path = CString::new(source_path.to_string_lossy().to_string()).unwrap();
             let hr = d3dcompiler::D3DCompile(
                 src_data.as_bytes().as_ptr() as LPCVOID,
                 src_data.as_bytes().len(),
-                CString::new(source_path.to_string_lossy().to_string())
-                    .unwrap()
-                    .as_ptr(),
+                c_source_path.as_ptr(),
                 ptr::null(),
                 ptr::null_mut(),
-                CString::new(entry_point).unwrap().as_ptr(),
-                CString::new(target).unwrap().as_ptr(),
+                c_entry_point.as_ptr(),
+                c_target.as_ptr(),
                 0,
                 0,
                 &mut code,

--- a/imgui-sys-bindgen/src/main.rs
+++ b/imgui-sys-bindgen/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
 
     let wasm_ffi_import_name = option_env!("IMGUI_RS_WASM_IMPORT_NAME")
         .map(|s| s.to_string())
-        .or(Some("imgui-sys-v0".to_string()));
+        .or_else(|| Some("imgui-sys-v0".to_string()));
 
     let wasm_bindings = generate_bindings(&sys_path.join("third-party"), wasm_ffi_import_name)
         .expect("Failed to generate bindings");

--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -100,7 +100,7 @@ fn test_imvec2_memory_layout() {
     assert_eq!(mem::align_of::<ImVec2>(), mem::align_of::<[f32; 2]>());
     let test = ImVec2::new(1.0, 2.0);
     let ref_a: &ImVec2 = &test;
-    let ref_b: &[f32; 2] = unsafe { mem::transmute(&test) };
+    let ref_b: &[f32; 2] = unsafe { &*(&test as *const _ as *const [f32; 2]) };
     assert_eq!(&ref_a.x as *const _, &ref_b[0] as *const _);
     assert_eq!(&ref_a.y as *const _, &ref_b[1] as *const _);
 }
@@ -112,7 +112,7 @@ fn test_imvec4_memory_layout() {
     assert_eq!(mem::align_of::<ImVec4>(), mem::align_of::<[f32; 4]>());
     let test = ImVec4::new(1.0, 2.0, 3.0, 4.0);
     let ref_a: &ImVec4 = &test;
-    let ref_b: &[f32; 4] = unsafe { mem::transmute(&test) };
+    let ref_b: &[f32; 4] = unsafe { &*(&test as *const _ as *const [f32; 4]) };
     assert_eq!(&ref_a.x as *const _, &ref_b[0] as *const _);
     assert_eq!(&ref_a.y as *const _, &ref_b[1] as *const _);
     assert_eq!(&ref_a.z as *const _, &ref_b[2] as *const _);

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -18,3 +18,9 @@ winit-23 = { version = "0.23", package = "winit", optional = true }
 
 [features]
 default = ["winit-23"]
+
+# This is phrased as a negative (unlike most features) so that it needs to be
+# explicitly disabled (and `default-features = false` won't do it). To avoid
+# problems from this we don't expose this in the public API in any way, keeping
+# things additive.
+no-warn-on-multiple = []

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -248,6 +248,7 @@ struct Button {
 impl Button {
     // we can use this in an array initializer, unlike `Default::default()` or a
     // `const fn new()`.
+    #[allow(clippy::declare_interior_mutable_const)]
     const INIT: Button = Self {
         pressed_this_frame: Cell::new(false),
         state: Cell::new(false),

--- a/src/context.rs
+++ b/src/context.rs
@@ -59,11 +59,9 @@ pub struct Context {
     clipboard_ctx: Option<Box<ClipboardContext>>,
 }
 
-lazy_static! {
-    // This mutex needs to be used to guard all public functions that can affect the underlying
-    // Dear ImGui active context
-    static ref CTX_MUTEX: ReentrantMutex<()> = ReentrantMutex::new(());
-}
+// This mutex needs to be used to guard all public functions that can affect the underlying
+// Dear ImGui active context
+static CTX_MUTEX: ReentrantMutex<()> = parking_lot::const_reentrant_mutex(());
 
 fn clear_current_context() {
     unsafe {

--- a/src/context.rs
+++ b/src/context.rs
@@ -388,7 +388,7 @@ fn test_shared_font_atlas() {
     let _guard = crate::test::TEST_MUTEX.lock();
     let atlas = Rc::new(RefCell::new(SharedFontAtlas::create()));
     let suspended1 = SuspendedContext::create_with_shared_font_atlas(atlas.clone());
-    let mut ctx2 = Context::create_with_shared_font_atlas(atlas.clone());
+    let mut ctx2 = Context::create_with_shared_font_atlas(atlas);
     {
         let _borrow = ctx2.fonts();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 pub extern crate imgui_sys as sys;
-#[macro_use]
-extern crate lazy_static;
 
 use std::cell;
 use std::ffi::CStr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::float_cmp)]
 pub extern crate imgui_sys as sys;
 
 use std::cell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,10 +342,10 @@ impl<'ui> Ui<'ui> {
 
 // Widgets: Popups
 impl<'ui> Ui<'ui> {
-    pub fn open_popup<'p>(&self, str_id: &'p ImStr) {
+    pub fn open_popup(&self, str_id: &ImStr) {
         unsafe { sys::igOpenPopup(str_id.as_ptr(), 0) };
     }
-    pub fn popup<'p, F>(&self, str_id: &'p ImStr, f: F)
+    pub fn popup<F>(&self, str_id: &ImStr, f: F)
     where
         F: FnOnce(),
     {

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,9 +3,7 @@ use std::ptr;
 
 use crate::context::Context;
 
-lazy_static! {
-    pub static ref TEST_MUTEX: ReentrantMutex<()> = ReentrantMutex::new(());
-}
+pub static TEST_MUTEX: ReentrantMutex<()> = parking_lot::const_reentrant_mutex(());
 
 pub fn test_ctx() -> (ReentrantMutexGuard<'static, ()>, Context) {
     let guard = TEST_MUTEX.lock();


### PR DESCRIPTION
Several changes that I had done before officially being made maintainer.

- Improve winit version wrangling in imgui-winit-support.
- Replace `lazy_static` with `parking_lot::const_recursive_mutex`
- Make `window_draw_list` atomic code both actually-correct and faster (probably not visibly faster).
- Fix dropping mouse events in `imgui-winit-support` if press/release is on same frame (very common on macos in recent winit versions).
- clean up CI
- actually run clippy on the examples (and fix all the lint warnings)
