### PR TITLE
Disable winit default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-target-lint-
       - run: cargo clippy --workspace --all-targets
       # supported winit versions
-      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --features winit-19 --features winit-20 --features winit-22 --features winit-23/default --features winit-24/default --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --all-features --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19 --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20 --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22 --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19 --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20 --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22 --all-targets
-      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23 --all-targets
-      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-24 --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23/default --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-24/default --all-targets
   rustfmt:
     name: Check rustfmt
     runs-on: ubuntu-latest
@@ -138,8 +138,8 @@ jobs:
       - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19
       - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20
       - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22
-      - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23
-      - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-24
+      - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23/default
+      - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-24/default
       # Run unreasonably slow tests under release, but only the crates that have
       # them, and don't bother doing this on most platforms.
       - run: cargo test -p imgui --release -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22 --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23/default --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-24/default --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-25/default --all-targets
   rustfmt:
     name: Check rustfmt
     runs-on: ubuntu-latest
@@ -140,6 +141,7 @@ jobs:
       - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22
       - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23/default
       - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-24/default
+      - run: cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-25/default
       # Run unreasonably slow tests under release, but only the crates that have
       # them, and don't bother doing this on most platforms.
       - run: cargo test -p imgui --release -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-target-lint-
       - run: cargo clippy --workspace --all-targets
       # supported winit versions
-      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --all-features --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --features winit-19 --features winit-20 --features winit-22 --features winit-23/default --features winit-24/default --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19 --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20 --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22 --all-targets

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Removed automatically adding default features for `imgui-winit-support`
+with the exception of the current default winit feature/dep version. Additionally, that version was updated to 0.25. If you want to not have the default features of winit with 0.25, set `default-features = false` and add `winit-25` as a normal feature. Thank you to @dzil123 for the work [implementing this here](https://github.com/imgui-rs/imgui-rs/pull/477)!
+
 - Added an `imgui-glow-renderer` which targets `glow 0.10`. Before release, this will be updated to target current `0.11` glow when further features are added. Thank you to @jmaargh for the work [implementing this here](https://github.com/imgui-rs/imgui-rs/pull/495)!
 
 - BREAKING: Reworked `.range` calls on `Slider`, `VerticalSlider`, and `Drag` to simply take two min and max values, and requires that they are provided in the constructor.

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -11,12 +11,11 @@ categories = ["gui"]
 
 [dependencies]
 imgui = { version = "0.7.0", path = "../imgui" }
-winit-19 = { version = ">= 0.16, < 0.20", package = "winit", optional = true }
-winit-20 = { version = ">= 0.20, < 0.22", package = "winit", optional = true }
-winit-22 = { version = "0.22", package = "winit", optional = true }
-winit-23 = { version = "0.23", package = "winit", optional = true }
-winit-24 = { version = "0.24", package = "winit", optional = true }
-winit-25 = { version = "0.25", package = "winit", optional = true }
+winit-19 = { version = ">= 0.16, < 0.20", package = "winit", default-features = false, optional = true }
+winit-20 = { version = ">= 0.20, < 0.22", package = "winit", default-features = false, optional = true }
+winit-22 = { version = "0.22", package = "winit", default-features = false, optional = true }
+winit-23 = { version = "0.23", package = "winit", default-features = false, optional = true }
+winit-24 = { version = "0.24", package = "winit", default-features = false, optional = true }
 
 [features]
 default = ["winit-25"]

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -16,10 +16,11 @@ winit-20 = { version = ">= 0.20, < 0.22", package = "winit", optional = true }
 winit-22 = { version = "0.22", package = "winit", optional = true }
 winit-23 = { version = "0.23", package = "winit", default-features = false, optional = true }
 winit-24 = { version = "0.24", package = "winit", default-features = false, optional = true }
+winit-25 = { version = "0.25", package = "winit", default-features = false, optional = true }
 
 [features]
-default = ["winit-24"]
-test = ["winit-23/default", "winit-24/default"]
+default = ["winit-24"] # TODO: Change to winit-25 when glutin has upgraded to it
+test = ["winit-23/default", "winit-24/default", "winit-25/default"]
 
 # This is phrased as a negative (unlike most features) so that it needs to be
 # explicitly disabled (and `default-features = false` won't do it). To avoid

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["gui"]
 
 [dependencies]
 imgui = { version = "0.7.0", path = "../imgui" }
-winit-19 = { version = ">= 0.16, < 0.20", package = "winit", default-features = false, optional = true }
-winit-20 = { version = ">= 0.20, < 0.22", package = "winit", default-features = false, optional = true }
-winit-22 = { version = "0.22", package = "winit", default-features = false, optional = true }
+winit-19 = { version = ">= 0.16, < 0.20", package = "winit", optional = true }
+winit-20 = { version = ">= 0.20, < 0.22", package = "winit", optional = true }
+winit-22 = { version = "0.22", package = "winit", optional = true }
 winit-23 = { version = "0.23", package = "winit", default-features = false, optional = true }
 winit-24 = { version = "0.24", package = "winit", default-features = false, optional = true }
 

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -18,7 +18,8 @@ winit-23 = { version = "0.23", package = "winit", default-features = false, opti
 winit-24 = { version = "0.24", package = "winit", default-features = false, optional = true }
 
 [features]
-default = ["winit-25"]
+default = ["winit-24"]
+test = ["winit-23/default", "winit-24/default"]
 
 # This is phrased as a negative (unlike most features) so that it needs to be
 # explicitly disabled (and `default-features = false` won't do it). To avoid

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -19,7 +19,7 @@ winit-24 = { version = "0.24", package = "winit", default-features = false, opti
 winit-25 = { version = "0.25", package = "winit", default-features = false, optional = true }
 
 [features]
-default = ["winit-24"] # TODO: Change to winit-25 when glutin has upgraded to it
+default = ["winit-25/default"]
 test = ["winit-23/default", "winit-24/default", "winit-25/default"]
 
 # This is phrased as a negative (unlike most features) so that it needs to be

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -194,15 +194,13 @@ use winit::{
     TouchPhase, VirtualKeyCode, Window, WindowEvent,
 };
 
-#[cfg(
-    any(
-        feature = "winit-25",
-        feature = "winit-24",
-        feature = "winit-23",
-        feature = "winit-22",
-        feature = "winit-20"
-    )
-)]
+#[cfg(any(
+    feature = "winit-25",
+    feature = "winit-24",
+    feature = "winit-23",
+    feature = "winit-22",
+    feature = "winit-20"
+))]
 use winit::{
     error::ExternalError,
     event::{

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -47,6 +47,7 @@ fn lint_all() -> Result<()> {
         "winit-22",
         "winit-23/default",
         "winit-24/default",
+        "winit-25/default",
     ];
     for &winit in winits {
         xshell::cmd!("cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features {winit} --all-targets").run()?;
@@ -64,6 +65,7 @@ fn test_all() -> Result<()> {
         "winit-22",
         "winit-23/default",
         "winit-24/default",
+        "winit-25/default",
     ];
     for &winit in winits {
         xshell::cmd!("cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features {winit} --all-targets").run()?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -41,7 +41,13 @@ fn lint_all() -> Result<()> {
         "cargo clippy --manifest-path imgui-winit-support/Cargo.toml --all-features --all-targets"
     )
     .run()?;
-    let winits = &["winit-19", "winit-20", "winit-22", "winit-23", "winit-24"];
+    let winits = &[
+        "winit-19",
+        "winit-20",
+        "winit-22",
+        "winit-23/default",
+        "winit-24/default",
+    ];
     for &winit in winits {
         xshell::cmd!("cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features {winit} --all-targets").run()?;
     }
@@ -52,7 +58,13 @@ fn lint_all() -> Result<()> {
 fn test_all() -> Result<()> {
     xshell::cmd!("cargo test --workspace --all-targets").run()?;
     xshell::cmd!("cargo test --workspace --doc").run()?;
-    let winits = &["winit-19", "winit-20", "winit-22", "winit-23", "winit-24"];
+    let winits = &[
+        "winit-19",
+        "winit-20",
+        "winit-22",
+        "winit-23/default",
+        "winit-24/default",
+    ];
     for &winit in winits {
         xshell::cmd!("cargo test --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features {winit} --all-targets").run()?;
     }


### PR DESCRIPTION
Allows users to set their own winit features. 

Previously the winit default features would have been enabled even if the user disabled it in their own Cargo.toml. This is because of the way Cargo does [feature unification](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification).

This modification does not change any functionality because imgui-winit-support does not use winit::platform.