### PR TITLE
Refactor WindowDrawList into DrawListMut and fix #413.

### DIFF
--- a/imgui-examples/examples/draw_list.rs
+++ b/imgui-examples/examples/draw_list.rs
@@ -1,0 +1,90 @@
+use imgui::*;
+
+mod support;
+
+// rect is [x, y, w, h]
+fn draw_text_centered(
+    ui: &Ui,
+    draw_list: &DrawListMut,
+    rect: [f32; 4],
+    text: &ImStr,
+    color: [f32; 3],
+) {
+    let text_size = ui.calc_text_size(text, false, 0.0);
+    let cx = (rect[2] - text_size[0]) / 2.0;
+    let cy = (rect[3] - text_size[1]) / 2.0;
+    draw_list.add_text([rect[0] + cx, rect[1] + cy], color, text);
+}
+
+fn main() {
+    let system = support::init(file!());
+    system.main_loop(move |_, ui| {
+        {
+            let bg_draw_list = ui.get_background_draw_list();
+            bg_draw_list
+                .add_circle([150.0, 150.0], 150.0, [1.0, 0.0, 0.0])
+                .thickness(4.0)
+                .build();
+            draw_text_centered(
+                ui,
+                &bg_draw_list,
+                [0.0, 0.0, 300.0, 300.0],
+                im_str!("background draw list"),
+                [0.0, 0.0, 0.0],
+            );
+        }
+
+        {
+            let [w, h] = ui.io().display_size;
+            let fg_draw_list = ui.get_foreground_draw_list();
+            fg_draw_list
+                .add_circle([w - 150.0, h - 150.0], 150.0, [1.0, 0.0, 0.0])
+                .thickness(4.0)
+                .build();
+            draw_text_centered(
+                ui,
+                &fg_draw_list,
+                [w - 300.0, h - 300.0, 300.0, 300.0],
+                im_str!("foreground draw list"),
+                [1.0, 0.0, 0.0],
+            );
+        }
+
+        Window::new(im_str!("Draw list"))
+            .size([300.0, 110.0], Condition::FirstUseEver)
+            .scroll_bar(false)
+            .build(ui, || {
+                ui.button(im_str!("random button"), [0.0, 0.0]);
+                let draw_list = ui.get_window_draw_list();
+                let o = ui.cursor_screen_pos();
+                let ws = ui.content_region_avail();
+                draw_list
+                    .add_circle([o[0] + 10.0, o[1] + 10.0], 5.0, [1.0, 0.0, 0.0])
+                    .thickness(4.0)
+                    .build();
+                draw_list
+                    .add_circle([o[0] + ws[0] - 10.0, o[1] + 10.0], 5.0, [0.0, 1.0, 0.0])
+                    .thickness(4.0)
+                    .build();
+                draw_list
+                    .add_circle(
+                        [o[0] + ws[0] - 10.0, o[1] + ws[1] - 10.0],
+                        5.0,
+                        [0.0, 0.0, 1.0],
+                    )
+                    .thickness(4.0)
+                    .build();
+                draw_list
+                    .add_circle([o[0] + 10.0, o[1] + ws[1] - 10.0], 5.0, [1.0, 1.0, 0.0])
+                    .thickness(4.0)
+                    .build();
+                draw_text_centered(
+                    ui,
+                    &draw_list,
+                    [o[0], o[1], ws[0], ws[1]],
+                    im_str!("window draw list"),
+                    [1.0, 1.0, 1.0],
+                );
+            });
+    });
+}

--- a/imgui/src/lib.rs
+++ b/imgui/src/lib.rs
@@ -10,6 +10,7 @@ use std::thread;
 
 pub use self::clipboard::*;
 pub use self::context::*;
+pub use self::draw_list::{ChannelsSplit, DrawListMut, ImColor};
 pub use self::fonts::atlas::*;
 pub use self::fonts::font::*;
 pub use self::fonts::glyph::*;
@@ -45,12 +46,12 @@ pub use self::widget::tab::*;
 pub use self::widget::tree::*;
 pub use self::window::child_window::*;
 pub use self::window::*;
-pub use self::window_draw_list::{ChannelsSplit, ImColor, WindowDrawList};
 use internal::RawCast;
 
 mod clipboard;
 mod columns;
 mod context;
+mod draw_list;
 mod fonts;
 mod input;
 mod input_widget;
@@ -70,7 +71,6 @@ mod test;
 mod utils;
 mod widget;
 mod window;
-mod window_draw_list;
 
 /// Returns the underlying Dear ImGui library version
 pub fn dear_imgui_version() -> &'static str {
@@ -468,7 +468,7 @@ impl<'ui> Ui<'ui> {
     /// }
     /// ```
     ///
-    /// This function will panic if several instances of [`WindowDrawList`]
+    /// This function will panic if several instances of [`DrawListMut`]
     /// coexist. Before a new instance is got, a previous instance should be
     /// dropped.
     ///
@@ -483,13 +483,18 @@ impl<'ui> Ui<'ui> {
     /// }
     /// ```
     #[must_use]
-    pub fn get_window_draw_list(&'ui self) -> WindowDrawList<'ui> {
-        WindowDrawList::new(self)
+    pub fn get_window_draw_list(&'ui self) -> DrawListMut<'ui> {
+        DrawListMut::window(self)
     }
 
     #[must_use]
-    pub fn get_background_draw_list(&'ui self) -> WindowDrawList<'ui> {
-        WindowDrawList::new(self).background()
+    pub fn get_background_draw_list(&'ui self) -> DrawListMut<'ui> {
+        DrawListMut::background(self)
+    }
+
+    #[must_use]
+    pub fn get_foreground_draw_list(&'ui self) -> DrawListMut<'ui> {
+        DrawListMut::foreground(self)
     }
 }
 


### PR DESCRIPTION
- Rename WindowDrawList -> DrawListMut. It's not about window draw lists, but
  about background/foreground draw lists as well. The naming was not an easy
  choice, but seems like in rust it's a common convention to add a Mut suffix for
  mutable entities. Imgui-rs already has DrawList and it acts as an immutable
  reference type for rendering implementations to consume. Hence the name
  DrawListMut, which becomes a mutable reference to draw list with methods
  to modify it.
- Add Ui::get_foreground_draw_list(). Same as Ui::get_background_draw_list()
  but for foreground.
- Add draw_list example which shows the use of all three draw lists
  (window, bg, fg).