### PR TITLE
Adds callbacks from rust.

### DIFF
--- a/imgui/src/input_widget.rs
+++ b/imgui/src/input_widget.rs
@@ -199,6 +199,302 @@ extern "C" fn resize_callback(data: *mut sys::ImGuiInputTextCallbackData) -> c_i
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
+pub enum CallbackType {
+    Completion,
+    History,
+    CharacterFilter,
+    Edit,
+    Resize,
+}
+// tighten the data provided to each event type
+// so that the user can understand what they need to use to do what they want
+// don't allow resize to be registered, and just let the normal callback
+
+pub struct CallbackData {
+    inner: *mut sys::ImGuiInputTextCallbackData,
+}
+
+impl CallbackData {
+    // todo make this more intuitive
+    pub fn insert_characters(&mut self, pos: i32, text: &ImStr) {
+        unsafe {
+            sys::ImGuiInputTextCallbackData_InsertChars(
+                self.inner,
+                pos,
+                text.as_ptr(),
+                ptr::null(), // imgui will read strlen for us based on nul character, though if we want to calc this our selves we can
+            );
+        }
+    }
+    // TODO make this more intuitive
+    // things like deleting to the last X should be easy todo?
+    // imgui repo says this code path isnt executed a lot
+    // so we might consider not using this, and letting the user
+    // do this kind of stuff through the &mut ImString
+    pub fn delete_characters(&mut self, pos: i32, bytes_count: i32) {
+        unsafe { sys::ImGuiInputTextCallbackData_DeleteChars(self.inner, pos, bytes_count) }
+    }
+
+    pub fn has_selection(&mut self) -> bool {
+        unsafe { sys::ImGuiInputTextCallbackData_HasSelection(self.inner) }
+    }
+
+    pub fn clear_selection(&mut self) {
+        unsafe { sys::ImGuiInputTextCallbackData_ClearSelection(self.inner) }
+    }
+
+    pub fn select_all(&mut self) {
+        unsafe { sys::ImGuiInputTextCallbackData_SelectAll(self.inner) }
+    }
+
+    pub fn cursor_pos(&self) -> usize {
+        let byte_position = unsafe { (*self.inner).CursorPos } as usize;
+
+        self.byte_to_index(byte_position).unwrap()
+    }
+
+    pub fn set_cursor_pos(&mut self, index: usize) -> bool {
+        if let Some(position) = self.index_to_byte(index) {
+            unsafe {
+                (*self.inner).CursorPos = position as i32;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn event_char(&self) -> char {
+        // pretty sure EventChar is utf16 but i need to double check
+        std::char::decode_utf16(std::iter::once(unsafe { (*self.inner).EventChar }))
+            .next()
+            .unwrap()
+            .unwrap()
+    }
+
+    pub fn event_key(&self) -> crate::Key {
+        let _ = unsafe { (*self.inner).EventKey };
+        todo!()
+    }
+
+    // from what I can tell, selection_start and end represent byte positions
+    // rather than utf8 scalar values, so we need to call get unchecked here
+    // I looked at the https://github.com/ocornut/imgui/blob/master/imgui_widgets.cpp#L4354
+    // to understand the caclulations, so it looks like these values should be safe to call
+    // get_unchcked with
+    // it might be reasonable to change the API of selection_start and selection_end to calculate
+    // the utf8 boundaries, but im not sure how to do that off the top of my head
+    pub fn selection_start(&self) -> usize {
+        let byte_position = unsafe { (*self.inner).SelectionStart } as usize;
+
+        self.byte_to_index(byte_position).unwrap()
+    }
+    pub fn set_selection_start(&mut self, index: usize) -> bool {
+        if let Some(position) = self.index_to_byte(index) {
+            unsafe {
+                (*self.inner).SelectionStart = position as i32;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn selection_end(&self) -> usize {
+        let byte_position = unsafe { (*self.inner).SelectionEnd } as usize;
+
+        self.byte_to_index(byte_position).unwrap()
+    }
+    pub fn set_selection_end(&mut self, index: usize) -> bool {
+        if let Some(position) = self.index_to_byte(index) {
+            unsafe {
+                (*self.inner).SelectionEnd = position as i32;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    // these 2 are probably good helper functions for users
+    pub fn delete_selection(&mut self) -> bool {
+        todo!()
+    }
+    pub fn replace_selection(&mut self, value: &'_ str) {
+        todo!()
+    }
+
+    // this functionality probably makes sense to implement ourselves?
+    // i kind of presume that autocomplete is a word by word basis
+    // so this would be deleting all the data from the cursor to the most recent
+    // whitespace, and then insert the new value at the new cursor position
+
+    pub fn autocomplete_with(&mut self, value: &'_ str) {
+        todo!()
+    }
+
+    // these seem slow cause of the iteration
+    // but it also doesnt seem like theyre going to be called often enough to be
+    // a pain point?
+    fn byte_to_index(&self, byte_position: usize) -> Option<usize> {
+        // alternative impl
+        // str.get(..byte_position).map(|s| s.chars().count())
+        self.buffer()
+            .to_str()
+            .char_indices()
+            .enumerate()
+            .find(|(_, (byte_offset, _))| *byte_offset == byte_position)
+            .map(|(idx, _)| idx)
+    }
+    fn index_to_byte(&self, index: usize) -> Option<usize> {
+        self.buffer()
+            .to_str()
+            .char_indices()
+            .nth(index)
+            .map(|(value, _)| value)
+    }
+
+    pub fn selection(&self) -> &str {
+        &self.buffer().to_str()[self.selection_start()..self.selection_end()]
+    }
+
+    pub fn is_buffer_dirty(&self) -> bool {
+        unsafe { (*self.inner).BufDirty }
+    }
+
+    // this values is in bytes, not in unicode scalar values
+    pub fn text_len(&self) -> i32 {
+        // this might not make sense to even keep around?
+        // our wrapper should probably update this after the callback is over to match what
+        // is in the &mut ImString buffer
+        // this number is a byte size regardless
+        // and im not sure the users actually care
+        unsafe { (*self.inner).BufTextLen }
+    }
+
+    // interestingly we pass a usize to imgui
+    // but this struct will give us back an i32
+    // not sure if this behavior is actually correct
+    // it seems like we cast this straight to i32 in most cases
+    // but I'm not sure how good of an idea that actually is given
+    // usize != i32 in terms of range
+    // its unlikely someone is gonna use a buffer size greater than i32::MAX
+    // but we should note down somewhere that this is an "issue"
+    //
+    // we should probably just let the buffer method take care of this
+    // as ImString/ImStr have capacity/lenghth info
+    pub fn buffer_size(&self) -> i32 {
+        unsafe { (*self.inner).BufSize }
+    }
+
+    pub fn buffer(&self) -> &ImString {
+        unsafe { &*((*self.inner).Buf as *mut ImString) }
+    }
+
+    /// calling this function automatically sets the buffer dirty flag.
+    // it's also not clear to me if we should let users modify this instance at will
+    // and instead force them to use the add/delete character subfuncs
+    // as far as i can tell thats what the intention in the C++ API is
+    // though I'm not sure if its enforced
+    //
+    // looking through the imgui code
+    // it seems like the funcs above actually just do in place buffer manipulation
+    // so it might be worth it to not expose those and just let the user
+    // manipulate them through the &mut ImString
+    /* the following comment is from the imgui_widgets.cpp file:
+        // Public API to manipulate UTF-8 text
+        // We expose UTF-8 to the user (unlike the STB_TEXTEDIT_* functions which are manipulating wchar)
+        // FIXME: The existence of this rarely exercised code path is a bit of a nuisance.
+        void ImGuiInputTextCallbackData::DeleteChars(int pos, int bytes_count) { ... }
+    */
+    // it might be worth it to just let the user mutate this
+    // and then set all the particulars for textlen, capacity et al
+    // after the users callback is done
+    // that way we can just let the user manipulate the &mut ImString as normal
+    // the only weirdness here is updating the selection i32s
+    // imgui has some logic in the InsertCharacters routine
+    // that we might be better if we duplicate instead
+    pub fn buffer_mut(&mut self) -> &mut ImString {
+        self.set_buffer_dirty();
+        unsafe { &mut *((*self.inner).Buf as *mut ImString) }
+    }
+
+    pub fn set_buffer_dirty(&mut self) {
+        unsafe {
+            (*self.inner).BufDirty = true;
+        }
+    }
+
+    pub fn callback_type(&self) -> CallbackType {
+        unsafe {
+            let event = (*self.inner).EventFlag;
+
+            if event == InputTextFlags::CALLBACK_RESIZE.bits() as i32 {
+                CallbackType::Resize
+            } else if event == InputTextFlags::CALLBACK_CHAR_FILTER.bits() as i32 {
+                CallbackType::CharacterFilter
+            } else if event == InputTextFlags::CALLBACK_HISTORY.bits() as i32 {
+                CallbackType::History
+            } else if event == sys::ImGuiInputTextFlags_CallbackEdit as i32 {
+                CallbackType::Edit
+            } else if event == InputTextFlags::CALLBACK_COMPLETION.bits() as i32 {
+                CallbackType::Completion
+            } else {
+                panic!("Imgui returned unexpected callback type");
+            }
+        }
+    }
+}
+
+// when callback_type == CharacterFilter
+// the return value of this function tells imgui whether or not to keep the character
+// 0 -> ignore, 1 -> keep
+extern "C" fn generic_callback(data: *mut sys::ImGuiInputTextCallbackData) -> c_int {
+    unsafe {
+        // this has to be an FnMut, because imgui will call the closure multiple times
+        // this also means we have to deal with the resize callback here
+        // and the etc
+
+        // 99% sure the API we want to provide, is giving an enum back to the user
+        // explaining which call this was
+        // and also passing a object that represents the rest of the callback info, but something rusty
+        // also need to implement the functions it provides
+
+        let callback = &mut *((*data).UserData as *mut InternalCallback);
+        let mut callback_data = CallbackData { inner: data };
+
+        if let Some(buffer) = callback.buffer_to_resize.and_then(|buffer| buffer.as_mut()) {
+            if (*data).EventFlag == InputTextFlags::CALLBACK_RESIZE.bits() as i32 {
+                let requested_size = (*data).BufSize as usize;
+                if requested_size > buffer.capacity_with_nul() {
+                    // Refresh the buffer's length to take into account changes made by dear imgui.
+                    buffer.refresh_len();
+                    buffer.reserve(requested_size - buffer.0.len());
+                    debug_assert!(buffer.capacity_with_nul() >= requested_size);
+                    // the Buf passed back to us by Imgui, and the one we hold onto, are the same?
+                    // when exactly do we dealloc the buffer?
+                    (*data).Buf = buffer.as_mut_ptr();
+                    (*data).BufDirty = true;
+                }
+            }
+        }
+
+        if let Some(user_callback) = &mut callback.user_callback {
+            if callback.buffer_to_resize.is_none()
+                || (*data).EventFlag != InputTextFlags::CALLBACK_RESIZE.bits() as i32
+            {
+                return if user_callback(&mut callback_data) {
+                    1
+                } else {
+                    0
+                };
+            }
+        }
+        0
+    }
+}
+
 #[must_use]
 pub struct InputText<'ui, 'p> {
     label: &'p ImStr,
@@ -231,39 +527,172 @@ impl<'ui, 'p> InputText<'ui, 'p> {
     // TODO: boxed closure...?
     // pub fn callback(self) -> Self { }
 
-    pub fn build(self) -> bool {
+    unsafe fn build_internal(
+        self,
+        callback: sys::ImGuiInputTextCallback,
+        data: *mut c_void,
+    ) -> bool {
         let (ptr, capacity) = (self.buf.as_mut_ptr(), self.buf.capacity_with_nul());
+
+        let result = if let Some(hint) = self.hint {
+            sys::igInputTextWithHint(
+                self.label.as_ptr(),
+                hint.as_ptr(),
+                ptr,
+                capacity,
+                self.flags.bits() as i32,
+                callback,
+                data,
+            )
+        } else {
+            sys::igInputText(
+                self.label.as_ptr(),
+                ptr,
+                capacity,
+                self.flags.bits() as i32,
+                callback,
+                data,
+            )
+        };
+        self.buf.refresh_len();
+        result
+    }
+
+    pub fn build(self) -> bool {
+        let mut user_data = InternalCallback {
+            user_callback: None,
+            buffer_to_resize: self
+                .flags
+                .contains(InputTextFlags::CALLBACK_RESIZE)
+                .then(|| self.buf as *mut _),
+        };
         let (callback, data): (sys::ImGuiInputTextCallback, _) = {
-            if self.flags.contains(InputTextFlags::CALLBACK_RESIZE) {
-                (Some(resize_callback), self.buf as *mut _ as *mut c_void)
-            } else {
-                (None, ptr::null_mut())
-            }
+            (
+                Some(generic_callback),
+                &mut user_data as *mut _ as *mut c_void,
+            )
         };
 
-        unsafe {
-            let result = if let Some(hint) = self.hint {
-                sys::igInputTextWithHint(
-                    self.label.as_ptr(),
-                    hint.as_ptr(),
-                    ptr,
-                    capacity,
-                    self.flags.bits() as i32,
-                    callback,
-                    data,
-                )
-            } else {
-                sys::igInputText(
-                    self.label.as_ptr(),
-                    ptr,
-                    capacity,
-                    self.flags.bits() as i32,
-                    callback,
-                    data,
-                )
-            };
-            self.buf.refresh_len();
-            result
+        unsafe { self.build_internal(callback, data) }
+    }
+
+    pub fn build_with_callback<F: FnMut(&mut CallbackData) -> bool>(self, mut f: F) -> bool {
+        let mut user_data = InternalCallback {
+            user_callback: Some(&mut f),
+            buffer_to_resize: self
+                .flags
+                .contains(InputTextFlags::CALLBACK_RESIZE)
+                .then(|| self.buf as *mut _),
+        };
+
+        let (callback, data): (sys::ImGuiInputTextCallback, _) = {
+            (
+                Some(generic_callback),
+                &mut user_data as *mut _ as *mut c_void,
+            )
+        };
+        unsafe { self.build_internal(callback, data) }
+    }
+}
+
+struct InternalCallback<'a> {
+    user_callback: Option<&'a mut dyn FnMut(&mut CallbackData) -> bool>,
+    buffer_to_resize: Option<*mut ImString>,
+}
+
+pub struct UserCallbacks<CompletionFunc, HistoryFunc, CharacterFilterFunc, EditFunc, ResizeFunc> {
+    completion: CompletionFunc,
+    history: HistoryFunc,
+    filter: CharacterFilterFunc,
+    edit: EditFunc,
+    resize: ResizeFunc,
+}
+
+impl<
+        CompletionFunc: ToDynFnMut,
+        HistoryFunc: ToDynFnMut,
+        CharacterFilterFunc,
+        EditFunc,
+        ResizeFunc,
+    > UserCallbacks<CompletionFunc, HistoryFunc, CharacterFilterFunc, EditFunc, ResizeFunc>
+{
+    fn get_refs(&mut self) -> CallbackRefs<'_> {
+        CallbackRefs {
+            completion: self.completion.as_dyn_fn_mut(),
+            history: self.history.as_dyn_fn_mut(),
+        }
+    }
+}
+
+pub struct CallbackRefs<'a> {
+    completion: Option<&'a mut dyn FnMut(&mut CallbackData)>,
+    history: Option<&'a mut dyn FnMut(&mut CallbackData)>,
+}
+
+pub trait ToDynFnMut {
+    fn as_dyn_fn_mut(&mut self) -> Option<&mut dyn FnMut(&mut CallbackData)>;
+}
+
+impl ToDynFnMut for () {
+    fn as_dyn_fn_mut(&mut self) -> Option<&mut dyn FnMut(&mut CallbackData)> {
+        None
+    }
+}
+
+impl<F: FnMut(&mut CallbackData)> ToDynFnMut for F {
+    fn as_dyn_fn_mut(&mut self) -> Option<&mut dyn FnMut(&mut CallbackData)> {
+        Some(self)
+    }
+}
+
+impl UserCallbacks<(), (), (), (), ()> {
+    pub fn new() -> Self {
+        Self {
+            completion: (),
+            history: (),
+            filter: (),
+            edit: (),
+            resize: (),
+        }
+    }
+}
+
+#[test]
+fn test() {
+    let mut x = UserCallbacks::new().history(|_| {});
+    let callbacks = x.get_refs();
+}
+
+impl<HistoryFunc, CharacterFilterFunc, EditFunc, ResizeFunc>
+    UserCallbacks<(), HistoryFunc, CharacterFilterFunc, EditFunc, ResizeFunc>
+{
+    pub fn completion<F: FnMut(&mut CallbackData)>(
+        self,
+        f: F,
+    ) -> UserCallbacks<F, HistoryFunc, CharacterFilterFunc, EditFunc, ResizeFunc> {
+        UserCallbacks {
+            completion: f,
+            history: self.history,
+            filter: self.filter,
+            edit: self.edit,
+            resize: self.resize,
+        }
+    }
+}
+
+impl<CompletionFunc, CharacterFilterFunc, EditFunc, ResizeFunc>
+    UserCallbacks<CompletionFunc, (), CharacterFilterFunc, EditFunc, ResizeFunc>
+{
+    pub fn history<F: FnMut(&mut CallbackData)>(
+        self,
+        f: F,
+    ) -> UserCallbacks<CompletionFunc, F, CharacterFilterFunc, EditFunc, ResizeFunc> {
+        UserCallbacks {
+            completion: self.completion,
+            history: f,
+            filter: self.filter,
+            edit: self.edit,
+            resize: self.resize,
         }
     }
 }


### PR DESCRIPTION
This is a WIP pull request implementing text edit callbacks in rust.

Current status:
~~I got imgui to call our basic callback, and I'm working on integrating a more rusty API for the end user.~~
I've started working on the end-user API, but I'm stuck on how we should allow the user to manipulate the ImString buffer.  I think it might be worth while to provide helper methods that do work the user could do themselves, but are pretty repetitive.

This should eventually resolve #430 