### PR TITLE
Switch to SCU build (aka 'Single File' or 'Unity build') for -sys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,11 @@ jobs:
             imgui-examples/target
             imgui-gfx-examples/target
             imgui-sys-bindgen/target
-          key: ${{ runner.os }}-target-stable-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-target-lint-stable-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-target-stable-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-target-stable-
+            ${{ runner.os }}-target-lint-stable-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-target-lint-stable-
+            ${{ runner.os }}-target-lint-
             ${{ runner.os }}-target-
       - run: cargo clippy --workspace --all-targets
       # excluded crates
@@ -141,10 +142,13 @@ jobs:
             imgui-examples/target
             imgui-gfx-examples/target
             imgui-sys-bindgen/target
-          key: ${{ runner.os }}-target-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          # note `cargo test` and `cargo clippy` don't use the same build
+          # artifacts, so this has a different key
+          key: ${{ runner.os }}-target-test-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-target-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-target-${{ matrix.rust }}-
+            ${{ runner.os }}-target-test-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-target-test-${{ matrix.rust }}-
+            ${{ runner.os }}-target-test-
             ${{ runner.os }}-target-
       - run: cargo test --all
       - run: cargo test --manifest-path imgui-examples/Cargo.toml

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -10,6 +10,8 @@ license = "MIT/Apache-2.0"
 categories = ["gui", "external-ffi-bindings"]
 build = "build.rs"
 links = "imgui"
+# exclude json, lua, and the imgui subdirs (imgui/examples, imgui/docs, etc)
+exclude = ["third-party/*.json", "third-party/*.lua", "third-party/imgui/*/"]
 
 [build-dependencies]
 cc = "1.0"

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -50,16 +50,13 @@ fn main() -> io::Result<()> {
         // Avoid the if-supported flag functions for easy cases, as they're
         // kinda costly.
         if compiler.is_like_gnu() || compiler.is_like_clang() {
-            build
-                .flag("-fno-exceptions")
-                .flag("-fno-rtti");
+            build.flag("-fno-exceptions").flag("-fno-rtti");
         }
         // TODO: disable linking C++ stdlib? Not sure if it's allowed.
         build
             .warnings(false)
             .file("include_all_imgui.cpp")
-            .compile("libcimgui.a")
-        ;
+            .compile("libcimgui.a");
     }
     Ok(())
 }

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -33,7 +33,7 @@ fn main() -> io::Result<()> {
     for (key, value) in DEFINES.iter() {
         println!("cargo:DEFINE_{}={}", key, value.unwrap_or(""));
     }
-    if !std::env::var_os("CARGO_FEATURE_WASM").is_some() {
+    if std::env::var_os("CARGO_FEATURE_WASM").is_none() {
         // Check submodule status. (Anything else should be a compile error in
         // the C code).
         assert_file_exists("third-party/cimgui.cpp")?;

--- a/imgui-sys/include_all_imgui.cpp
+++ b/imgui-sys/include_all_imgui.cpp
@@ -1,0 +1,11 @@
+// This improves build speed by only compiling a single file, and performance by
+// allowing the optimizer to inline across separate object files (note that even
+// when rust is built with LTO, unless the steps are taken to allow cross-lang
+// LTO (tricky), the C/C++ code won't be LTOed).
+#include "./third-party/imgui/imgui.cpp"
+#include "./third-party/imgui/imgui_demo.cpp"
+#include "./third-party/imgui/imgui_draw.cpp"
+#include "./third-party/imgui/imgui_widgets.cpp"
+#include "./third-party/cimgui.cpp"
+
+


### PR DESCRIPTION
This should improve build perf (only build one C++ file) and perhaps runtime perf too (c++ functions can be inlined into the cimgui impls)

Also cleans up/improves the build.rs, including compiling with -fno-exceptions (I don't think imgui throws any, but it'd be UB to unwind over rust frames in that manner anyway), and -fno-rtti

I'd like to eventually experiment with -fvisibility=hidden, and only linking against the c stdlib (and not the c++ one) if possible.