### PR TITLE
WIP: A software renderer

### DIFF
--- a/imgui-software-renderer/Cargo.toml
+++ b/imgui-software-renderer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "imgui-software-renderer"
+version = "0.7.0"
+edition = "2018"
+authors = ["The imgui-rs Developers"]
+description = "Software renderer for imgui-rs"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
+license = "MIT/Apache-2.0"
+categories = ["gui", "rendering"]
+
+[dependencies]
+tiny-skia = "0.5"
+imgui = { version = "0.7.0", path = "../imgui" }

--- a/imgui-software-renderer/README.md
+++ b/imgui-software-renderer/README.md
@@ -1,0 +1,28 @@
+# Software renderer for imgui-rs
+
+A renderer backend for imgui-rs to allow easy capture of an "dear imgui" interface to a file, without requiring any graphics hardware or complex dependencies.
+
+Some use cases:
+
+1. In a test case, run an application in a "headless" mode, interacting with the interface programatically. If an assertion fails, save the rendered image to a PNG file for debugging purposes.
+2. In a test case, render a widget and compare it again a "known good" reference image to check a complex custom widget hasn't been altered
+3. Use the renderer to automatically generate screenshots of an application or widget for use in documentation/tutorials.
+
+
+## Notes/performance
+
+Performance is not a high priority for this project.
+
+The renderer is reasonably fast (the basic example with the "Dear ImGUI demo" nad a few other windows renders in around 6ms per frame in release mode), but this is almost entirely thanks to the speed of [`tiny_skia`](https://github.com/RazrFalcon/tiny-skia) used for rasterisation.
+
+The renderer is inspired by [this C++ implementation](https://github.com/emilk/imgui_software_renderer/blob/master/src/imgui_sw.cpp) which contains many optimisations (e.g combining the polygons for each text character into a single square).
+
+The primary goals of this renderer are:
+
+1. Small, simple to follow code base
+2. Consistent output - the same draw list should produce the same pixel data
+
+
+## Usage
+
+See the `examples/` directory.

--- a/imgui-software-renderer/examples/software_renderer_basic.rs
+++ b/imgui-software-renderer/examples/software_renderer_basic.rs
@@ -1,0 +1,99 @@
+use tiny_skia::Pixmap;
+use imgui::{im_str, FontConfig, FontSource};
+
+fn main() {
+    // Size of our software "display"
+    let width = 1000;
+    let height = 500;
+
+    // Create imgui Context as per usual
+    let mut imgui_ctx = imgui::Context::create();
+
+    // Don't save window layout etc
+    imgui_ctx.set_ini_filename(None);
+
+    // Tell imgui to draw a cursor, and set the cursor position
+    imgui_ctx.io_mut().mouse_draw_cursor = true;
+    imgui_ctx.io_mut().mouse_pos = [200.0, 50.0];
+
+    // Register the default font
+    imgui_ctx.fonts().add_font(&[FontSource::DefaultFontData {
+        config: Some(FontConfig {
+            size_pixels: 13.0,
+            ..FontConfig::default()
+        }),
+    }]);
+
+    // Generate font atlas texture
+    // FIXME: Belongs as helper in lib
+    let font_pixmap = {
+        let mut font_atlas = imgui_ctx.fonts();
+        let font_atlas_tex = font_atlas.build_rgba32_texture();
+
+        let mut font_pixmap = Pixmap::new(font_atlas_tex.width, font_atlas_tex.height).unwrap();
+
+        {
+            let data = font_pixmap.pixels_mut();
+            for (i, src) in font_atlas_tex.data.chunks(4).enumerate() {
+                data[i] =
+                    tiny_skia::ColorU8::from_rgba(src[0], src[1], src[2], src[3]).premultiply();
+            }
+        }
+
+        font_pixmap
+    };
+
+    // Set display size
+    // FIXME: Belongs as helper in lib
+    imgui_ctx.io_mut().display_size = [width as f32, height as f32];
+    imgui_ctx.io_mut().display_framebuffer_scale = [1.0, 1.0];
+
+    for frame in 0..10 {
+        println!("Frame {}", frame);
+        imgui_ctx
+            .io_mut()
+            .update_delta_time(std::time::Duration::from_millis(20));
+
+        let draw_data: &imgui::DrawData = {
+            // New frame
+            let ui = imgui_ctx.frame();
+
+            // Create an example window
+            imgui::Window::new(im_str!("Example"))
+                .size([250.0, 100.0], imgui::Condition::FirstUseEver)
+                .position([10.0, 200.0], imgui::Condition::FirstUseEver)
+                .build(&ui, || {
+                    // Some basic widgets
+                    ui.button(imgui::im_str!("Hi"));
+                    ui.text("Ok");
+                    let mut thing = 0.4;
+                    ui.input_float(im_str!("##Test"), &mut thing).build();
+
+                    // Use custom drawing API to draw useless purple box
+                    ui.get_window_draw_list()
+                        .add_rect([10.0, 10.0], [50.0, 50.0], [0.5, 0.0, 1.0])
+                        .filled(true)
+                        .rounding(6.0)
+                        .build();
+                });
+
+            // Show built-in example windows
+            ui.show_demo_window(&mut true);
+            ui.show_metrics_window(&mut true);
+
+            // Done, get draw list data
+            ui.render()
+        };
+
+        // Create empty pixmap
+        let mut px = Pixmap::new(width, height).unwrap();
+        px.fill(tiny_skia::Color::from_rgba8(89, 89, 89, 255));
+
+        // Render imgui data
+        let r = imgui_software_renderer::Renderer::new();
+        r.render(&mut px, draw_data, font_pixmap.as_ref());
+
+        // Save output
+        px.save_png(format!("test_{}.png", frame)).unwrap();
+    }
+}

--- a/imgui-software-renderer/src/copypaste.rs
+++ b/imgui-software-renderer/src/copypaste.rs
@@ -1,0 +1,88 @@
+//! The tiny_skia::Transform::invert method is useful but private in
+//! tiny_skia currently, so duplicated here for now.
+
+mod copypaste {
+    use tiny_skia::Transform;
+
+    fn dcross(a: f64, b: f64, c: f64, d: f64) -> f64 {
+        a * b - c * d
+    }
+
+    fn dcross_dscale(a: f32, b: f32, c: f32, d: f32, scale: f64) -> f32 {
+        (dcross(a as f64, b as f64, c as f64, d as f64) * scale) as f32
+    }
+
+    pub fn compute_inv(ts: &Transform, inv_det: f64) -> Transform {
+        Transform::from_row(
+            (ts.sy as f64 * inv_det) as f32,
+            (-ts.ky as f64 * inv_det) as f32,
+            (-ts.kx as f64 * inv_det) as f32,
+            (ts.sx as f64 * inv_det) as f32,
+            dcross_dscale(ts.kx, ts.ty, ts.sy, ts.tx, inv_det),
+            dcross_dscale(ts.ky, ts.tx, ts.sx, ts.ty, inv_det),
+        )
+    }
+
+    fn is_nearly_zero_within_tolerance(value: f32, tolerance: f32) -> bool {
+        debug_assert!(tolerance >= 0.0);
+        value.abs() <= tolerance
+    }
+
+    fn inv_determinant(ts: &Transform) -> Option<f64> {
+        let det = dcross(ts.sx as f64, ts.sy as f64, ts.kx as f64, ts.ky as f64);
+
+        // Since the determinant is on the order of the cube of the matrix members,
+        // compare to the cube of the default nearly-zero constant (although an
+        // estimate of the condition number would be better if it wasn't so expensive).
+        const SCALAR_NEARLY_ZERO: f32 = 1.0 / (1 << 12) as f32;
+
+        let tolerance = SCALAR_NEARLY_ZERO * SCALAR_NEARLY_ZERO * SCALAR_NEARLY_ZERO;
+        if is_nearly_zero_within_tolerance(det as f32, tolerance) {
+            None
+        } else {
+            Some(1.0 / det)
+        }
+    }
+
+    fn is_finite(x: &Transform) -> bool {
+        x.sx.is_finite()
+            && x.ky.is_finite()
+            && x.kx.is_finite()
+            && x.sy.is_finite()
+            && x.tx.is_finite()
+            && x.ty.is_finite()
+    }
+
+    pub fn invert(ts: &Transform) -> Option<Transform> {
+        debug_assert!(!ts.is_identity());
+
+        if ts.is_scale_translate() {
+            if ts.has_scale() {
+                let inv_x = 1.0 / ts.sx;
+                let inv_y = 1.0 / ts.sy;
+                Some(Transform::from_row(
+                    inv_x,
+                    0.0,
+                    0.0,
+                    inv_y,
+                    -ts.tx * inv_x,
+                    -ts.ty * inv_y,
+                ))
+            } else {
+                // translate only
+                Some(Transform::from_translate(-ts.tx, -ts.ty))
+            }
+        } else {
+            let inv_det = inv_determinant(ts)?;
+            let inv_ts = compute_inv(ts, inv_det);
+
+            if is_finite(&inv_ts) {
+                Some(inv_ts)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+pub(crate) use copypaste::invert;

--- a/imgui-software-renderer/src/drawing.rs
+++ b/imgui-software-renderer/src/drawing.rs
@@ -1,0 +1,208 @@
+use tiny_skia::{Paint, PathBuilder, Pixmap, PixmapRef, Transform};
+
+use imgui::internal::RawWrapper;
+use imgui::{DrawCmd, DrawCmdParams};
+
+/// Transform which takes three corners of a 0..1 cube and maps them
+/// to the specified coordinates.
+fn cornerpin(ul: (f32, f32), ur: (f32, f32), ll: (f32, f32)) -> Transform {
+    // Affine (3 points, no skewing)
+    let m11 = ur.0 - ul.0;
+    let m12 = ur.1 - ul.1;
+    let m21 = ll.0 - ul.0;
+    let m22 = ll.1 - ul.1;
+    // let m33 = 1;
+    let m41 = ul.0;
+    let m42 = ul.1;
+    // let m44 = 1.0;
+
+    let affine = Transform::from_row(m11, m12, m21, m22, m41, m42);
+
+    affine
+}
+
+/// Render a triangle using the given texture UV coordinates, to the
+/// specified destination points. Encodes some imgui specific
+/// weirdness about texture lookups.
+fn render_textured_tri(
+    texture_px: PixmapRef,
+    uv_p0: [f32; 2],
+    uv_p1: [f32; 2],
+    uv_p2: [f32; 2],
+    output: &mut Pixmap,
+    dest_p0: [f32; 2],
+    dest_p1: [f32; 2],
+    dest_p2: [f32; 2],
+    clip_mask: Option<&tiny_skia::ClipMask>,
+    col_p0: [u8; 4],
+    col_p1: [u8; 4],
+    col_p2: [u8; 4],
+) {
+    /// Convert between imgui-rs and tiny_skia point encodings
+    fn p(x: [f32; 2]) -> (f32, f32) {
+        (x[0], x[1])
+    }
+
+    // Path for the triangle
+    let path = {
+        let mut path = PathBuilder::new();
+        path.move_to(dest_p0[0], dest_p0[1]);
+        path.line_to(dest_p1[0], dest_p1[1]);
+        path.line_to(dest_p2[0], dest_p2[1]);
+        path.close();
+        path.finish().unwrap()
+    };
+
+    // Check if the tri is a single colour (e.g window background
+    // area), or requires a texture lookup (e.g text or icon)
+    let is_solid = true
+        && (uv_p0[0] - uv_p1[0]).abs() < 1e-8
+        && (uv_p1[0] - uv_p2[0]).abs() < 1e-8
+        && (uv_p0[1] - uv_p1[1]).abs() < 1e-8
+        && (uv_p1[1] - uv_p2[1]).abs() < 1e-8;
+    // TODO: Better check
+
+    if is_solid {
+        // Draw a non-textured triangle
+
+        let mut base_paint = Paint::default();
+        // TODO: Gradient between col_p0/1/2, currently using first colour for entire surface which is wrong
+        base_paint.set_color_rgba8(col_p0[0], col_p0[1], col_p0[2], col_p0[3]);
+
+        output.fill_path(
+            &path,
+            &base_paint,
+            tiny_skia::FillRule::default(),
+            Transform::identity(),
+            clip_mask,
+        );
+    } else {
+        // Draw a textured triangle
+
+        // Calculate the transform for the texture lookups.
+        // 1. Transform from image coordinates into 0..1 space
+        let xform_image_to_norm = Transform::from_scale(
+            1.0 / texture_px.width() as f32,
+            1.0 / texture_px.height() as f32,
+        );
+
+        // 2. Then use the UV coordinates
+        let xform_norm_to_uv =
+            match crate::copypaste::invert(&cornerpin(p(uv_p0), p(uv_p1), p(uv_p2))) {
+                // FIXME: Why are some of these transforms non-invertible?
+                None => return,
+                Some(x) => x,
+            };
+
+        // 3. and destination coordinates
+        let xform_uv_to_dest = cornerpin(p(dest_p0), p(dest_p1), p(dest_p2));
+
+        // Combine the transforms into one
+        let xform = xform_image_to_norm
+            .post_concat(xform_norm_to_uv)
+            .post_concat(xform_uv_to_dest);
+
+        // `Pattern` is tiny_skia's name for image shader
+        let tex = tiny_skia::Pattern::new(
+            texture_px,
+            tiny_skia::SpreadMode::Pad,
+            tiny_skia::FilterQuality::Bilinear,
+            col_p0[3] as f32 / 255.0,
+            xform,
+        );
+
+        // Create painter
+        let mut paint = Paint::default();
+        paint.shader = tex;
+
+        // Paint the tri
+        output.fill_path(
+            &path,
+            &paint,
+            tiny_skia::FillRule::default(),
+            Transform::identity(),
+            clip_mask,
+        );
+    }
+}
+
+pub(crate) fn rasterize(mut px: &mut Pixmap, draw_data: &imgui::DrawData, font_pixmap: PixmapRef) {
+    let mut counter = 0;
+
+    let mut paint = Paint::default();
+    paint.anti_alias = false;
+    paint.set_color_rgba8(50, 70, 200, 255);
+
+    for draw_list in draw_data.draw_lists() {
+        let verts = draw_list.vtx_buffer();
+        for cmd in draw_list.commands() {
+            let idx_buffer = draw_list.idx_buffer();
+
+            match cmd {
+                DrawCmd::Elements {
+                    count: _count,
+                    cmd_params:
+                        DrawCmdParams {
+                            clip_rect: _clip_rect,
+                            texture_id: _texture_id,
+                            vtx_offset,
+                            idx_offset,
+                            ..
+                        },
+                } => {
+                    assert!(vtx_offset == 0);
+
+                    for x in idx_buffer[idx_offset..].chunks(3) {
+                        let v0 = verts[x[0] as usize];
+                        let v1 = verts[x[1] as usize];
+                        let v2 = verts[x[2] as usize];
+
+                        let path = {
+                            let mut pb = tiny_skia::PathBuilder::new();
+                            pb.move_to(v0.pos[0], v0.pos[1]);
+                            pb.line_to(v1.pos[0], v1.pos[1]);
+                            pb.line_to(v2.pos[0], v2.pos[1]);
+                            pb.close();
+                            pb.finish().unwrap()
+                        };
+
+                        // Paint texture
+                        render_textured_tri(
+                            font_pixmap,
+                            v0.uv,
+                            v1.uv,
+                            v2.uv,
+                            &mut px,
+                            v0.pos,
+                            v1.pos,
+                            v2.pos,
+                            None,
+                            v0.col,
+                            v1.col,
+                            v2.col,
+                        );
+
+                        // Debug: show poly outline
+                        if false {
+                            paint.set_color_rgba8(255, 255, 0, 128);
+                            px.stroke_path(
+                                &path,
+                                &paint,
+                                &tiny_skia::Stroke::default(),
+                                Transform::default(),
+                                None,
+                            );
+                        }
+
+                        // px.save_png(format!("debug_{}.png", counter)).unwrap();
+                        counter += 1;
+                    }
+                }
+                DrawCmd::ResetRenderState => (), // TODO
+                DrawCmd::RawCallback { callback, raw_cmd } => unsafe {
+                    callback(draw_list.raw(), raw_cmd)
+                },
+            }
+        }
+    }
+}

--- a/imgui-software-renderer/src/lib.rs
+++ b/imgui-software-renderer/src/lib.rs
@@ -1,0 +1,86 @@
+mod copypaste;
+pub mod drawing;
+
+use tiny_skia::{Pixmap, PixmapRef};
+
+use imgui::{FontConfig, FontSource};
+
+pub struct Renderer {}
+
+impl Renderer {
+    pub fn new() -> Self {
+        Self {}
+    }
+    pub fn render(&self, mut px: &mut Pixmap, draw_data: &imgui::DrawData, font_pixmap: PixmapRef) {
+        crate::drawing::rasterize(&mut px, draw_data, font_pixmap);
+    }
+}
+
+pub struct TestHelper {
+    context: imgui::Context,
+    renderer: Renderer,
+    buffer: tiny_skia::Pixmap,
+    font_atlas_px: tiny_skia::Pixmap,
+}
+
+impl TestHelper {
+    pub fn setup(size: [f32; 2]) -> Self {
+        let mut imgui_ctx = imgui::Context::create();
+
+        // Disable settings save/restore
+        imgui_ctx.set_ini_filename(None);
+
+        // Set display size
+        imgui_ctx.io_mut().display_size = size;
+
+        // Register font
+        imgui_ctx.fonts().add_font(&[FontSource::DefaultFontData {
+            config: Some(FontConfig {
+                size_pixels: 13.0,
+                ..FontConfig::default()
+            }),
+        }]);
+
+        // Create pixmap for font atlas
+        let font_pixmap = {
+            let mut font_atlas = imgui_ctx.fonts();
+            let font_atlas_tex = font_atlas.build_rgba32_texture();
+
+            let mut font_pixmap = Pixmap::new(font_atlas_tex.width, font_atlas_tex.height).unwrap();
+
+            {
+                let data = font_pixmap.pixels_mut();
+                for (i, src) in font_atlas_tex.data.chunks(4).enumerate() {
+                    data[i] =
+                        tiny_skia::ColorU8::from_rgba(src[0], src[1], src[2], src[3]).premultiply();
+                }
+            }
+
+            font_pixmap
+        };
+
+        Self {
+            renderer: Renderer::new(),
+            context: imgui_ctx,
+            buffer: tiny_skia::Pixmap::new(size[0] as u32, size[1] as u32).unwrap(),
+            font_atlas_px: font_pixmap,
+        }
+    }
+
+    pub fn process<F>(&mut self, interface: F)
+    where
+        F: FnOnce(&imgui::Ui),
+    {
+        self.buffer
+            .fill(tiny_skia::Color::from_rgba(0.18, 0.18, 0.18, 1.0).unwrap());
+        let ui = self.context.frame();
+        interface(&ui);
+        let draw_data = ui.render();
+        self.renderer
+            .render(&mut self.buffer, &draw_data, self.font_atlas_px.as_ref());
+    }
+
+    pub fn save_snapshot(&self, path: std::path::PathBuf) {
+        self.buffer.save_png(path).unwrap();
+    }
+}


### PR DESCRIPTION
Something I wanted for writing test cases for some imgui widgets, but might be useful for a few reasons:

1. An alternative backend as discussed in #444 - not being dependent on any particular hardware or OS makes it quite a nice reference (assuming it works properly)
2. Writing more comprehensive tests for imgui-rs code, since it can run on any CI platform (doesn't need actual graphics hardware, or platform-specific things like Xvfb)
3. I have a half-formed idea that it would be possible to write mdbook preprocessor which would allow you to write docs including snippets like:

      ```rust

      # let ui = setup_renderer().display_size([100.0, 200.0])
      ui.button(im_str!("Example button!")
      # ui.render_png()
      ```

      ..and so building the mdbook would magically and automatically generate all the screenshots (which would be much less tedious than manually cropping screenshots, and also serve as some form of high-level test case)

The renderer seems to work quite well in the limited testing I've given it - but there are a few oddities/issues:

1. The first few frames never render properly - I'm pretty sure this is due to how imgui calculates layouts etc
2. Had to duplicate the `Transform::invert` code from tiny_skia as it's currently private. Need to open an issue with that project to see if it's something that can be made `pub` (if not, the implementation can be rewritten in a much shorter way)
3. The `TestHelper` struct could also be improved drastically, and should probably have a better name. It's intended to make the "just render this widget and give me a PNG" case as simple
4. It would be helpful to have some kind of `imgui-software-support` which lets you easily emulate mouse/keyboard input etc

Thoughts?