### PR TITLE
Fix for default cursor on linux with winit-support

### DIFF
--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -285,7 +285,7 @@ struct CursorSettings {
 
 fn to_winit_cursor(cursor: imgui::MouseCursor) -> MouseCursor {
     match cursor {
-        imgui::MouseCursor::Arrow => MouseCursor::Arrow,
+        imgui::MouseCursor::Arrow => MouseCursor::Default,
         imgui::MouseCursor::TextInput => MouseCursor::Text,
         imgui::MouseCursor::ResizeAll => MouseCursor::Move,
         imgui::MouseCursor::ResizeNS => MouseCursor::NsResize,


### PR DESCRIPTION
Changes `to_winit_cursor` to give MouseCursor::Default for Arrow

Resolves [#409](https://github.com/imgui-rs/imgui-rs/issues/409)