### PR TITLE
Add Listclipper wrapper

### DIFF
--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -1277,12 +1277,12 @@ fn show_app_log(ui: &Ui, app_log: &mut Vec<String>) {
             ChildWindow::new("logwindow")
                 .flags(WindowFlags::HORIZONTAL_SCROLLBAR)
                 .build(ui, || {
-                    let mut clipper = ListClipper::new()
-                        .items_count(app_log.len() as i32)
-                        .begin(ui);
-                    while clipper.step() {
-                        for line in clipper.display_start()..clipper.display_end() {
-                            ui.text(&app_log[line as usize]);
+                    if !app_log.is_empty() {
+                        let mut clipper = ListClipper::new(app_log.len() as i32).begin(ui);
+                        while clipper.step() {
+                            for line in clipper.display_start()..clipper.display_end() {
+                                ui.text(&app_log[line as usize]);
+                            }
                         }
                     }
                     if ui.scroll_y() >= ui.scroll_max_y() {

--- a/imgui/src/lib.rs
+++ b/imgui/src/lib.rs
@@ -23,6 +23,7 @@ pub use self::input_widget::{
 pub use self::io::*;
 pub use self::layout::*;
 pub use self::legacy::*;
+pub use self::list_clipper::ListClipper;
 pub use self::plothistogram::PlotHistogram;
 pub use self::plotlines::PlotLines;
 pub use self::popup_modal::PopupModal;
@@ -58,6 +59,7 @@ pub mod internal;
 mod io;
 mod layout;
 mod legacy;
+mod list_clipper;
 mod plothistogram;
 mod plotlines;
 mod popup_modal;

--- a/imgui/src/list_clipper.rs
+++ b/imgui/src/list_clipper.rs
@@ -1,0 +1,82 @@
+use std::marker::PhantomData;
+use std::thread;
+
+use crate::sys;
+use crate::Ui;
+
+pub struct ListClipper {
+    items_count: i32,
+    items_height: f32,
+}
+
+impl ListClipper {
+    pub fn new() -> Self {
+        ListClipper {
+            items_count: -1,
+            items_height: -1.0,
+        }
+    }
+
+    pub fn items_count(mut self, items_count: i32) -> Self {
+        self.items_count = items_count;
+        self
+    }
+
+    pub fn items_height(mut self, items_height: f32) -> Self {
+        self.items_height = items_height;
+        self
+    }
+
+    pub fn begin<'ui>(self, ui: &Ui<'ui>) -> ListClipperToken<'ui> {
+        let list_clipper = unsafe {
+            let list_clipper = sys::ImGuiListClipper_ImGuiListClipper();
+            sys::ImGuiListClipper_Begin(list_clipper, self.items_count, self.items_height);
+            list_clipper
+        };
+        ListClipperToken::new(ui, list_clipper)
+    }
+}
+
+pub struct ListClipperToken<'ui> {
+    list_clipper: *mut sys::ImGuiListClipper,
+    _phantom: PhantomData<&'ui Ui<'ui>>,
+}
+
+impl<'ui> ListClipperToken<'ui> {
+    fn new(_: &Ui<'ui>, list_clipper: *mut sys::ImGuiListClipper) -> Self {
+        Self {
+            list_clipper,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn step(&mut self) -> bool {
+        unsafe { sys::ImGuiListClipper_Step(self.list_clipper) }
+    }
+
+    pub fn end(&mut self) {
+        unsafe {
+            sys::ImGuiListClipper_End(self.list_clipper);
+        }
+    }
+
+    pub fn display_start(&self) -> i32 {
+        unsafe { (*self.list_clipper).DisplayStart }
+    }
+
+    pub fn display_end(&self) -> i32 {
+        unsafe { (*self.list_clipper).DisplayEnd }
+    }
+}
+
+impl<'ui> Drop for ListClipperToken<'ui> {
+    fn drop(&mut self) {
+        if !self.step() {
+            unsafe {
+                sys::ImGuiListClipper_destroy(self.list_clipper);
+            };
+        } else if !thread::panicking() {
+            panic!("step() was not called until it returned false");
+        }
+    }
+}

--- a/imgui/src/list_clipper.rs
+++ b/imgui/src/list_clipper.rs
@@ -10,16 +10,11 @@ pub struct ListClipper {
 }
 
 impl ListClipper {
-    pub fn new() -> Self {
+    pub fn new(items_count: i32) -> Self {
         ListClipper {
-            items_count: -1,
+            items_count,
             items_height: -1.0,
         }
-    }
-
-    pub fn items_count(mut self, items_count: i32) -> Self {
-        self.items_count = items_count;
-        self
     }
 
     pub fn items_height(mut self, items_height: f32) -> Self {
@@ -76,7 +71,7 @@ impl<'ui> Drop for ListClipperToken<'ui> {
                 sys::ImGuiListClipper_destroy(self.list_clipper);
             };
         } else if !thread::panicking() {
-            panic!("step() was not called until it returned false");
+            panic!("Forgot to call End(), or to Step() until false?");
         }
     }
 }


### PR DESCRIPTION
Adds a wrapper around [ImGuiListClipper](https://github.com/ocornut/imgui/blob/fa963b9aafde7f05b1d32d42e3d2b084c9685e31/imgui.h#L2100) api.

The "log" example of the demo window is using ListClipper so it felt apropriate to add that as well, or at least enough of it to show how ListClipper works.
