### PR TITLE
Support both glium 0.28 and 0.29

### DIFF
--- a/imgui-glium-renderer/Cargo.toml
+++ b/imgui-glium-renderer/Cargo.toml
@@ -10,5 +10,5 @@ license = "MIT/Apache-2.0"
 categories = ["gui", "rendering"]
 
 [dependencies]
-glium = { version = "0.29", default-features = false }
+glium = { version = ">=0.28, < 0.30", default-features = false }
 imgui = { version = "0.6.0", path = "../imgui", features = ["glium"] }

--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["/resources"]
 
 [dependencies]
 bitflags = "1.0"
-glium = { version = "0.29", default-features = false, optional = true }
+glium = { version = ">= 0.28, < 0.30", default-features = false, optional = true }
 gfx = { version = "0.18", optional = true }
 imgui-sys = { version = "0.6.0", path = "../imgui-sys" }
 parking_lot = "0.11"


### PR DESCRIPTION
As discussed in https://github.com/imgui-rs/imgui-rs/pull/404 : allow both `glium` 0.28 and 0.29.