### PR TITLE
support winit-0.24

### DIFF
--- a/imgui-examples/Cargo.toml
+++ b/imgui-examples/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dev-dependencies]
 clipboard = "0.5"
-glium = { version = "0.28", default-features = true }
+glium = { version = "0.29", default-features = true }
 image = "0.23"
 imgui = { path = "../imgui" }
 imgui-glium-renderer = { path = "../imgui-glium-renderer" }

--- a/imgui-gfx-examples/Cargo.toml
+++ b/imgui-gfx-examples/Cargo.toml
@@ -18,12 +18,12 @@ default = ["opengl"]
 [dev-dependencies]
 gfx = "0.18"
 gfx_device_gl = "0.16"
-glutin = "0.25"
+glutin = "0.26"
 image = "0.23"
 imgui = { path = "../imgui" }
 imgui-gfx-renderer = { path = "../imgui-gfx-renderer" }
 imgui-winit-support = { path = "../imgui-winit-support" }
-old_school_gfx_glutin_ext = "0.25"
+old_school_gfx_glutin_ext = "0.26"
 
 [target.'cfg(windows)'.dev-dependencies]
 gfx_device_dx11 = "0.8"

--- a/imgui-gfx-examples/examples/support/mod.rs
+++ b/imgui-gfx-examples/examples/support/mod.rs
@@ -4,7 +4,7 @@ use glutin::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     // XXX for easier porting...
-    platform::desktop::EventLoopExtDesktop,
+    platform::run_return::EventLoopExtRunReturn,
     window::WindowBuilder,
 };
 use imgui::{Context, FontConfig, FontGlyphRanges, FontSource, Ui};

--- a/imgui-glium-renderer/Cargo.toml
+++ b/imgui-glium-renderer/Cargo.toml
@@ -10,5 +10,5 @@ license = "MIT/Apache-2.0"
 categories = ["gui", "rendering"]
 
 [dependencies]
-glium = { version = "0.28", default-features = false }
+glium = { version = "0.29", default-features = false }
 imgui = { version = "0.6.0", path = "../imgui", features = ["glium"] }

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -14,7 +14,7 @@ imgui = { version = "0.6.0", path = "../imgui" }
 winit-19 = { version = ">= 0.16, < 0.20", package = "winit", optional = true }
 winit-20 = { version = ">= 0.20, < 0.22", package = "winit", optional = true }
 winit-22 = { version = "0.22", package = "winit", optional = true }
-winit-23 = { version = "0.23", package = "winit", optional = true }
+winit-23 = { version = ">= 0.23, < 0.25", package = "winit", optional = true }
 
 [features]
 default = ["winit-23"]

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 //! The following versions are supported, controlled by the listed feature.
 //!
-//! - The `winit-23` feature uses winit versions compatible with `0.23`. This is
+//! - The `winit-23` feature supports winit versions `0.23` and `0.24`. This is
 //!   on by default, so to use any other version you need to disable this crates
 //!   default features.
 //! - The `winit-22` feature uses winit versions compatible with `0.22`.

--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["/resources"]
 
 [dependencies]
 bitflags = "1.0"
-glium = { version = "0.28", default-features = false, optional = true }
+glium = { version = "0.29", default-features = false, optional = true }
 gfx = { version = "0.18", optional = true }
 imgui-sys = { version = "0.6.0", path = "../imgui-sys" }
 parking_lot = "0.11"


### PR DESCRIPTION
I've checked the breaking changes in winit 0.24, and none of them affect this `imgui-winit-support` crate. Simply allowing the 0.24 version for the `winit-23` feature should be sufficient.

I also have the change ready where there is a separate `winit-24` feature, adjusting the `imgui-winit-support/src/lib.rs` file to take it into account. Let me know if you prefer that approach over this one.