### PR TITLE
Add example to Slider.range() doc

### DIFF
--- a/imgui/src/widget/slider.rs
+++ b/imgui/src/widget/slider.rs
@@ -48,6 +48,22 @@ impl<'a, T: DataTypeKind> Slider<'a, T> {
         }
     }
     /// Sets the range (inclusive)
+    ///
+    /// The argument uses the standard Rust [`std::ops::Range`] syntax.
+    ///
+    /// For example, to set both the min and max values:
+    ///
+    /// ```rust
+    /// imgui::Slider::new(im_str!("Example"))
+    ///     .range(1 ..= 10)
+    /// ```
+    ///
+    /// To set only the max value, using the default minimum value:
+    ///
+    /// ```rust
+    /// imgui::Slider::new(im_str!("Example"))
+    ///     .range(..= 10)
+    /// ```
     #[inline]
     pub fn range<R: InclusiveRangeBounds<T>>(mut self, range: R) -> Self {
         self.min = range.start_bound().copied().unwrap_or(T::SLIDER_MIN);

--- a/imgui/src/widget/slider.rs
+++ b/imgui/src/widget/slider.rs
@@ -54,15 +54,21 @@ impl<'a, T: DataTypeKind> Slider<'a, T> {
     /// For example, to set both the min and max values:
     ///
     /// ```rust
+    /// # use imgui::im_str;
     /// imgui::Slider::new(im_str!("Example"))
     ///     .range(1 ..= 10)
+    ///     // Remember to call .build(&ui)
+    ///     ;
     /// ```
     ///
     /// To set only the max value, using the default minimum value:
     ///
     /// ```rust
+    /// # use imgui::im_str;
     /// imgui::Slider::new(im_str!("Example"))
     ///     .range(..= 10)
+    ///     // Remember to call .build(&ui)
+    ///     ;
     /// ```
     #[inline]
     pub fn range<R: InclusiveRangeBounds<T>>(mut self, range: R) -> Self {


### PR DESCRIPTION
Was a bit hard to work out what to pass to the `.range(...)` method, so added an example to clarify