### PR TITLE
Fix typo in GFX examples

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -102,8 +102,8 @@ Examples for the gfx backend are under the imgui-gfx-examples directory.
 cd imgui-gfx-examples
 cargo test
 
-cargo run --example hello_world
-cargo run --example test_window
+cargo run --example gfx_hello_world
+cargo run --example gfx_test_window
 ```
 
 Note to Windows users:  You will need to use the *MSVC ABI* version of the Rust

--- a/imgui-gfx-examples/README.md
+++ b/imgui-gfx-examples/README.md
@@ -1,4 +1,4 @@
 # `imgui-gfx-examples`
 
-- Run with OpenGL backend: `cargo run --example hello_gfx`
-- Run with DirectX backend: `cargo run --example hello_gfx --features directx --no-default-features`
+- Run with OpenGL backend: `cargo run --example gfx_hello_world`
+- Run with DirectX backend: `cargo run --example gfx_hello_world --features directx --no-default-features`


### PR DESCRIPTION
Just two typo errors in GFX examples in the README page.