### PR TITLE
Fix some (nightly-only) clippy lints where they make sense

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -38,6 +38,9 @@
 
 - The `io.config_windows_memory_compact_timer` flag has been renamed to `io.config_memory_compact_timer`. This follows the similar rename in the C++ ImGui, and was done because it no longer only applies to window memory usage.
 
+- The variants of `ColorEditInputMode` and `ColorEditDisplayMode` have been renamed to be CamelCase instead of upper case (e.g. `ColorEditFooMode::RGB` => `ColorEditFooMode::Rgb`).
+    - However, this change is probably not breaking (in practice if not in theory) because const aliases using the old names are provided.
+
 ## [0.6.1] - 2020-12-16
 
 - Support for winit 0.24.x

--- a/imgui/src/input/mouse.rs
+++ b/imgui/src/input/mouse.rs
@@ -60,7 +60,6 @@ pub enum MouseCursor {
     NotAllowed = sys::ImGuiMouseCursor_NotAllowed,
 }
 
-
 impl MouseCursor {
     /// All possible `MouseCursor` varirants
     pub const VARIANTS: [MouseCursor; MouseCursor::COUNT] = [

--- a/imgui/src/input/mouse.rs
+++ b/imgui/src/input/mouse.rs
@@ -36,6 +36,8 @@ fn test_mouse_button_variants() {
 /// Mouse cursor type identifier
 #[repr(i32)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[allow(unknown_lints)] // Fixme: remove once `clippy::upper_case_acronyms` is stable
+#[allow(clippy::upper_case_acronyms)]
 pub enum MouseCursor {
     Arrow = sys::ImGuiMouseCursor_Arrow,
     /// Automatically used when hovering over text inputs, etc.
@@ -57,6 +59,7 @@ pub enum MouseCursor {
     /// Usually a crossed circle.
     NotAllowed = sys::ImGuiMouseCursor_NotAllowed,
 }
+
 
 impl MouseCursor {
     /// All possible `MouseCursor` varirants

--- a/imgui/src/input/mouse.rs
+++ b/imgui/src/input/mouse.rs
@@ -36,8 +36,11 @@ fn test_mouse_button_variants() {
 /// Mouse cursor type identifier
 #[repr(i32)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[allow(unknown_lints)] // Fixme: remove once `clippy::upper_case_acronyms` is stable
-#[allow(clippy::upper_case_acronyms)]
+// TODO: this should just be `#[allow(clippy::upper_case_acronyms)]`, but doing
+// so in a way that works before it stabilizes is a pain (in part because
+// `unknown_clippy_lints` was renamed to unknown_lints). Oh well, it's over a
+// small amount of code.
+#[allow(warnings)]
 pub enum MouseCursor {
     Arrow = sys::ImGuiMouseCursor_Arrow,
     /// Automatically used when hovering over text inputs, etc.

--- a/imgui/src/stacks.rs
+++ b/imgui/src/stacks.rs
@@ -272,7 +272,7 @@ impl<'ui> Ui<'ui> {
     /// the right side)
     pub fn push_item_width(&self, item_width: f32) -> ItemWidthStackToken {
         unsafe { sys::igPushItemWidth(item_width) };
-        ItemWidthStackToken { ctx: self.ctx }
+        ItemWidthStackToken { _ctx: self.ctx }
     }
     /// Sets the width of the next item.
     ///
@@ -298,7 +298,7 @@ impl<'ui> Ui<'ui> {
     /// - `< 0.0`: no wrapping
     pub fn push_text_wrap_pos(&self, wrap_pos_x: f32) -> TextWrapPosStackToken {
         unsafe { sys::igPushTextWrapPos(wrap_pos_x) };
-        TextWrapPosStackToken { ctx: self.ctx }
+        TextWrapPosStackToken { _ctx: self.ctx }
     }
     /// Changes an item flag by pushing a change to the item flag stack.
     ///
@@ -311,7 +311,7 @@ impl<'ui> Ui<'ui> {
         }
         ItemFlagsStackToken {
             discriminant: mem::discriminant(&item_flag),
-            ctx: self.ctx,
+            _ctx: self.ctx,
         }
     }
 }
@@ -325,26 +325,26 @@ pub enum ItemFlag {
 
 /// Tracks a change pushed to the item width stack
 pub struct ItemWidthStackToken {
-    ctx: *const Context,
+    _ctx: *const Context,
 }
 
 impl ItemWidthStackToken {
     /// Pops a change from the item width stack
     pub fn pop(mut self, _: &Ui) {
-        self.ctx = ptr::null();
+        self._ctx = ptr::null();
         unsafe { sys::igPopItemWidth() };
     }
 }
 
 /// Tracks a change pushed to the text wrap position stack
 pub struct TextWrapPosStackToken {
-    ctx: *const Context,
+    _ctx: *const Context,
 }
 
 impl TextWrapPosStackToken {
     /// Pops a change from the text wrap position stack
     pub fn pop(mut self, _: &Ui) {
-        self.ctx = ptr::null();
+        self._ctx = ptr::null();
         unsafe { sys::igPopTextWrapPos() };
     }
 }
@@ -352,13 +352,13 @@ impl TextWrapPosStackToken {
 /// Tracks a change pushed to the item flags stack
 pub struct ItemFlagsStackToken {
     discriminant: mem::Discriminant<ItemFlag>,
-    ctx: *const Context,
+    _ctx: *const Context,
 }
 
 impl ItemFlagsStackToken {
     /// Pops a change from the item flags stack
     pub fn pop(mut self, _: &Ui) {
-        self.ctx = ptr::null();
+        self._ctx = ptr::null();
         const ALLOW_KEYBOARD_FOCUS: ItemFlag = ItemFlag::AllowKeyboardFocus(true);
         const BUTTON_REPEAT: ItemFlag = ItemFlag::ButtonRepeat(true);
 

--- a/imgui/src/widget/color_editors.rs
+++ b/imgui/src/widget/color_editors.rs
@@ -25,12 +25,14 @@ impl<'a> EditableColor<'a> {
 }
 
 impl<'a> From<&'a mut [f32; 3]> for EditableColor<'a> {
+    #[inline]
     fn from(value: &'a mut [f32; 3]) -> EditableColor<'a> {
         EditableColor::Float3(value)
     }
 }
 
 impl<'a> From<&'a mut [f32; 4]> for EditableColor<'a> {
+    #[inline]
     fn from(value: &'a mut [f32; 4]) -> EditableColor<'a> {
         EditableColor::Float4(value)
     }
@@ -40,21 +42,40 @@ impl<'a> From<&'a mut [f32; 4]> for EditableColor<'a> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ColorEditInputMode {
     /// Edit as RGB(A).
-    RGB,
+    Rgb,
     /// Edit as HSV(A).
-    HSV,
+    Hsv,
+}
+
+impl ColorEditInputMode {
+    // Note: Probably no point in deprecating these since they're ~0 maintance burden.
+    /// Edit as RGB(A). Alias for [`Self::Rgb`] for backwards-compatibility.
+    pub const RGB: Self = Self::Rgb;
+    /// Edit as HSV(A). Alias for [`Self::Hsv`] for backwards-compatibility.
+    pub const HSV: Self = Self::Hsv;
 }
 
 /// Color editor display mode.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ColorEditDisplayMode {
     /// Display as RGB(A).
-    RGB,
+    Rgb,
     /// Display as HSV(A).
-    HSV,
-    /// Display as hex (e.g. #AABBCC(DD))
-    HEX,
+    Hsv,
+    /// Display as hex (e.g. `#AABBCC(DD)`)
+    Hex,
 }
+
+impl ColorEditDisplayMode {
+    // Note: Probably no point in deprecating these since they're ~0 maintance burden.
+    /// Display as RGB(A). Alias for [`Self::Rgb`] for backwards-compatibility.
+    pub const RGB: Self = Self::Rgb;
+    /// Display as HSV(A). Alias for [`Self::Hsv`] for backwards-compatibility.
+    pub const HSV: Self = Self::Hsv;
+    /// Display as hex. Alias for [`Self::Hex`] for backwards-compatibility.
+    pub const HEX: Self = Self::Hex;
+}
+
 
 /// Color picker hue/saturation/value editor mode
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/imgui/src/widget/color_editors.rs
+++ b/imgui/src/widget/color_editors.rs
@@ -76,7 +76,6 @@ impl ColorEditDisplayMode {
     pub const HEX: Self = Self::Hex;
 }
 
-
 /// Color picker hue/saturation/value editor mode
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ColorPickerMode {


### PR DESCRIPTION
For upper_case_acronyms, the MouseCursor variants IMO don't help, but the color modes can be renamed in a non-breaking way, and I prefer this pattern anyway.

Kinda annoying to need to allow `unknown_lints`, but it's only in that one decl so whatever.


@sanbox-irl I suspect the changes in stacks.rs will conflict with some of your stuff... Sorry, the yellow squiggles were too much for me (and the lint for it would be `dead_code` which I don't want to `allow()` on a whole module).