### PR TITLE
add input_text hinting

### DIFF
--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -30,6 +30,7 @@ struct State {
     item2: usize,
     item3: i32,
     text: ImString,
+    text_with_hint: ImString,
     text_multiline: ImString,
     i0: i32,
     f0: f32,
@@ -60,6 +61,7 @@ impl Default for State {
         buf.push_str("日本語");
         let mut text = ImString::with_capacity(128);
         text.push_str("Hello, world!");
+        let text_with_hint = ImString::with_capacity(128);
         let mut text_multiline = ImString::with_capacity(128);
         text_multiline.push_str("Hello, world!\nMultiline");
         State {
@@ -90,6 +92,7 @@ impl Default for State {
             item2: 0,
             item3: 0,
             text,
+            text_with_hint,
             text_multiline,
             i0: 123,
             f0: 0.001,
@@ -532,6 +535,9 @@ fn show_test_window(ui: &Ui, state: &mut State, opened: &mut bool) {
             });
 
             ui.input_text(im_str!("input text"), &mut state.text)
+                .build();
+            ui.input_text(im_str!("input text with hint"), &mut state.text_with_hint)
+                .hint(im_str!("enter text here"))
                 .build();
             ui.input_int(im_str!("input int"), &mut state.i0).build();
             Drag::new(im_str!("drag int")).build(ui, &mut state.i0);

--- a/imgui/src/input_widget.rs
+++ b/imgui/src/input_widget.rs
@@ -159,6 +159,7 @@ extern "C" fn resize_callback(data: *mut sys::ImGuiInputTextCallbackData) -> c_i
 #[must_use]
 pub struct InputText<'ui, 'p> {
     label: &'p ImStr,
+    hint: Option<&'p ImStr>,
     buf: &'p mut ImString,
     flags: ImGuiInputTextFlags,
     _phantom: PhantomData<&'ui Ui<'ui>>,
@@ -168,10 +169,18 @@ impl<'ui, 'p> InputText<'ui, 'p> {
     pub fn new(_: &Ui<'ui>, label: &'p ImStr, buf: &'p mut ImString) -> Self {
         InputText {
             label,
+            hint: None,
             buf,
             flags: ImGuiInputTextFlags::empty(),
             _phantom: PhantomData,
         }
+    }
+
+    /// Sets the hint displayed in the input text background.
+    #[inline]
+    pub fn hint(mut self, hint: &'p ImStr) -> Self {
+        self.hint = Some(hint);
+        self
     }
 
     impl_text_flags!(InputText);
@@ -190,14 +199,26 @@ impl<'ui, 'p> InputText<'ui, 'p> {
         };
 
         unsafe {
-            let result = sys::igInputText(
-                self.label.as_ptr(),
-                ptr,
-                capacity,
-                self.flags.bits(),
-                callback,
-                data,
-            );
+            let result = if let Some(hint) = self.hint {
+                sys::igInputTextWithHint(
+                    self.label.as_ptr(),
+                    hint.as_ptr(),
+                    ptr,
+                    capacity,
+                    self.flags.bits(),
+                    callback,
+                    data,
+                )
+            } else {
+                sys::igInputText(
+                    self.label.as_ptr(),
+                    ptr,
+                    capacity,
+                    self.flags.bits(),
+                    callback,
+                    data,
+                )
+            };
             self.buf.refresh_len();
             result
         }


### PR DESCRIPTION
Added hinting to `InputText`, including the addition of an example in `test_window_impl`.