### PR TITLE
Combobox: Focus the selected item.

### DIFF
--- a/imgui/src/widget/combo_box.rs
+++ b/imgui/src/widget/combo_box.rs
@@ -203,6 +203,9 @@ impl<'a> ComboBox<'a> {
                     *current_item = idx;
                     result = true;
                 }
+                if selected {
+                    ui.set_item_default_focus();
+                }
             }
         }
         result


### PR DESCRIPTION
When building a combo box via the `build_simple` APIs, default-focus the selected item.
