### PR TITLE
ImColor changes and improvements:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,7 @@ jobs:
       - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22
       - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23
       - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-24
+      # Run unreasonably slow tests under release, but only the crates that have
+      # them, and don't bother doing this on most platforms.
+      - run: cargo test -p imgui --release -- --ignored
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -22,6 +22,9 @@
     - `Ui::get_background_draw_list()` has been fixed when used outside of a window context, and now has an example.
     - `Ui::get_foreground_draw_list()` has been added, analogous to `Ui::get_background_draw_list()`.
 
+- `ImColor` (which is a wrapper around `u32`) has been renamed to `ImColor32` in order to avoid confusion with the `ImColor` type from the Dear ImGui C++ code (which is a wrapper around `ImVec4`). In the future an `ImColor` type which maps more closely to the C++ one will be added.
+    - Additionally, a number of constructor and accessor methods have been added to it `ImColor`, which are `const fn` where possible.
+
 ## [0.6.1] - 2020-12-16
 
 - Support for winit 0.24.x

--- a/imgui/src/color.rs
+++ b/imgui/src/color.rs
@@ -1,0 +1,370 @@
+/// Wraps u32 that represents a packed RGBA color. Mostly used by types in the
+/// low level custom drawing API, such as [`DrawListMut`](crate::DrawListMut).
+///
+/// The bits of a color are in "`0xAABBGGRR`" format (e.g. RGBA as little endian
+/// bytes). For clarity: we don't support an equivalent to the
+/// `IMGUI_USE_BGRA_PACKED_COLOR` define.
+///
+/// This used to be named `ImColor32`, but was renamed to avoid confusion with
+/// the type with that name in the C++ API (which uses 32 bits per channel).
+///
+/// While it doesn't provide methods to access the fields, they can be accessed
+/// via the `Deref`/`DerefMut` impls it provides targeting
+/// [`imgui::color::ImColor32Fields`](crate::color::ImColor32Fields), which has
+/// no other meaningful uses.
+///
+/// # Example
+/// ```
+/// let mut c = imgui::ImColor32::from_rgba(0x80, 0xc0, 0x40, 0xff);
+/// assert_eq!(c.to_bits(), 0xff_40_c0_80); // Note: 0xAA_BB_GG_RR
+/// // Field access
+/// assert_eq!(c.r, 0x80);
+/// assert_eq!(c.g, 0xc0);
+/// assert_eq!(c.b, 0x40);
+/// assert_eq!(c.a, 0xff);
+/// c.b = 0xbb;
+/// assert_eq!(c.to_bits(), 0xff_bb_c0_80);
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct ImColor32(u32); // TBH maybe the wrapped field should be `pub`.
+
+impl ImColor32 {
+    /// Convenience constant for solid black.
+    pub const BLACK: Self = Self(0xff_00_00_00);
+
+    /// Convenience constant for solid white.
+    pub const WHITE: Self = Self(0xff_ff_ff_ff);
+
+    /// Convenience constant for full transparency.
+    pub const TRANSPARENT: Self = Self(0);
+
+    /// Construct a color from 4 single-byte `u8` channel values, which should
+    /// be between 0 and 255.
+    #[inline]
+    pub const fn from_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self(
+            ((a as u32) << Self::A_SHIFT)
+                | ((r as u32) << Self::R_SHIFT)
+                | ((g as u32) << Self::G_SHIFT)
+                | ((b as u32) << Self::B_SHIFT),
+        )
+    }
+
+    /// Construct a fully opaque color from 3 single-byte `u8` channel values.
+    /// Same as [`Self::from_rgba`] with a == 255
+    #[inline]
+    pub const fn from_rgb(r: u8, g: u8, b: u8) -> Self {
+        Self::from_rgba(r, g, b, 0xff)
+    }
+
+    /// Construct a fully opaque color from 4 `f32` channel values in the range
+    /// `0.0 ..= 1.0` (values outside this range are clamped to it, with NaN
+    /// mapped to 0.0).
+    ///
+    /// Note: No alpha premultiplication is done, so your input should be have
+    /// premultiplied alpha if needed.
+    #[inline]
+    // not const fn because no float math in const eval yet 😩
+    pub fn from_rgba_f32s(r: f32, g: f32, b: f32, a: f32) -> Self {
+        Self::from_rgba(
+            f32_to_u8_sat(r),
+            f32_to_u8_sat(g),
+            f32_to_u8_sat(b),
+            f32_to_u8_sat(a),
+        )
+    }
+
+    /// Return the channels as an array of f32 in `[r, g, b, a]` order.
+    #[inline]
+    pub fn to_rgba_f32s(self) -> [f32; 4] {
+        let &ImColor32Fields { r, g, b, a } = &*self;
+        [
+            u8_to_f32_sat(r),
+            u8_to_f32_sat(g),
+            u8_to_f32_sat(b),
+            u8_to_f32_sat(a),
+        ]
+    }
+
+    /// Return the channels as an array of u8 in `[r, g, b, a]` order.
+    #[inline]
+    pub fn to_rgba(self) -> [u8; 4] {
+        let &ImColor32Fields { r, g, b, a } = &*self;
+        [r, g, b, a]
+    }
+
+    /// Equivalent to [`Self::from_rgba_f32s`], but with an alpha of 1.0 (e.g.
+    /// opaque).
+    #[inline]
+    pub fn from_rgb_f32s(r: f32, g: f32, b: f32) -> Self {
+        Self::from_rgba(f32_to_u8_sat(r), f32_to_u8_sat(g), f32_to_u8_sat(b), 0xff)
+    }
+
+    /// Construct a color from the `u32` that makes up the bits in `0xAABBGGRR`
+    /// format.
+    ///
+    /// Specifically, this takes the RGBA values as a little-endian u32 with 8
+    /// bits per channel.
+    ///
+    /// Note that [`ImColor32::from_rgba`] may be a bit easier to use.
+    #[inline]
+    pub const fn from_bits(u: u32) -> Self {
+        Self(u)
+    }
+
+    /// Return the bits of the color as a u32. These are in "`0xAABBGGRR`" format, that
+    /// is, little-endian RGBA with 8 bits per channel.
+    #[inline]
+    pub const fn to_bits(self) -> u32 {
+        self.0
+    }
+
+    // These are public in C++ ImGui, should they be public here?
+    /// The number of bits to shift the byte of the red channel. Always 0.
+    const R_SHIFT: u32 = 0;
+    /// The number of bits to shift the byte of the green channel. Always 8.
+    const G_SHIFT: u32 = 8;
+    /// The number of bits to shift the byte of the blue channel. Always 16.
+    const B_SHIFT: u32 = 16;
+    /// The number of bits to shift the byte of the alpha channel. Always 24.
+    const A_SHIFT: u32 = 24;
+}
+
+impl Default for ImColor32 {
+    #[inline]
+    fn default() -> Self {
+        Self::TRANSPARENT
+    }
+}
+
+impl std::fmt::Debug for ImColor32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImColor32")
+            .field("r", &self.r)
+            .field("g", &self.g)
+            .field("b", &self.b)
+            .field("a", &self.a)
+            .finish()
+    }
+}
+
+/// A struct that exists to allow field access to [`ImColor32`]. It essentially
+/// exists to be a `Deref`/`DerefMut` target and provide field access.
+///
+/// Note that while this is repr(C), be aware that on big-endian machines
+/// (`cfg(target_endian = "big")`) the order of the fields is reversed, as this
+/// is a view into a packed u32.
+///
+/// Generally should not be used, except as the target of the `Deref` impl of
+/// [`ImColor32`].
+#[derive(Copy, Clone, Debug)]
+#[repr(C, align(4))]
+// Should this be #[non_exhaustive] to discourage direct use?
+#[rustfmt::skip]
+pub struct ImColor32Fields {
+    #[cfg(target_endian = "little")] pub r: u8,
+    #[cfg(target_endian = "little")] pub g: u8,
+    #[cfg(target_endian = "little")] pub b: u8,
+    #[cfg(target_endian = "little")] pub a: u8,
+    // TODO(someday): i guess we should have BE tests, but for now I verified
+    // this locally.
+    #[cfg(target_endian = "big")] pub a: u8,
+    #[cfg(target_endian = "big")] pub b: u8,
+    #[cfg(target_endian = "big")] pub g: u8,
+    #[cfg(target_endian = "big")] pub r: u8,
+}
+
+// We assume that big and little are the only endiannesses, and that exactly one
+// is set. That is, PDP endian is not in use, and the we aren't using a
+// completely broken custom target json or something.
+#[cfg(any(
+    all(target_endian = "little", target_endian = "big"),
+    all(not(target_endian = "little"), not(target_endian = "big")),
+))]
+compile_error!("`cfg(target_endian = \"little\")` must be `cfg(not(target_endian = \"big\")`");
+
+// static assert sizes match
+const _: [(); core::mem::size_of::<ImColor32>()] = [(); core::mem::size_of::<ImColor32Fields>()];
+const _: [(); core::mem::align_of::<ImColor32>()] = [(); core::mem::align_of::<ImColor32Fields>()];
+
+impl core::ops::Deref for ImColor32 {
+    type Target = ImColor32Fields;
+    #[inline]
+    fn deref(&self) -> &ImColor32Fields {
+        // Safety: we statically assert the size and align match, and neither
+        // type has any special invariants.
+        unsafe { &*(self as *const Self as *const ImColor32Fields) }
+    }
+}
+impl core::ops::DerefMut for ImColor32 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut ImColor32Fields {
+        // Safety: we statically assert the size and align match, and neither
+        // type has any special invariants.
+        unsafe { &mut *(self as *mut Self as *mut ImColor32Fields) }
+    }
+}
+
+impl From<ImColor32> for u32 {
+    #[inline]
+    fn from(color: ImColor32) -> Self {
+        color.0
+    }
+}
+
+impl From<u32> for ImColor32 {
+    #[inline]
+    fn from(color: u32) -> Self {
+        ImColor32(color)
+    }
+}
+
+impl From<[f32; 4]> for ImColor32 {
+    #[inline]
+    fn from(v: [f32; 4]) -> Self {
+        Self::from_rgba_f32s(v[0], v[1], v[2], v[3])
+    }
+}
+
+impl From<(f32, f32, f32, f32)> for ImColor32 {
+    #[inline]
+    fn from(v: (f32, f32, f32, f32)) -> Self {
+        Self::from_rgba_f32s(v.0, v.1, v.2, v.3)
+    }
+}
+
+impl From<[f32; 3]> for ImColor32 {
+    #[inline]
+    fn from(v: [f32; 3]) -> Self {
+        Self::from_rgb_f32s(v[0], v[1], v[2])
+    }
+}
+
+impl From<(f32, f32, f32)> for ImColor32 {
+    fn from(v: (f32, f32, f32)) -> Self {
+        Self::from_rgb_f32s(v.0, v.1, v.2)
+    }
+}
+
+impl From<ImColor32> for [f32; 4] {
+    #[inline]
+    fn from(v: ImColor32) -> Self {
+        v.to_rgba_f32s()
+    }
+}
+impl From<ImColor32> for (f32, f32, f32, f32) {
+    #[inline]
+    fn from(color: ImColor32) -> Self {
+        let [r, g, b, a]: [f32; 4] = color.into();
+        (r, g, b, a)
+    }
+}
+
+// These utilities might be worth making `pub` as free functions in
+// `crate::color` so user code can ensure their numeric handling is
+// consistent...
+
+/// Clamp `v` to between 0.0 and 1.0, always returning a value between those.
+///
+/// Never returns NaN, or -0.0 — instead returns +0.0 for these (We differ from
+/// C++ Dear ImGUI here which probably is just ignoring values like these).
+#[inline]
+pub(crate) fn saturate(v: f32) -> f32 {
+    // Note: written strangely so that special values (NaN/-0.0) are handled
+    // automatically with no extra checks.
+    if v > 0.0 {
+        if v <= 1.0 {
+            v
+        } else {
+            1.0
+        }
+    } else {
+        0.0
+    }
+}
+
+/// Quantize a value in `0.0..=1.0` to `0..=u8::MAX`. Input outside 0.0..=1.0 is
+/// clamped. Uses a bias of 0.5, because we assume centered quantization is used
+/// (and because C++ imgui does it too). See:
+/// - https://github.com/ocornut/imgui/blob/e28b51786eae60f32c18214658c15952639085a2/imgui_internal.h#L218
+/// - https://cbloomrants.blogspot.com/2020/09/topics-in-quantization-for-games.html
+///   (see `quantize_centered`)
+#[inline]
+pub(crate) fn f32_to_u8_sat(f: f32) -> u8 {
+    let f = saturate(f) * 255.0 + 0.5;
+    // Safety: `saturate`'s result is between 0.0 and 1.0 (never NaN even for
+    // NaN input), and so for all inputs, `saturate(f) * 255.0 + 0.5` is inside
+    // `0.5 ..= 255.5`.
+    //
+    // This is verified for all f32 in `test_f32_to_u8_sat_exhaustive`.
+    //
+    // Also note that LLVM doesn't bother trying to figure this out so the
+    // unchecked does actually help. (That said, this likely doesn't matter
+    // for imgui-rs, but I had this code in another project and it felt
+    // silly to needlessly pessimize it).
+    unsafe { f.to_int_unchecked() }
+}
+
+/// Opposite of `f32_to_u8_sat`. Since we assume centered quantization, this is
+/// equivalent to dividing by 255 (or, multiplying by 1.0/255.0)
+#[inline]
+pub(crate) fn u8_to_f32_sat(u: u8) -> f32 {
+    (u as f32) * (1.0 / 255.0)
+}
+
+#[test]
+fn check_sat() {
+    assert_eq!(saturate(1.0), 1.0);
+    assert_eq!(saturate(0.5), 0.5);
+    assert_eq!(saturate(0.0), 0.0);
+    assert_eq!(saturate(-1.0), 0.0);
+    // next float from 1.0
+    assert_eq!(saturate(1.0 + f32::EPSILON), 1.0);
+    // prev float from 0.0 (Well, from -0.0)
+    assert_eq!(saturate(-f32::MIN_POSITIVE), 0.0);
+    // some NaNs.
+    assert_eq!(saturate(f32::NAN), 0.0);
+    assert_eq!(saturate(-f32::NAN), 0.0);
+    // neg zero comes through as +0
+    assert_eq!(saturate(-0.0).to_bits(), 0.0f32.to_bits());
+}
+
+// Check that the unsafe in `f32_to_u8_sat` is fine for all f32 (and that the
+// comments I wrote about `saturate` are actually true). This is way too slow in
+// debug mode, but finishes in ~15s on my machine for release (just this test).
+// This is tested in CI, but will only run if invoked manually with something
+// like: `cargo test -p imgui --release -- --ignored`.
+#[test]
+#[ignore]
+fn test_f32_to_u8_sat_exhaustive() {
+    for f in (0..=u32::MAX).map(f32::from_bits) {
+        let v = saturate(f);
+        assert!(
+            (0.0..=1.0).contains(&v) && (v.to_bits() != (-0.0f32).to_bits()),
+            "sat({} [e.g. {:#x}]) => {} [e.g {:#x}]",
+            f,
+            f.to_bits(),
+            v,
+            v.to_bits(),
+        );
+        let sat = v * 255.0 + 0.5;
+        // Note: This checks what's required by is the safety predicate for
+        // `f32::to_int_unchecked`:
+        // https://doc.rust-lang.org/std/primitive.f32.html#method.to_int_unchecked
+        assert!(
+            sat.trunc() >= 0.0 && sat.trunc() <= (u8::MAX as f32) && sat.is_finite(),
+            "f32_to_u8_sat({} [e.g. {:#x}]) would be UB!",
+            f,
+            f.to_bits(),
+        );
+    }
+}
+
+#[test]
+fn test_saturate_all_u8s() {
+    for u in 0..=u8::MAX {
+        let v = f32_to_u8_sat(u8_to_f32_sat(u));
+        assert_eq!(u, v);
+    }
+}

--- a/imgui/src/draw_list.rs
+++ b/imgui/src/draw_list.rs
@@ -1,55 +1,10 @@
-use sys::{ImDrawList, ImU32};
+use crate::ImColor32;
+use sys::ImDrawList;
 
 use super::Ui;
 use crate::legacy::ImDrawCornerFlags;
 
 use std::marker::PhantomData;
-
-/// Wrap `ImU32` (a type typically used by ImGui to store packed colors)
-/// This type is used to represent the color of drawing primitives in ImGui's
-/// custom drawing API.
-///
-/// The type implements `From<ImU32>`, `From<ImVec4>`, `From<[f32; 4]>`,
-/// `From<[f32; 3]>`, `From<(f32, f32, f32, f32)>` and `From<(f32, f32, f32)>`
-/// for convenience. If alpha is not provided, it is assumed to be 1.0 (255).
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct ImColor(ImU32);
-
-impl From<ImColor> for ImU32 {
-    fn from(color: ImColor) -> Self {
-        color.0
-    }
-}
-
-impl From<ImU32> for ImColor {
-    fn from(color: ImU32) -> Self {
-        ImColor(color)
-    }
-}
-
-impl From<[f32; 4]> for ImColor {
-    fn from(v: [f32; 4]) -> Self {
-        ImColor(unsafe { sys::igColorConvertFloat4ToU32(v.into()) })
-    }
-}
-
-impl From<(f32, f32, f32, f32)> for ImColor {
-    fn from(v: (f32, f32, f32, f32)) -> Self {
-        ImColor(unsafe { sys::igColorConvertFloat4ToU32(v.into()) })
-    }
-}
-
-impl From<[f32; 3]> for ImColor {
-    fn from(v: [f32; 3]) -> Self {
-        [v[0], v[1], v[2], 1.0].into()
-    }
-}
-
-impl From<(f32, f32, f32)> for ImColor {
-    fn from(v: (f32, f32, f32)) -> Self {
-        [v.0, v.1, v.2, 1.0].into()
-    }
-}
 
 /// Object implementing the custom draw API.
 ///
@@ -167,7 +122,7 @@ impl<'ui> DrawListMut<'ui> {
     /// Returns a line from point `p1` to `p2` with color `c`.
     pub fn add_line<C>(&'ui self, p1: [f32; 2], p2: [f32; 2], c: C) -> Line<'ui>
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         Line::new(self, p1, p2, c)
     }
@@ -176,7 +131,7 @@ impl<'ui> DrawListMut<'ui> {
     /// and lower-right corner is at point `p2`, with color `c`.
     pub fn add_rect<C>(&'ui self, p1: [f32; 2], p2: [f32; 2], c: C) -> Rect<'ui>
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         Rect::new(self, p1, p2, c)
     }
@@ -195,10 +150,10 @@ impl<'ui> DrawListMut<'ui> {
         col_bot_right: C3,
         col_bot_left: C4,
     ) where
-        C1: Into<ImColor>,
-        C2: Into<ImColor>,
-        C3: Into<ImColor>,
-        C4: Into<ImColor>,
+        C1: Into<ImColor32>,
+        C2: Into<ImColor32>,
+        C3: Into<ImColor32>,
+        C4: Into<ImColor32>,
     {
         unsafe {
             sys::ImDrawList_AddRectFilledMultiColor(
@@ -223,7 +178,7 @@ impl<'ui> DrawListMut<'ui> {
         c: C,
     ) -> Triangle<'ui>
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         Triangle::new(self, p1, p2, p3, c)
     }
@@ -231,7 +186,7 @@ impl<'ui> DrawListMut<'ui> {
     /// Returns a circle with the given `center`, `radius` and `color`.
     pub fn add_circle<C>(&'ui self, center: [f32; 2], radius: f32, color: C) -> Circle<'ui>
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         Circle::new(self, center, radius, color)
     }
@@ -239,7 +194,7 @@ impl<'ui> DrawListMut<'ui> {
     /// Draw a text whose upper-left corner is at point `pos`.
     pub fn add_text<C, T>(&self, pos: [f32; 2], col: C, text: T)
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
         T: AsRef<str>,
     {
         use std::os::raw::c_char;
@@ -263,7 +218,7 @@ impl<'ui> DrawListMut<'ui> {
         color: C,
     ) -> BezierCurve<'ui>
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         BezierCurve::new(self, pos0, cp0, cp1, pos1, color)
     }
@@ -301,7 +256,7 @@ impl<'ui> DrawListMut<'ui> {
 pub struct Line<'ui> {
     p1: [f32; 2],
     p2: [f32; 2],
-    color: ImColor,
+    color: ImColor32,
     thickness: f32,
     draw_list: &'ui DrawListMut<'ui>,
 }
@@ -309,7 +264,7 @@ pub struct Line<'ui> {
 impl<'ui> Line<'ui> {
     fn new<C>(draw_list: &'ui DrawListMut, p1: [f32; 2], p2: [f32; 2], c: C) -> Self
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         Self {
             p1,
@@ -345,7 +300,7 @@ impl<'ui> Line<'ui> {
 pub struct Rect<'ui> {
     p1: [f32; 2],
     p2: [f32; 2],
-    color: ImColor,
+    color: ImColor32,
     rounding: f32,
     flags: ImDrawCornerFlags,
     thickness: f32,
@@ -356,7 +311,7 @@ pub struct Rect<'ui> {
 impl<'ui> Rect<'ui> {
     fn new<C>(draw_list: &'ui DrawListMut, p1: [f32; 2], p2: [f32; 2], c: C) -> Self
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         Self {
             p1,
@@ -448,7 +403,7 @@ pub struct Triangle<'ui> {
     p1: [f32; 2],
     p2: [f32; 2],
     p3: [f32; 2],
-    color: ImColor,
+    color: ImColor32,
     thickness: f32,
     filled: bool,
     draw_list: &'ui DrawListMut<'ui>,
@@ -457,7 +412,7 @@ pub struct Triangle<'ui> {
 impl<'ui> Triangle<'ui> {
     fn new<C>(draw_list: &'ui DrawListMut, p1: [f32; 2], p2: [f32; 2], p3: [f32; 2], c: C) -> Self
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         Self {
             p1,
@@ -514,7 +469,7 @@ impl<'ui> Triangle<'ui> {
 pub struct Circle<'ui> {
     center: [f32; 2],
     radius: f32,
-    color: ImColor,
+    color: ImColor32,
     num_segments: u32,
     thickness: f32,
     filled: bool,
@@ -524,7 +479,7 @@ pub struct Circle<'ui> {
 impl<'ui> Circle<'ui> {
     pub fn new<C>(draw_list: &'ui DrawListMut, center: [f32; 2], radius: f32, color: C) -> Self
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         Self {
             center,
@@ -590,7 +545,7 @@ pub struct BezierCurve<'ui> {
     cp0: [f32; 2],
     pos1: [f32; 2],
     cp1: [f32; 2],
-    color: ImColor,
+    color: ImColor32,
     thickness: f32,
     /// If num_segments is not set, the bezier curve is auto-tessalated.
     num_segments: Option<u32>,
@@ -607,7 +562,7 @@ impl<'ui> BezierCurve<'ui> {
         c: C,
     ) -> Self
     where
-        C: Into<ImColor>,
+        C: Into<ImColor32>,
     {
         Self {
             pos0,

--- a/imgui/src/lib.rs
+++ b/imgui/src/lib.rs
@@ -9,8 +9,9 @@ use std::str;
 use std::thread;
 
 pub use self::clipboard::*;
+pub use self::color::ImColor32;
 pub use self::context::*;
-pub use self::draw_list::{ChannelsSplit, DrawListMut, ImColor};
+pub use self::draw_list::{ChannelsSplit, DrawListMut};
 pub use self::fonts::atlas::*;
 pub use self::fonts::font::*;
 pub use self::fonts::glyph::*;
@@ -50,6 +51,7 @@ pub use self::window::*;
 use internal::RawCast;
 
 mod clipboard;
+pub mod color;
 mod columns;
 mod context;
 mod draw_list;

--- a/imgui/src/utils.rs
+++ b/imgui/src/utils.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::clippy::float_cmp)]
 use bitflags::bitflags;
 
 use crate::input::mouse::MouseButton;


### PR DESCRIPTION
This ended up being a bit more than I had bargained for, mostly because I, unfortunately, have ✨color opinions✨.

Concretely:

1. Renamed to `ImColor32` to avoid confusion with `ImColor` from the C++ code: https://github.com/ocornut/imgui/blob/9499afdf/imgui.h#L2180.

    - I think `ImCol32` is actually more consistent with C++ Dear ImGui's naming of this (e.g. `IM_COL32(r, g, b, a)` or `IM_COL32_FOO` macros, ...), so maybe that would have been better.

    - Eventually I'd probably like to add something mirroring the actual `ImColor`, and probably also a few things to make it easier to do the "right" thing WRT color with imgui (e.g. minimal utilities for premultiplied alpha, proper sRGB). That said, in practice, `imgui` stuff isn't really user facing, so this probably doesn't matter that much.

    - I didn't do this since I'd like to give it more thought, and I'd rather not both rename a type, and add a new type with the old name in one go.

2. Now supports construction and access from `const fn` where possible.
    - Still impossible for the `f32` APIs :(

3. Now supports `.r`/`.g`/`.b`/.a` field access (read and write), by way of a new type `imgui::color::ImColor32Fields`, which essentially exists just to serve this purpose.
    - This is a bit cludgey, but lets us provide the ability for reading and writing `r/g/b/a` values without adding many `fn get_r(self) -> u8` and `fn set_r(&mut self, r: u8);` style functions.

4. No longer requires FFI calls to construct from RGB floats.

    - This gives much more freedom to the optimizer, as external calls are impenetrable optimization barriers (It has to pessimistically assume that they read/write to all globally accessable memory, and must be called in the exact order that is listed).

    - Also, it allows inlining these calls, and avoid computing the same value twice (if the args are the same).

    - Also improves usage from IDEs, debuggers, etc, and avoids a rare possibility of UB if NaN was passed in (however, this almost certainly could only cause problems if cross-lang LTO was used, which I believe we don't support).

    - This code is more complex than needed, but was taken from another project of mine (functions were renamed to line up with imgui's names), and has good (literally exhaustive) test coverage.

    - Unfortunately, float arithmetic in const fn is still not allowed, so for now these aren't usable `const fn`.

5. Added utility constants to mirror the `IM_COL32_WHITE`, `IM_COL32_BLACK`, `IM_COL32_BLACK_TRANS` constants.

That's most of it anyway. I also added a few more `From` impls to mirror new functionality, and improved docs all around.

---

@sanbox-irl I'm open to using different names for the `ImColor32` construction functions if you want. I'll probably merge this after it's green (e.g. before you see it) as still have some energy left to bang out a bunch more `const fn` additions.

But feel free to file an issue/PR if you can think of a better naming convention here.