### PR TITLE
Oops. Fixed forgotten legacy flags

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Removed legacy `ImGuiDragDropFlags` from `legacy.rs`, which were accidentally not cleared when they were remade in `drag_drop.rs` in v0.7.0.
+
 ## [0.7.0] - 2021-02-04
 
 - Upgrade to [Dear ImGui v1.80](https://github.com/ocornut/imgui/releases/tag/v1.80). (Note that the new table functionality is not yet supported, however)

--- a/imgui/src/legacy.rs
+++ b/imgui/src/legacy.rs
@@ -5,45 +5,6 @@ use std::os::raw::c_int;
 use crate::widget::tree::TreeNodeFlags;
 
 bitflags!(
-    /// Flags for igBeginDragDropSource(), igAcceptDragDropPayload()
-    #[repr(C)]
-    pub struct ImGuiDragDropFlags: c_int {
-        /// By default, a successful call to igBeginDragDropSource opens a tooltip so you can
-        /// display a preview or description of the source contents. This flag disable this
-        /// behavior.
-        const SourceNoPreviewTooltip = 1;
-        /// By default, when dragging we clear data so that igIsItemHovered() will return false, to
-        /// avoid subsequent user code submitting tooltips. This flag disable this behavior so you
-        /// can still call igIsItemHovered() on the source item.
-        const SourceNoDisableHover = 1 << 1;
-        /// Disable the behavior that allows to open tree nodes and collapsing header by holding
-        /// over them while dragging a source item.
-        const SourceNoHoldToOpenOthers = 1 << 2;
-        /// Allow items such as igText(), igImage() that have no unique identifier to be used as
-        /// drag source, by manufacturing a temporary identifier based on their window-relative
-        /// position. This is extremely unusual within the dear imgui ecosystem and so we made it
-        /// explicit.
-        const SourceAllowNullID = 1 << 3;
-        /// External source (from outside of imgui), won't attempt to read current item/window
-        /// info. Will always return true. Only one Extern source can be active simultaneously.
-        const SourceExtern = 1 << 4;
-        /// Automatically expire the payload if the source cease to be submitted (otherwise
-        /// payloads are persisting while being dragged)
-        const SourceAutoExpirePayload = 1 << 5;
-        /// igAcceptDragDropPayload() will returns true even before the mouse button is released.
-        /// You can then call igIsDelivery() to test if the payload needs to be delivered.
-        const AcceptBeforeDelivery = 1 << 10;
-        /// Do not draw the default highlight rectangle when hovering over target.
-        const AcceptNoDrawDefaultRect = 1 << 11;
-        /// Request hiding the igBeginDragDropSource tooltip from the igBeginDragDropTarget site.
-        const AcceptNoPreviewTooltip = 1 << 12;
-        /// For peeking ahead and inspecting the payload before delivery.
-        const AcceptPeekOnly = ImGuiDragDropFlags::AcceptBeforeDelivery.bits
-            | ImGuiDragDropFlags::AcceptNoDrawDefaultRect.bits;
-    }
-);
-
-bitflags!(
     /// Flags for indictating which corner of a rectangle should be rounded
     #[repr(C)]
     pub struct ImDrawCornerFlags: c_int {


### PR DESCRIPTION
Should have been removed in last PR with drag/drop