### PR TITLE
glow renderer

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added an `imgui-glow-renderer` which targets `glow 0.10`. Before release, this will be updated to target current `0.11` glow when further features are added. Thank you to @jmaargh for the work [implementing this here](https://github.com/imgui-rs/imgui-rs/pull/495)!
+
 - BREAKING: Reworked `.range` calls on `Slider`, `VerticalSlider`, and `Drag` to simply take two min and max values, and requires that they are provided in the constructor.
 
   - To update without changing behavior, use the range `T::MIN` and `T::MAX` for the given numerical type (such as `i8::MIN` and `i8::MAX`).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "imgui-sys",
     "imgui-gfx-renderer",
     "imgui-glium-renderer",
+    "imgui-glow-renderer",
     "imgui-winit-support",
     "imgui-examples",
     "imgui-gfx-examples",

--- a/imgui-glow-renderer/Cargo.toml
+++ b/imgui-glow-renderer/Cargo.toml
@@ -17,6 +17,7 @@ memoffset = "0.6.4"
 [dev-dependencies]
 glutin = "0.26.0"
 imgui-winit-support = { version = "0.7.1", path = "../imgui-winit-support" }
+image = "0.23"
 
 [features]
 # Features here are used to opt-out of compiling code that depends on certain

--- a/imgui-glow-renderer/Cargo.toml
+++ b/imgui-glow-renderer/Cargo.toml
@@ -27,6 +27,7 @@ image = "0.23"
 # feature.
 default = [
   "gl_extensions_support",
+  "debug_message_insert_support",
   "bind_vertex_array_support",
   "vertex_offset_support",
   "clip_origin_support",
@@ -36,6 +37,8 @@ default = [
 ]
 # Enable checking for OpenGL extensions
 gl_extensions_support = []
+# Support for `glPrimitiveRestartIndex`
+debug_message_insert_support = []
 # Support for `glBindVertexArray`
 bind_vertex_array_support = []
 # Support for `glDrawElementsBaseVertex`

--- a/imgui-glow-renderer/Cargo.toml
+++ b/imgui-glow-renderer/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "imgui-glow-renderer"
+version = "0.7.0"
+edition = "2018"
+authors = ["The imgui-rs Developers"]
+description = "glow renderer for the imgui crate"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
+license = "MIT/Apache-2.0"
+categories = ["gui", "rendering"]
+
+[dependencies]
+imgui = { version = "0.7.0", path = "../imgui" }
+glow = "0.10.0"
+memoffset = "0.6.4"
+
+[dev-dependencies]
+glutin = "0.26.0"
+imgui-winit-support = { version = "0.7.1", path = "../imgui-winit-support" }
+
+[features]
+# Features here are used to opt-out of compiling code that depends on certain
+# OpenGL features. If the features are enabled, the renderer will check that the
+# feature is supported before attempting to use it. Only opt-out of any of these
+# if you are certain you will only target platforms that lack the corresponding
+# feature.
+default = [
+  "gl_extensions_support",
+  "bind_vertex_array_support",
+  "vertex_offset_support",
+  "clip_origin_support",
+  "bind_sampler_support",
+  "polygon_mode_support",
+  "primitive_restart_support",
+]
+# Enable checking for OpenGL extensions
+gl_extensions_support = []
+# Support for `glBindVertexArray`
+bind_vertex_array_support = []
+# Support for `glDrawElementsBaseVertex`
+vertex_offset_support = []
+# Support for `GL_CLIP_ORIGIN`
+clip_origin_support = []
+# Support for `glBindSampler`
+bind_sampler_support = []
+# Support for `glPolygonMode`
+polygon_mode_support = []
+# Support for `GL_PRIMITIVE_RESTART`
+primitive_restart_support = []

--- a/imgui-glow-renderer/LICENSE-APACHE
+++ b/imgui-glow-renderer/LICENSE-APACHE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/imgui-glow-renderer/LICENSE-MIT
+++ b/imgui-glow-renderer/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright (c) 2015-2020 The imgui-rs Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/imgui-glow-renderer/examples/01_basic.rs
+++ b/imgui-glow-renderer/examples/01_basic.rs
@@ -1,6 +1,8 @@
 //! A basic self-contained example to get you from zero-to-demo-window as fast
 //! as possible.
 
+use std::time::Instant;
+
 use glow::HasContext;
 use glutin::{event_loop::EventLoop, WindowedContext};
 use imgui_winit_support::WinitPlatform;
@@ -23,10 +25,19 @@ fn main() {
     let mut ig_renderer = imgui_glow_renderer::auto_renderer(gl, &mut imgui_context)
         .expect("failed to create renderer");
 
+    let mut last_frame = Instant::now();
+
     // Standard winit event loop
     event_loop.run(move |event, _, control_flow| {
         *control_flow = glutin::event_loop::ControlFlow::Wait;
         match event {
+            glutin::event::Event::NewEvents(_) => {
+                let now = Instant::now();
+                imgui_context
+                    .io_mut()
+                    .update_delta_time(now.duration_since(last_frame));
+                last_frame = now;
+            }
             glutin::event::Event::MainEventsCleared => {
                 winit_platform
                     .prepare_frame(imgui_context.io_mut(), window.window())

--- a/imgui-glow-renderer/examples/01_basic.rs
+++ b/imgui-glow-renderer/examples/01_basic.rs
@@ -22,7 +22,7 @@ fn main() {
     let gl = glow_context(&window);
 
     // OpenGL renderer from this crate
-    let mut ig_renderer = imgui_glow_renderer::auto_renderer(gl, &mut imgui_context)
+    let mut ig_renderer = imgui_glow_renderer::AutoRenderer::initialize(gl, &mut imgui_context)
         .expect("failed to create renderer");
 
     let mut last_frame = Instant::now();

--- a/imgui-glow-renderer/examples/01_basic.rs
+++ b/imgui-glow-renderer/examples/01_basic.rs
@@ -1,8 +1,6 @@
 //! A basic self-contained example to get you from zero-to-demo-window as fast
 //! as possible.
 
-use std::time::Instant;
-
 use glow::HasContext;
 use glutin::{event_loop::EventLoop, WindowedContext};
 use imgui_winit_support::WinitPlatform;
@@ -26,7 +24,6 @@ fn main() {
         .expect("failed to create renderer");
 
     // Standard winit event loop
-    let mut last_frame = Instant::now();
     event_loop.run(move |event, _, control_flow| {
         *control_flow = glutin::event_loop::ControlFlow::Wait;
         match event {

--- a/imgui-glow-renderer/examples/01_basic.rs
+++ b/imgui-glow-renderer/examples/01_basic.rs
@@ -20,6 +20,8 @@ fn main() {
 
     // OpenGL context from glow
     let gl = glow_context(&window);
+    // Outputting to screen, we want an sRGB framebuffer
+    unsafe { gl.enable(glow::FRAMEBUFFER_SRGB) };
 
     // OpenGL renderer from this crate
     let mut ig_renderer = imgui_glow_renderer::AutoRenderer::initialize(gl, &mut imgui_context)

--- a/imgui-glow-renderer/examples/01_basic.rs
+++ b/imgui-glow-renderer/examples/01_basic.rs
@@ -13,15 +13,13 @@ type Window = WindowedContext<glutin::PossiblyCurrent>;
 
 fn main() {
     // Common setup for creating a winit window and imgui context, not specifc
-    // to this renderer at all ecept that glutin is used to create the window
+    // to this renderer at all except that glutin is used to create the window
     // since it will give us access to a GL context
     let (event_loop, window) = create_window();
     let (mut winit_platform, mut imgui_context) = imgui_init(&window);
 
     // OpenGL context from glow
     let gl = glow_context(&window);
-    // Outputting to screen, we want an sRGB framebuffer
-    unsafe { gl.enable(glow::FRAMEBUFFER_SRGB) };
 
     // OpenGL renderer from this crate
     let mut ig_renderer = imgui_glow_renderer::AutoRenderer::initialize(gl, &mut imgui_context)

--- a/imgui-glow-renderer/examples/01_basic.rs
+++ b/imgui-glow-renderer/examples/01_basic.rs
@@ -56,7 +56,7 @@ fn main() {
 
                 // This is the only extra render step to add
                 ig_renderer
-                    .render(&draw_data)
+                    .render(draw_data)
                     .expect("error rendering imgui");
 
                 window.swap_buffers().unwrap();

--- a/imgui-glow-renderer/examples/02_triangle.rs
+++ b/imgui-glow-renderer/examples/02_triangle.rs
@@ -2,8 +2,6 @@
 
 use std::time::Instant;
 
-use glow::HasContext;
-
 mod utils;
 
 use utils::Triangler;

--- a/imgui-glow-renderer/examples/02_triangle.rs
+++ b/imgui-glow-renderer/examples/02_triangle.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 use glow::HasContext;
 
-pub mod utils;
+mod utils;
 
 use utils::Triangler;
 

--- a/imgui-glow-renderer/examples/02_triangle.rs
+++ b/imgui-glow-renderer/examples/02_triangle.rs
@@ -1,0 +1,82 @@
+//! A basic example showing imgui rendering together with some custom rendering.
+//!
+//! Note this example uses `RendererBuilder` rather than `auto_renderer` and
+//! (because we're using the default "trivial" `ContextStateManager`)
+//! therefore does not attempt to backup/restore OpenGL state.
+
+use std::time::Instant;
+
+use glow::HasContext;
+
+mod utils;
+
+use utils::Triangler;
+
+fn main() {
+    let (event_loop, window) = utils::create_window("Hello, triangle!", glutin::GlRequest::Latest);
+    let (mut winit_platform, mut imgui_context) = utils::imgui_init(&window);
+    let gl = utils::glow_context(&window);
+
+    let mut ig_renderer = imgui_glow_renderer::RendererBuilder::new()
+        .build_owning(gl, &mut imgui_context)
+        .expect("failed to create renderer");
+    let tri_renderer = Triangler::new(ig_renderer.gl_context(), "#version 330");
+
+    let mut last_frame = Instant::now();
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = glutin::event_loop::ControlFlow::Wait;
+        match event {
+            glutin::event::Event::NewEvents(_) => {
+                let now = Instant::now();
+                imgui_context
+                    .io_mut()
+                    .update_delta_time(now.duration_since(last_frame));
+                last_frame = now;
+            }
+            glutin::event::Event::MainEventsCleared => {
+                winit_platform
+                    .prepare_frame(imgui_context.io_mut(), window.window())
+                    .unwrap();
+
+                window.window().request_redraw();
+            }
+            glutin::event::Event::RedrawRequested(_) => {
+                {
+                    let gl = ig_renderer.gl_context();
+                    // This is required because, without the `StateBackupCsm`
+                    // (which is provided by `auto_renderer` but not
+                    // `RendererBuilder` by default), the OpenGL context is left
+                    // in an arbitrary, dirty state
+                    unsafe { gl.disable(glow::SCISSOR_TEST) };
+                    tri_renderer.render(gl);
+                }
+
+                let ui = imgui_context.frame();
+                // Safety: internally, this reference just gets passed as a
+                // pointer to imgui, which handles the null pointer properly.
+                ui.show_demo_window(unsafe { &mut *std::ptr::null_mut() });
+
+                winit_platform.prepare_render(&ui, window.window());
+                let draw_data = ui.render();
+                ig_renderer
+                    .render(&draw_data)
+                    .expect("error rendering imgui");
+
+                window.swap_buffers().unwrap();
+            }
+            glutin::event::Event::WindowEvent {
+                event: glutin::event::WindowEvent::CloseRequested,
+                ..
+            } => {
+                *control_flow = glutin::event_loop::ControlFlow::Exit;
+            }
+            glutin::event::Event::LoopDestroyed => {
+                let gl = ig_renderer.gl_context();
+                tri_renderer.destroy(gl);
+            }
+            event => {
+                winit_platform.handle_event(imgui_context.io_mut(), window.window(), &event);
+            }
+        }
+    });
+}

--- a/imgui-glow-renderer/examples/02_triangle.rs
+++ b/imgui-glow-renderer/examples/02_triangle.rs
@@ -17,8 +17,7 @@ fn main() {
     let (mut winit_platform, mut imgui_context) = utils::imgui_init(&window);
     let gl = utils::glow_context(&window);
 
-    let mut ig_renderer = imgui_glow_renderer::RendererBuilder::new()
-        .build_owning(gl, &mut imgui_context)
+    let mut ig_renderer = imgui_glow_renderer::AutoRenderer::initialize(gl, &mut imgui_context)
         .expect("failed to create renderer");
     let tri_renderer = Triangler::new(ig_renderer.gl_context(), "#version 330");
 

--- a/imgui-glow-renderer/examples/02_triangle.rs
+++ b/imgui-glow-renderer/examples/02_triangle.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 use glow::HasContext;
 
-mod utils;
+pub mod utils;
 
 use utils::Triangler;
 

--- a/imgui-glow-renderer/examples/02_triangle.rs
+++ b/imgui-glow-renderer/examples/02_triangle.rs
@@ -1,8 +1,4 @@
-//! A basic example showing imgui rendering together with some custom rendering.
-//!
-//! Note this example uses `RendererBuilder` rather than `auto_renderer` and
-//! (because we're using the default "trivial" `ContextStateManager`)
-//! therefore does not attempt to backup/restore OpenGL state.
+//! A basic example showing imgui rendering on top of a simple custom scene.
 
 use std::time::Instant;
 
@@ -40,21 +36,17 @@ fn main() {
                 window.window().request_redraw();
             }
             glutin::event::Event::RedrawRequested(_) => {
-                {
-                    let gl = ig_renderer.gl_context();
-                    // This is required because, without the `StateBackupCsm`
-                    // (which is provided by `auto_renderer` but not
-                    // `RendererBuilder` by default), the OpenGL context is left
-                    // in an arbitrary, dirty state
-                    unsafe { gl.disable(glow::SCISSOR_TEST) };
-                    tri_renderer.render(gl);
-                }
+                // Render your custom scene, note we need to borrow the OpenGL
+                // context from the `AutoRenderer`, which takes ownership of it.
+                tri_renderer.render(ig_renderer.gl_context());
 
                 let ui = imgui_context.frame();
                 ui.show_demo_window(&mut true);
 
                 winit_platform.prepare_render(&ui, window.window());
                 let draw_data = ui.render();
+
+                // Render imgui on top of it
                 ig_renderer
                     .render(&draw_data)
                     .expect("error rendering imgui");

--- a/imgui-glow-renderer/examples/02_triangle.rs
+++ b/imgui-glow-renderer/examples/02_triangle.rs
@@ -52,9 +52,7 @@ fn main() {
                 }
 
                 let ui = imgui_context.frame();
-                // Safety: internally, this reference just gets passed as a
-                // pointer to imgui, which handles the null pointer properly.
-                ui.show_demo_window(unsafe { &mut *std::ptr::null_mut() });
+                ui.show_demo_window(&mut true);
 
                 winit_platform.prepare_render(&ui, window.window());
                 let draw_data = ui.render();

--- a/imgui-glow-renderer/examples/02_triangle.rs
+++ b/imgui-glow-renderer/examples/02_triangle.rs
@@ -46,7 +46,7 @@ fn main() {
 
                 // Render imgui on top of it
                 ig_renderer
-                    .render(&draw_data)
+                    .render(draw_data)
                     .expect("error rendering imgui");
 
                 window.swap_buffers().unwrap();

--- a/imgui-glow-renderer/examples/03_triangle_gles.rs
+++ b/imgui-glow-renderer/examples/03_triangle_gles.rs
@@ -6,7 +6,7 @@
 
 use std::time::Instant;
 
-mod utils;
+pub mod utils;
 
 use utils::Triangler;
 

--- a/imgui-glow-renderer/examples/03_triangle_gles.rs
+++ b/imgui-glow-renderer/examples/03_triangle_gles.rs
@@ -12,7 +12,7 @@ use utils::Triangler;
 
 fn main() {
     let (event_loop, window) = utils::create_window(
-        "Hello, triangle!",
+        "Hello, triangle! (GLES 3.0)",
         glutin::GlRequest::Specific(glutin::Api::OpenGlEs, (3, 0)),
     );
     let (mut winit_platform, mut imgui_context) = utils::imgui_init(&window);
@@ -23,7 +23,10 @@ fn main() {
         imgui_glow_renderer::Renderer::initialize(&gl, &mut imgui_context, &mut texture_map)
             .expect("failed to create renderer");
     // Note the shader header now needs a precision specifier
-    let tri_renderer = Triangler::new(&gl, "#version 300 es\nprecision mediump float;");
+    let tri_renderer = Triangler::new(
+        &gl,
+        "#version 300 es\nprecision mediump float;\n#define IS_GLES",
+    );
 
     let mut last_frame = Instant::now();
     event_loop.run(move |event, _, control_flow| {

--- a/imgui-glow-renderer/examples/03_triangle_gles.rs
+++ b/imgui-glow-renderer/examples/03_triangle_gles.rs
@@ -1,0 +1,79 @@
+//! A basic example showing imgui rendering together with some custom rendering
+//! using OpenGL ES, rather than full-fat OpenGL.
+//!
+//! Note this example uses `Renderer` rather than `OwningRenderer` and
+//! therefore requries more lifetime-management of the OpenGL context.
+
+use std::time::Instant;
+
+mod utils;
+
+use utils::Triangler;
+
+fn main() {
+    let (event_loop, window) = utils::create_window(
+        "Hello, triangle!",
+        glutin::GlRequest::Specific(glutin::Api::OpenGlEs, (3, 0)),
+    );
+    let (mut winit_platform, mut imgui_context) = utils::imgui_init(&window);
+    let gl = utils::glow_context(&window);
+
+    let mut ig_renderer = imgui_glow_renderer::RendererBuilder::new()
+        .with_context_state_manager(imgui_glow_renderer::StateBackupCsm::default())
+        .build_borrowing(&gl, &mut imgui_context)
+        .expect("failed to create renderer");
+    // Note the shader header now needs a precision specifier
+    let tri_renderer = Triangler::new(&gl, "#version 300 es\nprecision mediump float;");
+
+    let mut last_frame = Instant::now();
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = glutin::event_loop::ControlFlow::Wait;
+        match event {
+            glutin::event::Event::NewEvents(_) => {
+                let now = Instant::now();
+                imgui_context
+                    .io_mut()
+                    .update_delta_time(now.duration_since(last_frame));
+                last_frame = now;
+            }
+            glutin::event::Event::MainEventsCleared => {
+                winit_platform
+                    .prepare_frame(imgui_context.io_mut(), window.window())
+                    .unwrap();
+
+                window.window().request_redraw();
+            }
+            glutin::event::Event::RedrawRequested(_) => {
+                tri_renderer.render(&gl);
+
+                let ui = imgui_context.frame();
+                // Safety: internally, this reference just gets passed as a
+                // pointer to imgui, which handles the null pointer properly.
+                ui.show_demo_window(unsafe { &mut *std::ptr::null_mut() });
+
+                winit_platform.prepare_render(&ui, window.window());
+                let draw_data = ui.render();
+                ig_renderer
+                    .render(&gl, &draw_data)
+                    .expect("error rendering imgui");
+
+                window.swap_buffers().unwrap();
+            }
+            glutin::event::Event::WindowEvent {
+                event: glutin::event::WindowEvent::CloseRequested,
+                ..
+            } => {
+                *control_flow = glutin::event_loop::ControlFlow::Exit;
+            }
+            glutin::event::Event::LoopDestroyed => {
+                tri_renderer.destroy(&gl);
+                // Note, to be good citizens we should manually call destroy
+                // when the renderer does not own the GL context
+                ig_renderer.destroy(&gl);
+            }
+            event => {
+                winit_platform.handle_event(imgui_context.io_mut(), window.window(), &event);
+            }
+        }
+    });
+}

--- a/imgui-glow-renderer/examples/03_triangle_gles.rs
+++ b/imgui-glow-renderer/examples/03_triangle_gles.rs
@@ -6,7 +6,7 @@
 
 use std::time::Instant;
 
-pub mod utils;
+mod utils;
 
 use utils::Triangler;
 

--- a/imgui-glow-renderer/examples/03_triangle_gles.rs
+++ b/imgui-glow-renderer/examples/03_triangle_gles.rs
@@ -18,9 +18,10 @@ fn main() {
     let (mut winit_platform, mut imgui_context) = utils::imgui_init(&window);
     let gl = utils::glow_context(&window);
 
-    let mut ig_renderer = imgui_glow_renderer::RendererBuilder::new()
-        .build_borrowing(&gl, &mut imgui_context)
-        .expect("failed to create renderer");
+    let mut texture_map = imgui_glow_renderer::SimpleTextureMap::default();
+    let mut ig_renderer =
+        imgui_glow_renderer::Renderer::initialize(&gl, &mut imgui_context, &mut texture_map)
+            .expect("failed to create renderer");
     // Note the shader header now needs a precision specifier
     let tri_renderer = Triangler::new(&gl, "#version 300 es\nprecision mediump float;");
 
@@ -51,7 +52,7 @@ fn main() {
                 winit_platform.prepare_render(&ui, window.window());
                 let draw_data = ui.render();
                 ig_renderer
-                    .render(&gl, &draw_data)
+                    .render(&gl, &texture_map, &draw_data)
                     .expect("error rendering imgui");
 
                 window.swap_buffers().unwrap();

--- a/imgui-glow-renderer/examples/03_triangle_gles.rs
+++ b/imgui-glow-renderer/examples/03_triangle_gles.rs
@@ -47,9 +47,7 @@ fn main() {
                 tri_renderer.render(&gl);
 
                 let ui = imgui_context.frame();
-                // Safety: internally, this reference just gets passed as a
-                // pointer to imgui, which handles the null pointer properly.
-                ui.show_demo_window(unsafe { &mut *std::ptr::null_mut() });
+                ui.show_demo_window(&mut true);
 
                 winit_platform.prepare_render(&ui, window.window());
                 let draw_data = ui.render();

--- a/imgui-glow-renderer/examples/03_triangle_gles.rs
+++ b/imgui-glow-renderer/examples/03_triangle_gles.rs
@@ -19,7 +19,6 @@ fn main() {
     let gl = utils::glow_context(&window);
 
     let mut ig_renderer = imgui_glow_renderer::RendererBuilder::new()
-        .with_context_state_manager(imgui_glow_renderer::StateBackupCsm::default())
         .build_borrowing(&gl, &mut imgui_context)
         .expect("failed to create renderer");
     // Note the shader header now needs a precision specifier

--- a/imgui-glow-renderer/examples/03_triangle_gles.rs
+++ b/imgui-glow-renderer/examples/03_triangle_gles.rs
@@ -60,7 +60,7 @@ fn main() {
 
                 // Render imgui on top
                 ig_renderer
-                    .render(&gl, &texture_map, &draw_data)
+                    .render(&gl, &texture_map, draw_data)
                     .expect("error rendering imgui");
 
                 window.swap_buffers().unwrap();

--- a/imgui-glow-renderer/examples/04_custom_textures.rs
+++ b/imgui-glow-renderer/examples/04_custom_textures.rs
@@ -8,7 +8,8 @@ use image::{jpeg::JpegDecoder, ImageDecoder};
 use imgui::{im_str, Condition};
 use imgui_glow_renderer::RendererBuilder;
 
-pub mod utils;
+#[allow(dead_code)]
+mod utils;
 
 const LENNA_JPEG: &[u8] = include_bytes!("../../resources/Lenna.jpg");
 

--- a/imgui-glow-renderer/examples/04_custom_textures.rs
+++ b/imgui-glow-renderer/examples/04_custom_textures.rs
@@ -8,7 +8,7 @@ use image::{jpeg::JpegDecoder, ImageDecoder};
 use imgui::{im_str, Condition};
 use imgui_glow_renderer::{RendererBuilder, StateBackupCsm};
 
-mod utils;
+pub mod utils;
 
 const LENNA_JPEG: &[u8] = include_bytes!("../../resources/Lenna.jpg");
 

--- a/imgui-glow-renderer/examples/04_custom_textures.rs
+++ b/imgui-glow-renderer/examples/04_custom_textures.rs
@@ -262,7 +262,7 @@ impl Lenna {
             gl.tex_image_2d(
                 glow::TEXTURE_2D,
                 0,
-                glow::RGB as _,
+                glow::SRGB as _,
                 width as _,
                 height as _,
                 0,

--- a/imgui-glow-renderer/examples/04_custom_textures.rs
+++ b/imgui-glow-renderer/examples/04_custom_textures.rs
@@ -6,7 +6,7 @@ use std::{io::Cursor, time::Instant};
 use glow::HasContext;
 use image::{jpeg::JpegDecoder, ImageDecoder};
 use imgui::{im_str, Condition};
-use imgui_glow_renderer::{RendererBuilder, StateBackupCsm};
+use imgui_glow_renderer::RendererBuilder;
 
 pub mod utils;
 
@@ -18,7 +18,6 @@ fn main() {
     let gl = utils::glow_context(&window);
 
     let mut ig_renderer = RendererBuilder::new()
-        .with_context_state_manager(StateBackupCsm::default())
         .with_texture_map(imgui::Textures::<glow::Texture>::default())
         .build_borrowing(&gl, &mut imgui_context)
         .expect("failed to create renderer");

--- a/imgui-glow-renderer/examples/04_custom_textures.rs
+++ b/imgui-glow-renderer/examples/04_custom_textures.rs
@@ -6,7 +6,8 @@ use std::{io::Cursor, time::Instant};
 use glow::HasContext;
 use image::{jpeg::JpegDecoder, ImageDecoder};
 use imgui::{im_str, Condition};
-use imgui_glow_renderer::RendererBuilder;
+
+use imgui_glow_renderer::Renderer;
 
 #[allow(dead_code)]
 mod utils;
@@ -18,11 +19,10 @@ fn main() {
     let (mut winit_platform, mut imgui_context) = utils::imgui_init(&window);
     let gl = utils::glow_context(&window);
 
-    let mut ig_renderer = RendererBuilder::new()
-        .with_texture_map(imgui::Textures::<glow::Texture>::default())
-        .build_borrowing(&gl, &mut imgui_context)
+    let mut textures = imgui::Textures::<glow::Texture>::default();
+    let mut ig_renderer = Renderer::initialize(&gl, &mut imgui_context, &mut textures)
         .expect("failed to create renderer");
-    let textures_ui = TexturesUi::new(&gl, &mut ig_renderer.texture_map);
+    let textures_ui = TexturesUi::new(&gl, &mut textures);
 
     let mut last_frame = Instant::now();
     event_loop.run(move |event, _, control_flow| {
@@ -51,7 +51,7 @@ fn main() {
                 winit_platform.prepare_render(&ui, window.window());
                 let draw_data = ui.render();
                 ig_renderer
-                    .render(&gl, &draw_data)
+                    .render(&gl, &textures, &draw_data)
                     .expect("error rendering imgui");
 
                 window.swap_buffers().unwrap();

--- a/imgui-glow-renderer/examples/04_custom_textures.rs
+++ b/imgui-glow-renderer/examples/04_custom_textures.rs
@@ -1,0 +1,284 @@
+//! Example showing the same functionality as
+//! `imgui-examples/examples/custom_textures.rs`
+
+use std::{io::Cursor, time::Instant};
+
+use glow::HasContext;
+use image::{jpeg::JpegDecoder, ImageDecoder};
+use imgui::{im_str, Condition};
+use imgui_glow_renderer::{RendererBuilder, StateBackupCsm};
+
+mod utils;
+
+const LENNA_JPEG: &[u8] = include_bytes!("../../resources/Lenna.jpg");
+
+fn main() {
+    let (event_loop, window) = utils::create_window("Custom textures", glutin::GlRequest::Latest);
+    let (mut winit_platform, mut imgui_context) = utils::imgui_init(&window);
+    let gl = utils::glow_context(&window);
+
+    let mut ig_renderer = RendererBuilder::new()
+        .with_context_state_manager(StateBackupCsm::default())
+        .with_texture_map(imgui::Textures::<glow::Texture>::default())
+        .build_borrowing(&gl, &mut imgui_context)
+        .expect("failed to create renderer");
+    let textures_ui = TexturesUi::new(&gl, &mut ig_renderer.texture_map);
+
+    let mut last_frame = Instant::now();
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = glutin::event_loop::ControlFlow::Wait;
+        match event {
+            glutin::event::Event::NewEvents(_) => {
+                let now = Instant::now();
+                imgui_context
+                    .io_mut()
+                    .update_delta_time(now.duration_since(last_frame));
+                last_frame = now;
+            }
+            glutin::event::Event::MainEventsCleared => {
+                winit_platform
+                    .prepare_frame(imgui_context.io_mut(), window.window())
+                    .unwrap();
+
+                window.window().request_redraw();
+            }
+            glutin::event::Event::RedrawRequested(_) => {
+                unsafe { gl.clear(glow::COLOR_BUFFER_BIT) };
+
+                let ui = imgui_context.frame();
+                textures_ui.show(&ui);
+
+                winit_platform.prepare_render(&ui, window.window());
+                let draw_data = ui.render();
+                ig_renderer
+                    .render(&gl, &draw_data)
+                    .expect("error rendering imgui");
+
+                window.swap_buffers().unwrap();
+            }
+            glutin::event::Event::WindowEvent {
+                event: glutin::event::WindowEvent::CloseRequested,
+                ..
+            } => {
+                *control_flow = glutin::event_loop::ControlFlow::Exit;
+            }
+            glutin::event::Event::LoopDestroyed => {
+                ig_renderer.destroy(&gl);
+            }
+            event => {
+                winit_platform.handle_event(imgui_context.io_mut(), window.window(), &event);
+            }
+        }
+    });
+}
+
+struct TexturesUi {
+    generated_texture: imgui::TextureId,
+    lenna: Lenna,
+}
+
+impl TexturesUi {
+    fn new(gl: &glow::Context, textures: &mut imgui::Textures<glow::Texture>) -> Self {
+        Self {
+            generated_texture: Self::generate(gl, textures),
+            lenna: Lenna::load(gl, textures),
+        }
+    }
+
+    /// Generate dummy texture
+    fn generate(
+        gl: &glow::Context,
+        textures: &mut imgui::Textures<glow::Texture>,
+    ) -> imgui::TextureId {
+        const WIDTH: usize = 100;
+        const HEIGHT: usize = 100;
+
+        let mut data = Vec::with_capacity(WIDTH * HEIGHT);
+        for i in 0..WIDTH {
+            for j in 0..HEIGHT {
+                // Insert RGB values
+                data.push(i as u8);
+                data.push(j as u8);
+                data.push((i + j) as u8);
+            }
+        }
+
+        let gl_texture = unsafe { gl.create_texture() }.expect("unable to create GL texture");
+
+        unsafe {
+            gl.bind_texture(glow::TEXTURE_2D, Some(gl_texture));
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MIN_FILTER,
+                glow::LINEAR as _,
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MAG_FILTER,
+                glow::LINEAR as _,
+            );
+            gl.tex_image_2d(
+                glow::TEXTURE_2D,
+                0,
+                glow::RGB as _,
+                WIDTH as _,
+                HEIGHT as _,
+                0,
+                glow::RGB,
+                glow::UNSIGNED_BYTE,
+                Some(&data),
+            )
+        }
+
+        textures.insert(gl_texture)
+    }
+
+    fn show(&self, ui: &imgui::Ui) {
+        imgui::Window::new(im_str!("Hello textures"))
+            .size([400.0, 400.0], Condition::FirstUseEver)
+            .build(ui, || {
+                ui.text(im_str!("Hello textures!"));
+                ui.text("Some generated texture");
+                imgui::Image::new(self.generated_texture, [100.0, 100.0]).build(ui);
+
+                ui.text("Say hello to Lenna.jpg");
+                self.lenna.show(ui);
+
+                // Example of using custom textures on a button
+                ui.text("The Lenna buttons");
+                {
+                    ui.invisible_button(im_str!("Boring Button"), [100.0, 100.0]);
+                    // See also `imgui::Ui::style_color`
+                    let tint_none = [1.0, 1.0, 1.0, 1.0];
+                    let tint_green = [0.5, 1.0, 0.5, 1.0];
+                    let tint_red = [1.0, 0.5, 0.5, 1.0];
+
+                    let tint = match (
+                        ui.is_item_hovered(),
+                        ui.is_mouse_down(imgui::MouseButton::Left),
+                    ) {
+                        (false, _) => tint_none,
+                        (true, false) => tint_green,
+                        (true, true) => tint_red,
+                    };
+
+                    let draw_list = ui.get_window_draw_list();
+                    draw_list
+                        .add_image(
+                            self.lenna.texture_id,
+                            ui.item_rect_min(),
+                            ui.item_rect_max(),
+                        )
+                        .col(tint)
+                        .build();
+                }
+
+                {
+                    ui.same_line();
+
+                    // Button using quad positioned image
+                    ui.invisible_button(im_str!("Exciting Button"), [100.0, 100.0]);
+
+                    // Button bounds
+                    let min = ui.item_rect_min();
+                    let max = ui.item_rect_max();
+
+                    // get corner coordinates
+                    let tl = [
+                        min[0],
+                        min[1] + (ui.frame_count() as f32 / 10.0).cos() * 10.0,
+                    ];
+                    let tr = [
+                        max[0],
+                        min[1] + (ui.frame_count() as f32 / 10.0).sin() * 10.0,
+                    ];
+                    let bl = [min[0], max[1]];
+                    let br = max;
+
+                    let draw_list = ui.get_window_draw_list();
+                    draw_list
+                        .add_image_quad(self.lenna.texture_id, tl, tr, br, bl)
+                        .build();
+                }
+
+                // Rounded image
+                {
+                    ui.same_line();
+                    ui.invisible_button(im_str!("Smooth Button"), [100.0, 100.0]);
+
+                    let draw_list = ui.get_window_draw_list();
+                    draw_list
+                        .add_image_rounded(
+                            self.lenna.texture_id,
+                            ui.item_rect_min(),
+                            ui.item_rect_max(),
+                            16.0,
+                        )
+                        // Tint brighter for visiblity of corners
+                        .col([2.0, 0.5, 0.5, 1.0])
+                        // Rounding on each corner can be changed separately
+                        .round_top_left(ui.frame_count() / 60 % 4 == 0)
+                        .round_top_right((ui.frame_count() + 1) / 60 % 4 == 1)
+                        .round_bot_right((ui.frame_count() + 3) / 60 % 4 == 2)
+                        .round_bot_left((ui.frame_count() + 2) / 60 % 4 == 3)
+                        .build();
+                }
+            });
+    }
+}
+
+struct Lenna {
+    texture_id: imgui::TextureId,
+    size: [f32; 2],
+}
+
+impl Lenna {
+    fn load(gl: &glow::Context, textures: &mut imgui::Textures<glow::Texture>) -> Self {
+        let decoder = JpegDecoder::new(Cursor::new(LENNA_JPEG)).expect("could not create decoder");
+        let (width, height) = decoder.dimensions();
+
+        let lenna_image = {
+            let mut bytes = vec![0; decoder.total_bytes() as usize];
+            decoder
+                .read_image(&mut bytes)
+                .expect("unable to decode jpeg");
+            bytes
+        };
+
+        let gl_texture = unsafe { gl.create_texture() }.expect("unable to create GL texture");
+
+        unsafe {
+            gl.bind_texture(glow::TEXTURE_2D, Some(gl_texture));
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MIN_FILTER,
+                glow::LINEAR as _,
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MAG_FILTER,
+                glow::LINEAR as _,
+            );
+            gl.tex_image_2d(
+                glow::TEXTURE_2D,
+                0,
+                glow::RGB as _,
+                width as _,
+                height as _,
+                0,
+                glow::RGB,
+                glow::UNSIGNED_BYTE,
+                Some(&lenna_image),
+            )
+        }
+
+        Self {
+            texture_id: textures.insert(gl_texture),
+            size: [width as _, height as _],
+        }
+    }
+
+    fn show(&self, ui: &imgui::Ui) {
+        imgui::Image::new(self.texture_id, self.size).build(ui);
+    }
+}

--- a/imgui-glow-renderer/examples/04_custom_textures.rs
+++ b/imgui-glow-renderer/examples/04_custom_textures.rs
@@ -61,7 +61,7 @@ fn main() {
                 winit_platform.prepare_render(&ui, window.window());
                 let draw_data = ui.render();
                 ig_renderer
-                    .render(&gl, &textures, &draw_data)
+                    .render(&gl, &textures, draw_data)
                     .expect("error rendering imgui");
 
                 window.swap_buffers().unwrap();

--- a/imgui-glow-renderer/examples/basic.rs
+++ b/imgui-glow-renderer/examples/basic.rs
@@ -1,0 +1,116 @@
+//! A basic self-contained example to get you from zero-to-demo-window as fast
+//! as possible.
+
+use std::time::Instant;
+
+use glow::HasContext;
+use glutin::{event_loop::EventLoop, WindowedContext};
+use imgui_winit_support::WinitPlatform;
+
+const TITLE: &str = "Hello, imgui-rs!";
+
+type Window = WindowedContext<glutin::PossiblyCurrent>;
+
+fn main() {
+    // Common setup for creating a winit window and imgui context, not specifc
+    // to this renderer at all ecept that glutin is used to create the window
+    // since it will give us access to a GL context
+    let (event_loop, window) = create_window();
+    let (mut winit_platform, mut imgui_context) = imgui_init(&window);
+
+    // OpenGL context from glow
+    let gl = glow_context(&window);
+    unsafe { gl.clear_color(0.05, 0.05, 0.1, 1.0) };
+
+    // OpenGL renderer from this crate
+    let mut ig_renderer = imgui_glow_renderer::auto_renderer(gl, &mut imgui_context)
+        .expect("failed to create renderer");
+
+    // Standard winit event loop
+    let mut last_frame = Instant::now();
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = glutin::event_loop::ControlFlow::Wait;
+        match event {
+            glutin::event::Event::NewEvents(_) => {
+                let now = Instant::now();
+                imgui_context
+                    .io_mut()
+                    .update_delta_time(now.duration_since(last_frame));
+                last_frame = now;
+            }
+            glutin::event::Event::MainEventsCleared => {
+                winit_platform
+                    .prepare_frame(imgui_context.io_mut(), window.window())
+                    .unwrap();
+                window.window().request_redraw();
+            }
+            glutin::event::Event::RedrawRequested(_) => {
+                // The renderer assumes you'll be clearing the buffer yourself
+                unsafe { ig_renderer.gl_context().clear(glow::COLOR_BUFFER_BIT) };
+
+                let ui = imgui_context.frame();
+                ui.show_demo_window(&mut true);
+
+                winit_platform.prepare_render(&ui, window.window());
+                let draw_data = ui.render();
+
+                // This is the only extra render step to add
+                ig_renderer
+                    .render(&draw_data)
+                    .expect("error rendering imgui");
+
+                window.swap_buffers().unwrap();
+            }
+            glutin::event::Event::WindowEvent {
+                event: glutin::event::WindowEvent::CloseRequested,
+                ..
+            } => {
+                *control_flow = glutin::event_loop::ControlFlow::Exit;
+            }
+            event => {
+                winit_platform.handle_event(imgui_context.io_mut(), window.window(), &event);
+            }
+        }
+    });
+}
+
+fn create_window() -> (EventLoop<()>, Window) {
+    let event_loop = glutin::event_loop::EventLoop::new();
+    let window = glutin::window::WindowBuilder::new()
+        .with_title(TITLE)
+        .with_inner_size(glutin::dpi::LogicalSize::new(1024, 768));
+    let window = glutin::ContextBuilder::new()
+        .with_vsync(true)
+        .build_windowed(window, &event_loop)
+        .expect("could not create window");
+    let window = unsafe {
+        window
+            .make_current()
+            .expect("could not make window context current")
+    };
+    (event_loop, window)
+}
+
+fn glow_context(window: &Window) -> glow::Context {
+    unsafe { glow::Context::from_loader_function(|s| window.get_proc_address(s).cast()) }
+}
+
+fn imgui_init(window: &Window) -> (WinitPlatform, imgui::Context) {
+    let mut imgui_context = imgui::Context::create();
+    imgui_context.set_ini_filename(None);
+
+    let mut winit_platform = WinitPlatform::init(&mut imgui_context);
+    winit_platform.attach_window(
+        imgui_context.io_mut(),
+        window.window(),
+        imgui_winit_support::HiDpiMode::Rounded,
+    );
+
+    imgui_context
+        .fonts()
+        .add_font(&[imgui::FontSource::DefaultFontData { config: None }]);
+
+    imgui_context.io_mut().font_global_scale = (1.0 / winit_platform.hidpi_factor()) as f32;
+
+    (winit_platform, imgui_context)
+}

--- a/imgui-glow-renderer/examples/basic.rs
+++ b/imgui-glow-renderer/examples/basic.rs
@@ -20,7 +20,6 @@ fn main() {
 
     // OpenGL context from glow
     let gl = glow_context(&window);
-    unsafe { gl.clear_color(0.05, 0.05, 0.1, 1.0) };
 
     // OpenGL renderer from this crate
     let mut ig_renderer = imgui_glow_renderer::auto_renderer(gl, &mut imgui_context)
@@ -31,13 +30,6 @@ fn main() {
     event_loop.run(move |event, _, control_flow| {
         *control_flow = glutin::event_loop::ControlFlow::Wait;
         match event {
-            glutin::event::Event::NewEvents(_) => {
-                let now = Instant::now();
-                imgui_context
-                    .io_mut()
-                    .update_delta_time(now.duration_since(last_frame));
-                last_frame = now;
-            }
             glutin::event::Event::MainEventsCleared => {
                 winit_platform
                     .prepare_frame(imgui_context.io_mut(), window.window())

--- a/imgui-glow-renderer/examples/utils/mod.rs
+++ b/imgui-glow-renderer/examples/utils/mod.rs
@@ -1,0 +1,135 @@
+use glow::HasContext;
+use glutin::{event_loop::EventLoop, GlRequest};
+use imgui_winit_support::WinitPlatform;
+
+pub type Window = glutin::WindowedContext<glutin::PossiblyCurrent>;
+
+pub fn create_window(title: &str, gl_request: GlRequest) -> (EventLoop<()>, Window) {
+    let event_loop = glutin::event_loop::EventLoop::new();
+    let window = glutin::window::WindowBuilder::new()
+        .with_title(title)
+        .with_inner_size(glutin::dpi::LogicalSize::new(1024, 768));
+    let window = glutin::ContextBuilder::new()
+        .with_gl(gl_request)
+        .with_vsync(true)
+        .build_windowed(window, &event_loop)
+        .expect("could not create window");
+    let window = unsafe {
+        window
+            .make_current()
+            .expect("could not make window context current")
+    };
+    (event_loop, window)
+}
+
+pub fn glow_context(window: &Window) -> glow::Context {
+    unsafe { glow::Context::from_loader_function(|s| window.get_proc_address(s).cast()) }
+}
+
+pub fn imgui_init(window: &Window) -> (WinitPlatform, imgui::Context) {
+    let mut imgui_context = imgui::Context::create();
+    imgui_context.set_ini_filename(None);
+
+    let mut winit_platform = WinitPlatform::init(&mut imgui_context);
+    winit_platform.attach_window(
+        imgui_context.io_mut(),
+        window.window(),
+        imgui_winit_support::HiDpiMode::Rounded,
+    );
+
+    imgui_context
+        .fonts()
+        .add_font(&[imgui::FontSource::DefaultFontData { config: None }]);
+
+    imgui_context.io_mut().font_global_scale = (1.0 / winit_platform.hidpi_factor()) as f32;
+
+    (winit_platform, imgui_context)
+}
+
+pub struct Triangler {
+    pub program: <glow::Context as HasContext>::Program,
+    pub vertex_array: <glow::Context as HasContext>::VertexArray,
+}
+
+impl Triangler {
+    pub fn new(gl: &glow::Context, shader_header: &str) -> Self {
+        const VERTEX_SHADER_SOURCE: &str = r#"
+const vec2 verts[3] = vec2[3](
+    vec2(0.5f, 1.0f),
+    vec2(0.0f, 0.0f),
+    vec2(1.0f, 0.0f)
+);
+
+out vec2 vert;
+
+void main() {
+    vert = verts[gl_VertexID];
+    gl_Position = vec4(vert - 0.5, 0.0, 1.0);
+}
+"#;
+        const FRAGMENT_SHADER_SOURCE: &str = r#"
+in vec2 vert;
+out vec4 colour;
+
+void main() {
+    colour = vec4(vert, 0.5, 1.0);
+}
+"#;
+
+        let mut shaders = [
+            (glow::VERTEX_SHADER, VERTEX_SHADER_SOURCE, 0),
+            (glow::FRAGMENT_SHADER, FRAGMENT_SHADER_SOURCE, 0),
+        ];
+
+        unsafe {
+            let vertex_array = gl
+                .create_vertex_array()
+                .expect("Cannot create vertex array");
+
+            let program = gl.create_program().expect("Cannot create program");
+
+            for (kind, source, handle) in &mut shaders {
+                let shader = gl.create_shader(*kind).expect("Cannot create shader");
+                gl.shader_source(shader, &format!("{}\n{}", shader_header, *source));
+                gl.compile_shader(shader);
+                if !gl.get_shader_compile_status(shader) {
+                    panic!("{}", gl.get_shader_info_log(shader));
+                }
+                gl.attach_shader(program, shader);
+                *handle = shader;
+            }
+
+            gl.link_program(program);
+            if !gl.get_program_link_status(program) {
+                panic!("{}", gl.get_program_info_log(program));
+            }
+
+            for &(_, _, shader) in &shaders {
+                gl.detach_shader(program, shader);
+                gl.delete_shader(shader);
+            }
+
+            Self {
+                program,
+                vertex_array,
+            }
+        }
+    }
+
+    pub fn render(&self, gl: &glow::Context) {
+        unsafe {
+            gl.clear_color(0.05, 0.05, 0.1, 1.0);
+            gl.clear(glow::COLOR_BUFFER_BIT);
+            gl.use_program(Some(self.program));
+            gl.bind_vertex_array(Some(self.vertex_array));
+            gl.draw_arrays(glow::TRIANGLES, 0, 3);
+        }
+    }
+
+    pub fn destroy(&self, gl: &glow::Context) {
+        unsafe {
+            gl.delete_program(self.program);
+            gl.delete_vertex_array(self.vertex_array);
+        }
+    }
+}

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -164,17 +164,19 @@ impl<G: Gl> Renderer<G> {
     ///
     /// `output_srgb` controls whether the shader outputs sRGB colors, or linear
     /// RGB colors. In short:
-    /// - If you're outputting to the screen and haven't specified the framebuffer
+    /// - If you're outputting to a display and haven't specified the framebuffer
     ///   is sRGB (e.g. with `gl.enable(glow::FRAMEBUFFER_SRGB)`), then you probably
     ///   want `output_srgb=true`.
-    /// - If you're outputting to a screen with an sRGB framebuffer (e.g. with
+    /// - OpenGL ES doesn't support sRGB framebuffers, so you almost always
+    ///   want `output_srgb=true` if you're using OpenGL ES and you're outputting
+    ///   to a display.
+    /// - If you're outputting to a display with an sRGB framebuffer (e.g. with
     ///   `gl.enable(glow::FRAMEBUFFER_SRGB)`), then you probably want
     ///   `output_srgb=false`, as OpenGL will convert to sRGB itself.
-    /// - If you're not outputting to some intermediate framebuffer, then you
-    ///   probably want `output_srgb=false` to keep the colours in linear
-    ///   color space, and then convert them to sRGB at some later stage.
-    /// - OpenGL ES doesn't support sRGB framebuffers, so you almost always
-    ///   want `output_srgb=true`.
+    /// - If you're not outputting to a display, but instead to some intermediate
+    ///   framebuffer, then you probably want `output_srgb=false` to keep the
+    ///   colors in linear color space, and then convert them to sRGB at some
+    ///   later stage.
     ///
     /// # Errors
     /// Any error initialising the OpenGL objects (including shaders) will

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -605,6 +605,7 @@ pub trait TextureMap {
     fn gl_texture(&self, imgui_texture: imgui::TextureId) -> Option<glow::Texture>;
 }
 
+#[derive(Default)]
 pub struct TrivialTextureMap();
 
 impl TextureMap for TrivialTextureMap {
@@ -646,6 +647,7 @@ pub trait ContextStateManager<G: Gl> {
     fn post_destroy(&mut self, gl: &G, gl_version: GlVersion) {}
 }
 
+#[derive(Default)]
 pub struct TrivialCsm();
 
 impl<G: Gl> ContextStateManager<G> for TrivialCsm {}

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -1,0 +1,1269 @@
+use std::{borrow::Cow, error::Error, fmt::Display, marker::PhantomData, mem::size_of};
+
+use imgui::{internal::RawWrapper, TextureId};
+
+use crate::versions::{GlVersion, GlslVersion};
+
+pub mod versions;
+
+// TODO: document all the things!
+
+// This may be generics overkill, but I have to assume there's some reason that
+// `glow` hid the functions of `Context` behind the `HasContext` trait. The
+// specified types I require here are necessary because otherwise I can't
+// perform the required initialisations or conversions in the code below. In
+// any case, the OpenGL standard specifies these types, so there should be no
+// loss of generality.
+pub trait Gl:
+    glow::HasContext<
+    Texture = glow::Texture,
+    UniformLocation = glow::UniformLocation,
+    Program = glow::Program,
+    Buffer = glow::Buffer,
+    Sampler = glow::Sampler,
+    VertexArray = glow::VertexArray,
+>
+{
+}
+impl<
+        G: glow::HasContext<
+            Texture = glow::Texture,
+            UniformLocation = glow::UniformLocation,
+            Program = glow::Program,
+            Buffer = glow::Buffer,
+            Sampler = glow::Sampler,
+            VertexArray = glow::VertexArray,
+        >,
+    > Gl for G
+{
+}
+
+/// Convenience function to get you going quickly. In most larger programs
+/// you probably want to take more control (including ownership of the GL
+/// context). In those cases, construct an appropriate renderer with
+/// `RendererBuilder`.
+pub fn auto_renderer<G: Gl>(
+    gl: G,
+    imgui_context: &mut imgui::Context,
+) -> Result<OwningRenderer<G, TrivialTextureMap, AutoShaderProvider<G>, StateBackupCsm>, InitError>
+{
+    RendererBuilder::new()
+        .with_context_state_manager(StateBackupCsm::default())
+        .build_owning(gl, imgui_context)
+}
+
+pub struct RendererBuilder<G, T, S, C>
+where
+    G: Gl,
+    T: TextureMap,
+    S: ShaderProvider<G>,
+    C: ContextStateManager<G>,
+{
+    texture_map: T,
+    shader_provider: S,
+    context_state_manager: C,
+    phantom_gl: PhantomData<G>,
+}
+
+impl<G: Gl> RendererBuilder<G, TrivialTextureMap, AutoShaderProvider<G>, TrivialCsm> {
+    #[allow(clippy::new_without_default)]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            texture_map: TrivialTextureMap(),
+            shader_provider: <AutoShaderProvider<G> as Default>::default(),
+            context_state_manager: TrivialCsm(),
+            phantom_gl: PhantomData::default(),
+        }
+    }
+}
+
+impl<G, T, S, C> RendererBuilder<G, T, S, C>
+where
+    G: Gl,
+    T: TextureMap,
+    S: ShaderProvider<G>,
+    C: ContextStateManager<G>,
+{
+    pub fn with_texture_map<T2: TextureMap>(self, texture_map: T2) -> RendererBuilder<G, T2, S, C> {
+        RendererBuilder {
+            texture_map,
+            shader_provider: self.shader_provider,
+            context_state_manager: self.context_state_manager,
+            phantom_gl: self.phantom_gl,
+        }
+    }
+
+    pub fn with_shader_provider<S2: ShaderProvider<G>>(
+        self,
+        shader_provider: S2,
+    ) -> RendererBuilder<G, T, S2, C> {
+        RendererBuilder {
+            texture_map: self.texture_map,
+            shader_provider,
+            context_state_manager: self.context_state_manager,
+            phantom_gl: self.phantom_gl,
+        }
+    }
+
+    pub fn with_context_state_manager<C2: ContextStateManager<G>>(
+        self,
+        context_state_manager: C2,
+    ) -> RendererBuilder<G, T, S, C2> {
+        RendererBuilder {
+            texture_map: self.texture_map,
+            shader_provider: self.shader_provider,
+            context_state_manager,
+            phantom_gl: self.phantom_gl,
+        }
+    }
+
+    pub fn build_owning(
+        self,
+        gl: G,
+        imgui_context: &mut imgui::Context,
+    ) -> Result<OwningRenderer<G, T, S, C>, InitError> {
+        let renderer = self.build_borrowing(&gl, imgui_context)?;
+        Ok(OwningRenderer::<G, T, S, C> { gl, renderer })
+    }
+
+    pub fn build_borrowing(
+        self,
+        gl: &G,
+        imgui_context: &mut imgui::Context,
+    ) -> Result<Renderer<G, T, S, C>, InitError> {
+        Renderer::<G, T, S, C>::initialize(
+            gl,
+            imgui_context,
+            self.texture_map,
+            self.shader_provider,
+            self.context_state_manager,
+        )
+    }
+}
+
+// TODO: builder pattern
+/// Renderer which owns the OpenGL context. Useful for simple applications, but
+/// more complicated applications may prefer to keep control of their own
+/// OpenGL context, or even change that context at runtime.
+///
+/// OpenGL context is still available to the rest of the application through
+/// the `gl_context` method.
+pub struct OwningRenderer<G, T = TrivialTextureMap, S = AutoShaderProvider<G>, C = TrivialCsm>
+where
+    G: Gl,
+    T: TextureMap,
+    S: ShaderProvider<G>,
+    C: ContextStateManager<G>,
+{
+    gl: G,
+    renderer: Renderer<G, T, S, C>,
+}
+
+impl<G, T, S, C> OwningRenderer<G, T, S, C>
+where
+    G: Gl,
+    T: TextureMap,
+    S: ShaderProvider<G>,
+    C: ContextStateManager<G>,
+{
+    /// Note: no need to provide a `mut` version of this, as all methods on
+    /// `glow::HasContext` are immutable.
+    #[inline]
+    pub fn gl_context(&self) -> &G {
+        &self.gl
+    }
+
+    #[inline]
+    pub fn renderer(&self) -> &Renderer<G, T, S, C> {
+        &self.renderer
+    }
+
+    /// # Errors
+    /// Some OpenGL errors trigger an error (few are explicitly checked,
+    /// however)
+    #[inline]
+    pub fn render(&mut self, draw_data: &imgui::DrawData) -> Result<(), RenderError> {
+        self.renderer.render(&self.gl, draw_data)
+    }
+}
+
+impl<G, T, S, C> Drop for OwningRenderer<G, T, S, C>
+where
+    G: Gl,
+    T: TextureMap,
+    S: ShaderProvider<G>,
+    C: ContextStateManager<G>,
+{
+    fn drop(&mut self) {
+        self.renderer.destroy(&self.gl);
+    }
+}
+
+pub struct Renderer<G, T = TrivialTextureMap, S = AutoShaderProvider<G>, C = TrivialCsm>
+where
+    G: Gl,
+    T: TextureMap,
+    S: ShaderProvider<G>,
+    C: ContextStateManager<G>,
+{
+    pub texture_map: T,
+    pub shader_provider: S,
+    pub context_state_manager: C,
+    pub vbo_handle: G::Buffer,
+    pub ebo_handle: G::Buffer,
+    pub font_atlas_texture: G::Texture,
+    #[cfg(feature = "bind_vertex_array_support")]
+    pub vertex_array_object: G::VertexArray,
+    pub gl_version: GlVersion,
+    pub has_clip_origin_support: bool,
+    pub is_destroyed: bool,
+}
+
+impl<G, T, S, C> Renderer<G, T, S, C>
+where
+    G: Gl,
+    T: TextureMap,
+    S: ShaderProvider<G>,
+    C: ContextStateManager<G>,
+{
+    /// # Errors
+    /// Any error initialising the OpenGL objects (including shaders) will
+    /// result in an error.
+    pub fn initialize(
+        gl: &G,
+        imgui_context: &mut imgui::Context,
+        texture_map: T,
+        shader_provider: S,
+        context_state_manager: C,
+    ) -> Result<Self, InitError> {
+        #![allow(
+            clippy::similar_names,
+            clippy::cast_sign_loss,
+            clippy::shadow_unrelated
+        )]
+
+        let gl_version = GlVersion::read(gl);
+
+        #[cfg(feature = "clip_origin_support")]
+        let has_clip_origin_support = {
+            let support = gl_version.clip_origin_support();
+
+            #[cfg(feature = "gl_extensions_support")]
+            if support {
+                support
+            } else {
+                let extensions_count = unsafe { gl.get_parameter_i32(glow::NUM_EXTENSIONS) } as u32;
+                (0..extensions_count).any(|index| {
+                    let extension_name =
+                        unsafe { gl.get_parameter_indexed_string(glow::EXTENSIONS, index) };
+                    extension_name == "GL_ARB_clip_control"
+                })
+            }
+            #[cfg(not(feature = "gl_extensions_support"))]
+            support
+        };
+        #[cfg(not(feature = "clip_origin_support"))]
+        let has_clip_origin_support = false;
+
+        let mut context_state_manager = context_state_manager;
+        context_state_manager.pre_init(gl, gl_version)?;
+
+        let font_atlas_texture = prepare_font_atlas(gl, imgui_context.fonts())?;
+
+        let mut shader_provider = shader_provider;
+        shader_provider.initialize(gl, gl_version)?;
+        let vbo_handle = unsafe { gl.create_buffer() }.map_err(InitError::CreateBufferObject)?;
+        let ebo_handle = unsafe { gl.create_buffer() }.map_err(InitError::CreateBufferObject)?;
+
+        context_state_manager.post_init(gl, gl_version)?;
+
+        let out = Self {
+            texture_map,
+            shader_provider,
+            context_state_manager,
+            vbo_handle,
+            ebo_handle,
+            font_atlas_texture,
+            #[cfg(feature = "bind_vertex_array_support")]
+            vertex_array_object: 0,
+            gl_version,
+            has_clip_origin_support,
+            is_destroyed: false,
+        };
+
+        // Leave this until the end of the function to avoid changing state if
+        // there was ever an error above
+        out.configure_imgui_context(imgui_context);
+
+        Ok(out)
+    }
+
+    pub fn destroy(&mut self, gl: &G) {
+        if self.is_destroyed {
+            return;
+        }
+
+        let gl_version = self.gl_version;
+        self.context_state_manager.pre_destroy(gl, gl_version);
+
+        if self.vbo_handle != 0 {
+            unsafe { gl.delete_buffer(self.vbo_handle) };
+            self.vbo_handle = 0;
+        }
+        if self.ebo_handle != 0 {
+            unsafe { gl.delete_buffer(self.vbo_handle) };
+            self.ebo_handle = 0;
+        }
+        let program = self.shader_provider.data().program;
+        if program != 0 {
+            unsafe { gl.delete_program(program) };
+        }
+        if self.font_atlas_texture != 0 {
+            unsafe { gl.delete_texture(self.font_atlas_texture) };
+            self.font_atlas_texture = 0;
+        }
+
+        self.context_state_manager.post_destroy(gl, gl_version);
+
+        self.is_destroyed = true;
+    }
+
+    /// # Errors
+    /// Some OpenGL errors trigger an error (few are explicitly checked,
+    /// however)
+    pub fn render(&mut self, gl: &G, draw_data: &imgui::DrawData) -> Result<(), RenderError> {
+        if self.is_destroyed {
+            return Err(Self::renderer_destroyed());
+        }
+
+        let fb_width = draw_data.display_size[0] * draw_data.framebuffer_scale[0];
+        let fb_height = draw_data.display_size[1] * draw_data.framebuffer_scale[1];
+        if !(fb_width > 0.0 && fb_height > 0.0) {
+            return Ok(());
+        }
+
+        gl_debug_message(gl, "imgui-rs-glow: start render");
+        self.context_state_manager.pre_render(gl, self.gl_version)?;
+
+        self.set_up_render_state(gl, draw_data, fb_width, fb_height)?;
+
+        gl_debug_message(gl, "start loop over draw lists");
+        for draw_list in draw_data.draw_lists() {
+            unsafe {
+                gl.buffer_data_u8_slice(
+                    glow::ARRAY_BUFFER,
+                    to_byte_slice(draw_list.vtx_buffer()),
+                    glow::STREAM_DRAW,
+                );
+                gl.buffer_data_u8_slice(
+                    glow::ELEMENT_ARRAY_BUFFER,
+                    to_byte_slice(draw_list.idx_buffer()),
+                    glow::STREAM_DRAW,
+                );
+            }
+
+            gl_debug_message(gl, "start loop over commands");
+            for command in draw_list.commands() {
+                match command {
+                    imgui::DrawCmd::Elements { count, cmd_params } => {
+                        self.render_elements(gl, count, cmd_params, draw_data, fb_width, fb_height)
+                    }
+                    imgui::DrawCmd::RawCallback { callback, raw_cmd } => unsafe {
+                        callback(draw_list.raw(), raw_cmd)
+                    },
+                    imgui::DrawCmd::ResetRenderState => {
+                        self.set_up_render_state(gl, draw_data, fb_width, fb_height)?
+                    }
+                }
+            }
+        }
+
+        #[cfg(feature = "bind_vertex_array_support")]
+        if self.gl_version.bind_vertex_array_support() {
+            unsafe { gl.delete_vertex_array(self.vertex_array_object) };
+        }
+
+        self.context_state_manager
+            .post_render(gl, self.gl_version)?;
+        gl_debug_message(gl, "imgui-rs-glow: complete render");
+        Ok(())
+    }
+
+    /// # Errors
+    /// Few GL calls are checked for errors, but any that are found will result
+    /// in an error. Errors from the state manager lifecycle callbacks will also
+    /// result in an error.
+    pub fn set_up_render_state(
+        &mut self,
+        gl: &G,
+        draw_data: &imgui::DrawData,
+        fb_width: f32,
+        fb_height: f32,
+    ) -> Result<(), RenderError> {
+        #![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
+        if self.is_destroyed {
+            return Err(Self::renderer_destroyed());
+        }
+
+        self.context_state_manager
+            .pre_setup_render(gl, self.gl_version)?;
+
+        unsafe {
+            gl.active_texture(glow::TEXTURE0);
+            gl.enable(glow::BLEND);
+            gl.blend_equation(glow::FUNC_ADD);
+            gl.blend_func_separate(
+                glow::SRC_ALPHA,
+                glow::ONE_MINUS_SRC_ALPHA,
+                glow::ONE,
+                glow::ONE_MINUS_SRC_ALPHA,
+            );
+            gl.disable(glow::CULL_FACE);
+            gl.disable(glow::DEPTH_TEST);
+            gl.disable(glow::STENCIL_TEST);
+            gl.enable(glow::SCISSOR_TEST);
+
+            #[cfg(feature = "primitive_restart_support")]
+            if self.gl_version.primitive_restart_support() {
+                gl.disable(glow::PRIMITIVE_RESTART);
+            }
+
+            #[cfg(feature = "polygon_mode_support")]
+            if self.gl_version.polygon_mode_support() {
+                gl.polygon_mode(glow::FRONT_AND_BACK, glow::FILL);
+            }
+
+            gl.viewport(0, 0, fb_width as _, fb_height as _);
+        }
+
+        #[cfg(feature = "clip_origin_support")]
+        let clip_origin_is_lower_left = if self.has_clip_origin_support {
+            unsafe { gl.get_parameter_i32(glow::CLIP_ORIGIN) != glow::UPPER_LEFT as i32 }
+        } else {
+            true
+        };
+        #[cfg(not(feature = "clip_origin_support"))]
+        let clip_origin_is_lower_left = true;
+
+        let projection_matrix = calculate_matrix(draw_data, clip_origin_is_lower_left);
+        let shader_data = self.shader_provider.data();
+
+        unsafe {
+            gl.use_program(Some(shader_data.program));
+            gl.uniform_1_i32(Some(&shader_data.texture_uniform_location), 0);
+            gl.uniform_matrix_4_f32_slice(
+                Some(&shader_data.matrix_uniform_location),
+                false,
+                &projection_matrix,
+            );
+        }
+
+        #[cfg(feature = "bind_sampler_support")]
+        if self.gl_version.bind_sampler_support() {
+            unsafe { gl.bind_sampler(0, None) };
+        }
+
+        #[cfg(feature = "bind_vertex_array_support")]
+        if self.gl_version.bind_vertex_array_support() {
+            unsafe {
+                self.vertex_array_object = gl
+                    .create_vertex_array()
+                    .map_err(|err| format!("Error creating vertex array object: {}", err))?;
+                gl.bind_vertex_array(Some(self.vertex_array_object));
+            }
+        }
+
+        // TODO: soon it should be possible for these to be `const` functions
+        let position_field_offset = memoffset::offset_of!(imgui::DrawVert, pos) as _;
+        let uv_field_offset = memoffset::offset_of!(imgui::DrawVert, uv) as _;
+        let color_field_offset = memoffset::offset_of!(imgui::DrawVert, col) as _;
+
+        unsafe {
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vbo_handle));
+            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(self.ebo_handle));
+            gl.enable_vertex_attrib_array(shader_data.position_attribute_index);
+            gl.vertex_attrib_pointer_f32(
+                shader_data.position_attribute_index,
+                2,
+                glow::FLOAT,
+                false,
+                size_of::<imgui::DrawVert>() as _,
+                position_field_offset,
+            );
+            gl.enable_vertex_attrib_array(shader_data.uv_attribute_index);
+            gl.vertex_attrib_pointer_f32(
+                shader_data.uv_attribute_index,
+                2,
+                glow::FLOAT,
+                false,
+                size_of::<imgui::DrawVert>() as _,
+                uv_field_offset,
+            );
+            gl.enable_vertex_attrib_array(shader_data.color_attribute_index);
+            gl.vertex_attrib_pointer_f32(
+                shader_data.color_attribute_index,
+                4,
+                glow::UNSIGNED_BYTE,
+                true,
+                size_of::<imgui::DrawVert>() as _,
+                color_field_offset,
+            );
+        }
+
+        self.context_state_manager
+            .post_setup_render(gl, self.gl_version)
+    }
+
+    fn render_elements(
+        &self,
+        gl: &G,
+        element_count: usize,
+        element_params: imgui::DrawCmdParams,
+        draw_data: &imgui::DrawData,
+        fb_width: f32,
+        fb_height: f32,
+    ) {
+        #![allow(
+            clippy::similar_names,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap
+        )]
+
+        let imgui::DrawCmdParams {
+            clip_rect,
+            texture_id,
+            vtx_offset,
+            idx_offset,
+        } = element_params;
+        let clip_off = draw_data.display_pos;
+        let scale = draw_data.framebuffer_scale;
+
+        let clip_x1 = (clip_rect[0] - clip_off[0]) * scale[0];
+        let clip_y1 = (clip_rect[1] - clip_off[1]) * scale[1];
+        let clip_x2 = (clip_rect[2] - clip_off[0]) * scale[0];
+        let clip_y2 = (clip_rect[3] - clip_off[1]) * scale[1];
+
+        if clip_x1 >= fb_width || clip_y1 >= fb_height || clip_x2 < 0.0 || clip_y2 < 0.0 {
+            return;
+        }
+
+        unsafe {
+            gl.scissor(
+                clip_x1 as i32,
+                (fb_height - clip_y2) as i32,
+                (clip_x2 - clip_x1) as i32,
+                (clip_y2 - clip_y1) as i32,
+            );
+            gl.bind_texture(glow::TEXTURE_2D, self.texture_map.gl_texture(texture_id));
+
+            #[cfg(feature = "vertex_offset_support")]
+            let with_offset = self.gl_version.vertex_offset_support();
+            #[cfg(not(feature = "vertex_offset_support"))]
+            let with_offset = false;
+
+            if with_offset {
+                gl.draw_elements_base_vertex(
+                    glow::TRIANGLES,
+                    element_count as _,
+                    imgui_index_type_as_gl(),
+                    (idx_offset * size_of::<imgui::DrawIdx>()) as _,
+                    vtx_offset as _,
+                );
+            } else {
+                gl.draw_elements(
+                    glow::TRIANGLES,
+                    element_count as _,
+                    imgui_index_type_as_gl(),
+                    (idx_offset * size_of::<imgui::DrawIdx>()) as _,
+                );
+            }
+        }
+    }
+
+    fn configure_imgui_context(&self, imgui_context: &mut imgui::Context) {
+        imgui_context.set_renderer_name(Some(
+            format!("imgui-rs-glow-render {}", env!("CARGO_PKG_VERSION")).into(),
+        ));
+
+        #[cfg(feature = "vertex_offset_support")]
+        if self.gl_version.vertex_offset_support() {
+            imgui_context
+                .io_mut()
+                .backend_flags
+                .insert(imgui::BackendFlags::RENDERER_HAS_VTX_OFFSET);
+        }
+    }
+
+    fn renderer_destroyed() -> RenderError {
+        "Renderer is destroyed".into()
+    }
+}
+
+pub trait TextureMap {
+    fn gl_texture(&self, imgui_texture: imgui::TextureId) -> Option<glow::Texture>;
+}
+
+pub struct TrivialTextureMap();
+
+impl TextureMap for TrivialTextureMap {
+    fn gl_texture(&self, imgui_texture: imgui::TextureId) -> Option<glow::Texture> {
+        #[allow(clippy::cast_possible_truncation)]
+        Some(imgui_texture.id() as _)
+    }
+}
+
+pub trait ContextStateManager<G: Gl> {
+    #![allow(unused_variables, clippy::missing_errors_doc)]
+
+    fn pre_init(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), InitError> {
+        Ok(())
+    }
+
+    fn post_init(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), InitError> {
+        Ok(())
+    }
+
+    fn pre_render(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), RenderError> {
+        Ok(())
+    }
+
+    fn pre_setup_render(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), RenderError> {
+        Ok(())
+    }
+
+    fn post_setup_render(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), RenderError> {
+        Ok(())
+    }
+
+    fn post_render(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), RenderError> {
+        Ok(())
+    }
+
+    fn pre_destroy(&mut self, gl: &G, gl_version: GlVersion) {}
+
+    fn post_destroy(&mut self, gl: &G, gl_version: GlVersion) {}
+}
+
+pub struct TrivialCsm();
+
+impl<G: Gl> ContextStateManager<G> for TrivialCsm {}
+
+/// This `ContextStateManager` is based on the upstream OpenGL example from
+/// imgui, where an attempt is made to save and restore the OpenGL context state
+/// before and after rendering.
+///
+/// It is unlikely that any such attempt will be comprehensive for all possible
+/// applications, due to the complexity of OpenGL and the possibility of
+/// arbitrary extensions. However, it remains as a useful tool for quickly
+/// getting started, and a good example of how to use a `ContextStateManager` to
+/// customise the renderer.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Default)]
+pub struct StateBackupCsm {
+    active_texture: i32,
+    program: i32,
+    texture: i32,
+    #[cfg(feature = "bind_sampler_support")]
+    sampler: Option<i32>,
+    array_buffer: i32,
+    #[cfg(feature = "polygon_mode_support")]
+    polygon_mode: Option<[i32; 2]>,
+    viewport: [i32; 4],
+    scissor_box: [i32; 4],
+    blend_src_rgb: i32,
+    blend_dst_rgb: i32,
+    blend_src_alpha: i32,
+    blend_dst_alpha: i32,
+    blend_equation_rgb: i32,
+    blend_equation_alpha: i32,
+    blend_enabled: bool,
+    cull_face_enabled: bool,
+    depth_test_enabled: bool,
+    stencil_test_enabled: bool,
+    scissor_test_enabled: bool,
+    #[cfg(feature = "primitive_restart_support")]
+    primitive_restart_enabled: Option<bool>,
+    #[cfg(feature = "bind_vertex_array_support")]
+    vertex_array_object: Option<glow::VertexArray>,
+}
+
+impl<G: Gl> ContextStateManager<G> for StateBackupCsm {
+    fn pre_init(&mut self, gl: &G, _gl_version: GlVersion) -> Result<(), InitError> {
+        self.texture = unsafe { gl.get_parameter_i32(glow::TEXTURE_BINDING_2D) };
+        Ok(())
+    }
+
+    fn post_init(&mut self, gl: &G, _gl_version: GlVersion) -> Result<(), InitError> {
+        #[allow(clippy::clippy::cast_sign_loss)]
+        unsafe {
+            gl.bind_texture(glow::TEXTURE_2D, Some(self.texture as _));
+        }
+        Ok(())
+    }
+
+    fn pre_render(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), RenderError> {
+        #[allow(clippy::cast_sign_loss)]
+        unsafe {
+            self.active_texture = gl.get_parameter_i32(glow::ACTIVE_TEXTURE);
+            self.program = gl.get_parameter_i32(glow::CURRENT_PROGRAM);
+            self.texture = gl.get_parameter_i32(glow::TEXTURE_BINDING_2D);
+            #[cfg(feature = "bind_sampler_support")]
+            if gl_version.bind_sampler_support() {
+                self.sampler = Some(gl.get_parameter_i32(glow::SAMPLER_BINDING));
+            } else {
+                self.sampler = None;
+            }
+            self.array_buffer = gl.get_parameter_i32(glow::ARRAY_BUFFER_BINDING);
+
+            #[cfg(feature = "bind_vertex_array_support")]
+            if gl_version.bind_vertex_array_support() {
+                self.vertex_array_object =
+                    Some(gl.get_parameter_i32(glow::VERTEX_ARRAY_BINDING) as _);
+            }
+
+            #[cfg(feature = "polygon_mode_support")]
+            if gl_version.polygon_mode_support() {
+                if self.polygon_mode.is_none() {
+                    self.polygon_mode = Some(Default::default());
+                }
+                gl.get_parameter_i32_slice(glow::POLYGON_MODE, self.polygon_mode.as_mut().unwrap());
+            } else {
+                self.polygon_mode = None;
+            }
+            gl.get_parameter_i32_slice(glow::VIEWPORT, &mut self.viewport);
+            gl.get_parameter_i32_slice(glow::SCISSOR_BOX, &mut self.scissor_box);
+            self.blend_src_rgb = gl.get_parameter_i32(glow::BLEND_SRC_RGB);
+            self.blend_dst_rgb = gl.get_parameter_i32(glow::BLEND_DST_RGB);
+            self.blend_src_alpha = gl.get_parameter_i32(glow::BLEND_SRC_ALPHA);
+            self.blend_dst_alpha = gl.get_parameter_i32(glow::BLEND_DST_ALPHA);
+            self.blend_equation_rgb = gl.get_parameter_i32(glow::BLEND_EQUATION_RGB);
+            self.blend_equation_alpha = gl.get_parameter_i32(glow::BLEND_EQUATION_ALPHA);
+            self.blend_enabled = gl.is_enabled(glow::BLEND);
+            self.cull_face_enabled = gl.is_enabled(glow::CULL_FACE);
+            self.depth_test_enabled = gl.is_enabled(glow::DEPTH_TEST);
+            self.stencil_test_enabled = gl.is_enabled(glow::STENCIL_TEST);
+            self.scissor_test_enabled = gl.is_enabled(glow::SCISSOR_TEST);
+            #[cfg(feature = "primitive_restart_support")]
+            if gl_version.primitive_restart_support() {
+                self.primitive_restart_enabled = Some(gl.is_enabled(glow::PRIMITIVE_RESTART));
+            } else {
+                self.primitive_restart_enabled = None;
+            }
+        }
+        Ok(())
+    }
+
+    fn post_render(&mut self, gl: &G, _gl_version: GlVersion) -> Result<(), RenderError> {
+        #![allow(clippy::cast_sign_loss)]
+        unsafe {
+            gl.use_program(Some(self.program as _));
+            gl.bind_texture(glow::TEXTURE_2D, Some(self.texture as _));
+            #[cfg(feature = "bind_sampler_support")]
+            if let Some(sampler) = self.sampler {
+                gl.bind_sampler(0, Some(sampler as _));
+            }
+            gl.active_texture(self.active_texture as _);
+            #[cfg(feature = "bind_vertex_array_support")]
+            if let Some(vao) = self.vertex_array_object {
+                gl.bind_vertex_array(Some(vao));
+            }
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.array_buffer as _));
+            gl.blend_equation_separate(
+                self.blend_equation_rgb as _,
+                self.blend_equation_alpha as _,
+            );
+            gl.blend_func_separate(
+                self.blend_src_rgb as _,
+                self.blend_dst_rgb as _,
+                self.blend_src_alpha as _,
+                self.blend_dst_alpha as _,
+            );
+            if self.blend_enabled {
+                gl.enable(glow::BLEND)
+            } else {
+                gl.disable(glow::BLEND);
+            }
+            if self.cull_face_enabled {
+                gl.enable(glow::CULL_FACE)
+            } else {
+                gl.disable(glow::CULL_FACE)
+            }
+            if self.depth_test_enabled {
+                gl.enable(glow::DEPTH_TEST)
+            } else {
+                gl.disable(glow::DEPTH_TEST)
+            }
+            if self.stencil_test_enabled {
+                gl.enable(glow::STENCIL_TEST)
+            } else {
+                gl.disable(glow::STENCIL_TEST)
+            }
+            if self.scissor_test_enabled {
+                gl.enable(glow::SCISSOR_TEST)
+            } else {
+                gl.disable(glow::SCISSOR_TEST)
+            }
+            #[cfg(feature = "primitive_restart_support")]
+            if let Some(restart_enabled) = self.primitive_restart_enabled {
+                if restart_enabled {
+                    gl.enable(glow::PRIMITIVE_RESTART)
+                } else {
+                    gl.disable(glow::PRIMITIVE_RESTART)
+                }
+            }
+            #[cfg(feature = "polygon_mode_support")]
+            if let Some([mode, _]) = self.polygon_mode {
+                gl.polygon_mode(glow::FRONT_AND_BACK, mode as _);
+            }
+            gl.viewport(
+                self.viewport[0],
+                self.viewport[1],
+                self.viewport[2],
+                self.viewport[3],
+            );
+            gl.scissor(
+                self.scissor_box[0],
+                self.scissor_box[1],
+                self.scissor_box[2],
+                self.scissor_box[3],
+            );
+        }
+        Ok(())
+    }
+}
+
+pub trait ShaderProvider<G: Gl> {
+    /// Called during renderer initialization, before this call the shader
+    /// provide should be in a neutral state and have not interacted with the
+    /// OpenGL context.
+    ///
+    /// Implementors should use this opporunity to check whether the version of
+    /// the GL context (found with `GlVersion::read`) is compatible with the
+    /// shader they provide.
+    ///
+    /// # Errors
+    /// Any error creating the GL objects, compiling or linking or loading the
+    /// shaders, or an GL context with an incompatible OpenGL version will
+    /// result in an error.
+    fn initialize(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), ShaderError>;
+
+    fn data(&self) -> &GenericShaderData<G>;
+}
+
+/// A generic shader provider that parses `GL_VERSION` and
+/// `GL_SHADING_LANGUAGE_VERSION` at runtime in order to generate shaders which
+/// should work on a wide variety of modern devices (GL >= 3.3 and GLES >= 2.0
+/// are expected to work).
+pub struct AutoShaderProvider<G: Gl>(GenericShaderData<G>);
+
+impl<G: Gl> ShaderProvider<G> for AutoShaderProvider<G> {
+    fn initialize(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), ShaderError> {
+        const VERTEX_BODY: &str = r#"
+layout (location = 0) in vec2 position;
+layout (location = 1) in vec2 uv;
+layout (location = 2) in vec4 color;
+
+uniform mat4 matrix;
+out vec2 fragment_uv;
+out vec4 fragment_color;
+
+void main() {
+    fragment_uv = uv;
+    fragment_color = color;
+    gl_Position = matrix * vec4(position.xy, 0, 1);
+}
+"#;
+        const FRAGMENT_BODY: &str = r#"
+in vec2 fragment_uv;
+in vec4 fragment_color;
+
+uniform sampler2D tex;
+layout (location = 0) out vec4 out_color;
+
+void main() {
+    out_color = fragment_color * texture(tex, fragment_uv.st);
+}
+"#;
+
+        let glsl_version = GlslVersion::read(gl);
+
+        // Find the lowest common denominator version
+        let is_gles = gl_version.is_gles || glsl_version.is_gles;
+        let (major, minor) = if let std::cmp::Ordering::Less = gl_version
+            .major
+            .cmp(&glsl_version.major)
+            .then(gl_version.minor.cmp(&glsl_version.minor))
+        {
+            (gl_version.major, gl_version.minor)
+        } else {
+            (glsl_version.major, glsl_version.minor)
+        };
+
+        if is_gles && major < 2 {
+            return Err(ShaderError::IncompatibleVersion(format!(
+                "This auto-shader OpenGL version 3.0 or OpenGL ES version 2.0 or higher, found: ES {}.{}",
+                major, minor
+            )));
+        }
+        if !is_gles && major < 3 {
+            return Err(ShaderError::IncompatibleVersion(format!(
+                "This auto-shader OpenGL version 3.0 or OpenGL ES version 2.0 or higher, found: {}.{}",
+                major, minor
+            )));
+        }
+
+        let vertex_source = format!(
+            "#version {major}{minor}{es_extras}\n{body}",
+            major = major,
+            minor = minor * 10,
+            es_extras = if is_gles {
+                " es\nprecision mediump float;"
+            } else {
+                ""
+            },
+            body = VERTEX_BODY,
+        );
+        let fragment_source = format!(
+            "#version {major}{minor}{es_extras}\n{body}",
+            major = major,
+            minor = minor * 10,
+            es_extras = if is_gles {
+                " es\nprecision mediump float;"
+            } else {
+                ""
+            },
+            body = FRAGMENT_BODY,
+        );
+
+        create_shaders(&mut self.0, gl, &vertex_source, &fragment_source)
+    }
+
+    fn data(&self) -> &GenericShaderData<G> {
+        &self.0
+    }
+}
+
+impl<G: Gl> Default for AutoShaderProvider<G> {
+    fn default() -> Self {
+        Self(<GenericShaderData<G> as Default>::default())
+    }
+}
+
+/// A shader provider for specific shaders for OpenGL ES (GLSL ES) version(s)
+/// 3.0
+#[derive(Default)]
+pub struct Es3ShaderProvider<G: Gl>(GenericShaderData<G>);
+
+impl<G: Gl> ShaderProvider<G> for Es3ShaderProvider<G> {
+    fn initialize(&mut self, gl: &G, gl_version: GlVersion) -> Result<(), ShaderError> {
+        const VERTEX_SOURCE: &str = r#"#version 300 es
+precision mediump float;
+
+layout (location = 0) in vec2 position;
+layout (location = 1) in vec2 uv;
+layout (location = 2) in vec4 color;
+
+uniform mat4 matrix;
+out vec2 fragment_uv;
+out vec4 fragment_color;
+
+void main() {
+    fragment_uv = uv;
+    fragment_color = color;
+    gl_Position = matrix * vec4(position.xy, 0, 1);
+}
+"#;
+        const FRAGMENT_SOURCE: &str = r#"#version 300 es
+precision mediump float;
+
+in vec2 fragment_uv;
+in vec4 fragment_color;
+
+uniform sampler2D tex;
+layout (location = 0) out vec4 out_color;
+
+void main() {
+    out_color = fragment_color * texture(tex, fragment_uv.st);
+}
+"#;
+
+        if !gl_version.is_gles {
+            return Err(ShaderError::IncompatibleVersion(format!(
+                "A version of OpenGL ES is required for this shader, found: {}.{}",
+                gl_version.major, gl_version.minor
+            )));
+        }
+        if gl_version < GlVersion::gles(3, 0) {
+            return Err(ShaderError::IncompatibleVersion(format!(
+                "This shader requires OpenGL ES version 3.0 or higher, found: ES {}.{}",
+                gl_version.major, gl_version.minor
+            )));
+        }
+
+        create_shaders(&mut self.0, gl, VERTEX_SOURCE, FRAGMENT_SOURCE)
+    }
+
+    fn data(&self) -> &GenericShaderData<G> {
+        &self.0
+    }
+}
+
+pub struct GenericShaderData<G: Gl> {
+    program: G::Program,
+    texture_uniform_location: G::UniformLocation,
+    matrix_uniform_location: G::UniformLocation,
+    position_attribute_index: u32,
+    uv_attribute_index: u32,
+    color_attribute_index: u32,
+}
+
+impl<G: Gl> Default for GenericShaderData<G> {
+    fn default() -> Self {
+        Self {
+            program: Default::default(),
+            texture_uniform_location: Default::default(),
+            matrix_uniform_location: Default::default(),
+            position_attribute_index: Default::default(),
+            uv_attribute_index: Default::default(),
+            color_attribute_index: Default::default(),
+        }
+    }
+}
+
+/// # Errors
+/// Any error creating OpenGL objects, compiling, or linking the given shaders
+/// results in an error.
+pub fn create_shaders<G: Gl>(
+    data: &mut GenericShaderData<G>,
+    gl: &G,
+    vertex_source: &str,
+    fragment_source: &str,
+) -> Result<(), ShaderError> {
+    let vertex_shader =
+        unsafe { gl.create_shader(glow::VERTEX_SHADER) }.map_err(ShaderError::CreateShader)?;
+    unsafe {
+        gl.shader_source(vertex_shader, vertex_source);
+        gl.compile_shader(vertex_shader);
+        if !gl.get_shader_compile_status(vertex_shader) {
+            return Err(ShaderError::CompileShader(
+                gl.get_shader_info_log(vertex_shader),
+            ));
+        }
+    }
+
+    let fragment_shader =
+        unsafe { gl.create_shader(glow::FRAGMENT_SHADER) }.map_err(ShaderError::CreateShader)?;
+    unsafe {
+        gl.shader_source(fragment_shader, fragment_source);
+        gl.compile_shader(fragment_shader);
+        if !gl.get_shader_compile_status(fragment_shader) {
+            return Err(ShaderError::CompileShader(
+                gl.get_shader_info_log(fragment_shader),
+            ));
+        }
+    }
+
+    let program = unsafe { gl.create_program() }.map_err(ShaderError::CreateProgram)?;
+    unsafe {
+        gl.attach_shader(program, vertex_shader);
+        gl.attach_shader(program, fragment_shader);
+        gl.link_program(program);
+
+        if !gl.get_program_link_status(program) {
+            return Err(ShaderError::LinkProgram(gl.get_program_info_log(program)));
+        }
+
+        gl.detach_shader(program, vertex_shader);
+        gl.detach_shader(program, fragment_shader);
+        gl.delete_shader(vertex_shader);
+        gl.delete_shader(fragment_shader);
+    }
+
+    data.program = program;
+    unsafe {
+        data.texture_uniform_location = gl
+            .get_uniform_location(program, "tex")
+            .ok_or_else(|| ShaderError::UniformNotFound("tex".into()))?;
+        data.matrix_uniform_location = gl
+            .get_uniform_location(program, "matrix")
+            .ok_or_else(|| ShaderError::UniformNotFound("matrix".into()))?;
+        data.position_attribute_index = gl
+            .get_attrib_location(program, "position")
+            .ok_or_else(|| ShaderError::AttributeNotFound("position".into()))?;
+        data.uv_attribute_index = gl
+            .get_attrib_location(program, "uv")
+            .ok_or_else(|| ShaderError::AttributeNotFound("uv".into()))?;
+        data.color_attribute_index = gl
+            .get_attrib_location(program, "color")
+            .ok_or_else(|| ShaderError::AttributeNotFound("color".into()))?;
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum ShaderError {
+    IncompatibleVersion(String),
+    CreateShader(String),
+    CreateProgram(String),
+    CompileShader(String),
+    LinkProgram(String),
+    UniformNotFound(Cow<'static, str>),
+    AttributeNotFound(Cow<'static, str>),
+}
+
+impl Error for ShaderError {}
+
+impl Display for ShaderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IncompatibleVersion(msg) => write!(
+                f,
+                "Shader not compatible with OpenGL version found in the context: {}",
+                msg
+            ),
+            Self::CreateShader(msg) => write!(f, "Error creating shader object: {}", msg),
+            Self::CreateProgram(msg) => write!(f, "Error creating program object: {}", msg),
+            Self::CompileShader(msg) => write!(f, "Error compiling shader: {}", msg),
+            Self::LinkProgram(msg) => write!(f, "Error linking shader program: {}", msg),
+            Self::UniformNotFound(uniform_name) => {
+                write!(f, "Uniform `{}` not found in shader program", uniform_name)
+            }
+            Self::AttributeNotFound(attribute_name) => {
+                write!(
+                    f,
+                    "Attribute `{}` not found in shader program",
+                    attribute_name
+                )
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InitError {
+    Shader(ShaderError),
+    CreateBufferObject(String),
+    CreateTexture(String),
+    UserError(String),
+}
+
+impl Error for InitError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Shader(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl Display for InitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Shader(error) => write!(f, "Shader initialisation error: {}", error),
+            Self::CreateBufferObject(msg) => write!(f, "Error creating buffer object: {}", msg),
+            Self::CreateTexture(msg) => write!(f, "Error creating texture object: {}", msg),
+            Self::UserError(msg) => write!(f, "Initialization error: {}", msg),
+        }
+    }
+}
+
+impl From<ShaderError> for InitError {
+    fn from(error: ShaderError) -> Self {
+        Self::Shader(error)
+    }
+}
+
+pub type RenderError = String;
+
+fn prepare_font_atlas<G: Gl>(
+    gl: &G,
+    mut fonts: imgui::FontAtlasRefMut,
+) -> Result<G::Texture, InitError> {
+    #![allow(clippy::cast_possible_wrap)]
+
+    let atlas_texture = fonts.build_rgba32_texture();
+
+    let gl_texture = unsafe { gl.create_texture() }.map_err(InitError::CreateTexture)?;
+
+    unsafe {
+        gl.bind_texture(glow::TEXTURE_2D, Some(gl_texture));
+        gl.tex_parameter_i32(
+            glow::TEXTURE_2D,
+            glow::TEXTURE_MIN_FILTER,
+            glow::LINEAR as _,
+        );
+        gl.tex_parameter_i32(
+            glow::TEXTURE_2D,
+            glow::TEXTURE_MAG_FILTER,
+            glow::LINEAR as _,
+        );
+        gl.tex_image_2d(
+            glow::TEXTURE_2D,
+            0,
+            glow::RGBA as _,
+            atlas_texture.width as _,
+            atlas_texture.height as _,
+            0,
+            glow::RGBA,
+            glow::UNSIGNED_BYTE,
+            Some(atlas_texture.data),
+        )
+    }
+
+    fonts.tex_id = TextureId::new(gl_texture as _);
+
+    Ok(gl_texture)
+}
+
+fn gl_debug_message<G: glow::HasContext>(context: &G, message: impl AsRef<str>) {
+    unsafe {
+        context.debug_message_insert(
+            glow::DEBUG_SOURCE_APPLICATION,
+            glow::DEBUG_TYPE_MARKER,
+            0,
+            glow::DEBUG_SEVERITY_NOTIFICATION,
+            message,
+        )
+    };
+}
+
+fn calculate_matrix(draw_data: &imgui::DrawData, clip_origin_is_lower_left: bool) -> [f32; 16] {
+    #![allow(clippy::deprecated_cfg_attr)]
+
+    let left = draw_data.display_pos[0];
+    let right = draw_data.display_pos[0] + draw_data.display_size[0];
+    let top = draw_data.display_pos[1];
+    let bottom = draw_data.display_pos[1] + draw_data.display_size[1];
+
+    #[cfg(feature = "clip_origin_support")]
+    let (top, bottom) = if clip_origin_is_lower_left {
+        (top, bottom)
+    } else {
+        (bottom, top)
+    };
+
+    #[cfg_attr(rustfmt, rustfmt::skip)]
+    {
+        [
+        2.0 / (right - left)           , 0.0                            , 0.0 , 0.0,
+        0.0                            , (2.0 / (top - bottom))         , 0.0 , 0.0,
+        0.0                            , 0.0                            , -1.0, 0.0,
+        (right + left) / (left - right), (top + bottom) / (bottom - top), 0.0 , 1.0,
+        ]
+    }
+}
+
+unsafe fn to_byte_slice<T>(slice: &[T]) -> &[u8] {
+    std::slice::from_raw_parts(slice.as_ptr().cast(), slice.len() * size_of::<T>())
+}
+
+const fn imgui_index_type_as_gl() -> u32 {
+    match size_of::<imgui::DrawIdx>() {
+        1 => glow::UNSIGNED_BYTE,
+        2 => glow::UNSIGNED_SHORT,
+        _ => glow::UNSIGNED_INT,
+    }
+}

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -602,7 +602,7 @@ impl TextureMap for TrivialTextureMap {
 /// `Textures` from the `imgui` crate is a simple choice for a texture map
 impl TextureMap for imgui::Textures<glow::Texture> {
     fn gl_texture(&self, imgui_texture: imgui::TextureId) -> Option<glow::Texture> {
-        self.get(imgui_texture).cloned()
+        self.get(imgui_texture).copied()
     }
 
     fn register(&mut self, gl_texture: glow::Texture) -> Option<imgui::TextureId> {

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -1030,12 +1030,12 @@ void main() {
 }
 
 pub struct GenericShaderData<G: Gl> {
-    program: G::Program,
-    texture_uniform_location: G::UniformLocation,
-    matrix_uniform_location: G::UniformLocation,
-    position_attribute_index: u32,
-    uv_attribute_index: u32,
-    color_attribute_index: u32,
+    pub program: G::Program,
+    pub texture_uniform_location: G::UniformLocation,
+    pub matrix_uniform_location: G::UniformLocation,
+    pub position_attribute_index: u32,
+    pub uv_attribute_index: u32,
+    pub color_attribute_index: u32,
 }
 
 impl<G: Gl> Default for GenericShaderData<G> {

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -1183,9 +1183,10 @@ fn prepare_font_atlas<G: Gl, T: TextureMap>(
     Ok(gl_texture)
 }
 
-fn gl_debug_message<G: glow::HasContext>(context: &G, message: impl AsRef<str>) {
+#[cfg(feature = "debug_message_insert_support")]
+fn gl_debug_message<G: glow::HasContext>(gl: &G, message: impl AsRef<str>) {
     unsafe {
-        context.debug_message_insert(
+        gl.debug_message_insert(
             glow::DEBUG_SOURCE_APPLICATION,
             glow::DEBUG_TYPE_MARKER,
             0,
@@ -1194,6 +1195,9 @@ fn gl_debug_message<G: glow::HasContext>(context: &G, message: impl AsRef<str>) 
         )
     };
 }
+
+#[cfg(not(feature = "debug_message_insert_support"))]
+fn gl_debug_message<G: glow::HasContext>(_gl: &G, _message: impl AsRef<str>) {}
 
 fn calculate_matrix(draw_data: &imgui::DrawData, clip_origin_is_lower_left: bool) -> [f32; 16] {
     #![allow(clippy::deprecated_cfg_attr)]

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -793,7 +793,7 @@ uniform mat4 matrix;
 out vec2 fragment_uv;
 out vec4 fragment_color;
 
-// Because imgui only specifies linear colors
+// Because imgui only specifies sRGB colors
 vec4 srgb_to_linear(vec4 srgb_color) {
     // Calcuation as documented by OpenGL
     vec3 srgb = srgb_color.rgb;

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -42,6 +42,14 @@ impl<
 /// you probably want to take more control (including ownership of the GL
 /// context). In those cases, construct an appropriate renderer with
 /// `RendererBuilder`.
+///
+/// By default, it constructs a renderer which owns the OpenGL context and
+/// attempts to backup the OpenGL state before rendering and restore it after
+/// rendering.
+///
+/// # Errors
+/// Any error initialising the OpenGL objects (including shaders) will
+/// result in an error.
 pub fn auto_renderer<G: Gl>(
     gl: G,
     imgui_context: &mut imgui::Context,
@@ -117,7 +125,12 @@ where
             phantom_gl: self.phantom_gl,
         }
     }
-
+    /// Build a renderer which owns the OpenGL context (which can be borrowed
+    /// from the renderer, but not taken).
+    ///
+    /// # Errors
+    /// Any error initialising the OpenGL objects (including shaders) will
+    /// result in an error.
     pub fn build_owning(
         self,
         gl: G,
@@ -127,6 +140,11 @@ where
         Ok(OwningRenderer::<G, T, S, C> { gl, renderer })
     }
 
+    /// Build a renderer which needs to borrow a context in order to render.
+    ///
+    /// # Errors
+    /// Any error initialising the OpenGL objects (including shaders) will
+    /// result in an error.
     pub fn build_borrowing(
         self,
         gl: &G,
@@ -142,7 +160,6 @@ where
     }
 }
 
-// TODO: builder pattern
 /// Renderer which owns the OpenGL context. Useful for simple applications, but
 /// more complicated applications may prefer to keep control of their own
 /// OpenGL context, or even change that context at runtime.

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -329,7 +329,7 @@ where
             self.vbo_handle = 0;
         }
         if self.ebo_handle != 0 {
-            unsafe { gl.delete_buffer(self.vbo_handle) };
+            unsafe { gl.delete_buffer(self.ebo_handle) };
             self.ebo_handle = 0;
         }
         let program = self.shader_provider.data().program;

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -614,6 +614,8 @@ impl TextureMap for imgui::Textures<glow::Texture> {
 /// imgui, where an attempt is made to save and restore the OpenGL context state
 /// before and after rendering.
 ///
+/// If you're writing your own renderer, you can likely streamline most of this.
+///
 /// It is unlikely that any such attempt will be comprehensive for all possible
 /// applications, due to the complexity of OpenGL and the possibility of
 /// arbitrary extensions. However, it remains as a useful tool for quickly

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, error::Error, fmt::Display, marker::PhantomData, mem::size_of};
 
-use imgui::{internal::RawWrapper, TextureId};
+use imgui::internal::RawWrapper;
 
 use crate::versions::{GlVersion, GlslVersion};
 

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -9,9 +9,9 @@ pub mod versions;
 // TODO: document all the things!
 
 // This may be generics overkill, but I have to assume there's some reason that
-// `glow` hid the functions of `Context` behind the `HasContext` trait. The
-// specified types I require here are necessary because otherwise I can't
-// perform the required initialisations or conversions in the code below. In
+// `glow` hid the functions of `[glow::Context]` behind the `[glow::Context]`
+// trait. The specified types required here are necessary because otherwise
+// required initialisations or conversions in this crate can't be performed. In
 // any case, the OpenGL standard specifies these types, so there should be no
 // loss of generality.
 pub trait Gl:
@@ -41,7 +41,7 @@ impl<
 /// Convenience function to get you going quickly. In most larger programs
 /// you probably want to take more control (including ownership of the GL
 /// context). In those cases, construct an appropriate renderer with
-/// `RendererBuilder`.
+/// `[RendererBuilder]`.
 ///
 /// By default, it constructs a renderer which owns the OpenGL context and
 /// attempts to backup the OpenGL state before rendering and restore it after
@@ -165,7 +165,7 @@ where
 /// OpenGL context, or even change that context at runtime.
 ///
 /// OpenGL context is still available to the rest of the application through
-/// the `gl_context` method.
+/// the `[gl_context]` method.
 pub struct OwningRenderer<G, T = TrivialTextureMap, S = AutoShaderProvider<G>, C = TrivialCsm>
 where
     G: Gl,
@@ -185,7 +185,7 @@ where
     C: ContextStateManager<G>,
 {
     /// Note: no need to provide a `mut` version of this, as all methods on
-    /// `glow::HasContext` are immutable.
+    /// `[glow::HasContext]` are immutable.
     #[inline]
     pub fn gl_context(&self) -> &G {
         &self.gl
@@ -669,14 +669,14 @@ pub struct TrivialCsm();
 
 impl<G: Gl> ContextStateManager<G> for TrivialCsm {}
 
-/// This `ContextStateManager` is based on the upstream OpenGL example from
+/// This `[ContextStateManager]` is based on the upstream OpenGL example from
 /// imgui, where an attempt is made to save and restore the OpenGL context state
 /// before and after rendering.
 ///
 /// It is unlikely that any such attempt will be comprehensive for all possible
 /// applications, due to the complexity of OpenGL and the possibility of
 /// arbitrary extensions. However, it remains as a useful tool for quickly
-/// getting started, and a good example of how to use a `ContextStateManager` to
+/// getting started, and a good example of how to use a `[ContextStateManager]` to
 /// customise the renderer.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Default)]
@@ -859,7 +859,7 @@ pub trait ShaderProvider<G: Gl> {
     /// OpenGL context.
     ///
     /// Implementors should use this opporunity to check whether the version of
-    /// the GL context (found with `GlVersion::read`) is compatible with the
+    /// the GL context (found with `[GlVersion::read]`) is compatible with the
     /// shader they provide.
     ///
     /// # Errors

--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -49,6 +49,12 @@ use glow::{Context, HasContext};
 
 pub mod versions;
 
+pub type GlBuffer = <Context as HasContext>::Buffer;
+pub type GlTexture = <Context as HasContext>::Texture;
+pub type GlVertexArray = <Context as HasContext>::VertexArray;
+type GlProgram = <Context as HasContext>::Program;
+type GlUniformLocation = <Context as HasContext>::Program;
+
 /// Renderer which owns the OpenGL context and handles textures itself. Also
 /// converts all output colors to sRGB for display. Useful for simple applications,
 /// but more complicated applications may prefer to use `[Renderer]`, or even
@@ -121,11 +127,11 @@ impl Drop for AutoRenderer {
 pub struct Renderer {
     shaders: Shaders,
     state_backup: GlStateBackup,
-    pub vbo_handle: <Context as HasContext>::Buffer,
-    pub ebo_handle: <Context as HasContext>::Buffer,
-    pub font_atlas_texture: <Context as HasContext>::Texture,
+    pub vbo_handle: GlBuffer,
+    pub ebo_handle: GlBuffer,
+    pub font_atlas_texture: GlTexture,
     #[cfg(feature = "bind_vertex_array_support")]
-    pub vertex_array_object: <Context as HasContext>::VertexArray,
+    pub vertex_array_object: GlVertexArray,
     pub gl_version: GlVersion,
     pub has_clip_origin_support: bool,
     pub is_destroyed: bool,
@@ -533,15 +539,9 @@ impl Renderer {
 /// Then `[gl_texture]` can be called to find the OpenGL texture corresponding to
 /// that `[imgui::TextureId]`.
 pub trait TextureMap {
-    fn register(
-        &mut self,
-        gl_texture: <Context as HasContext>::Texture,
-    ) -> Option<imgui::TextureId>;
+    fn register(&mut self, gl_texture: GlTexture) -> Option<imgui::TextureId>;
 
-    fn gl_texture(
-        &self,
-        imgui_texture: imgui::TextureId,
-    ) -> Option<<Context as HasContext>::Texture>;
+    fn gl_texture(&self, imgui_texture: imgui::TextureId) -> Option<GlTexture>;
 }
 
 /// Texture map where the imgui texture ID is simply numerically equal to the
@@ -761,9 +761,9 @@ impl GlStateBackup {
 /// generate shaders which should work on a wide variety of modern devices
 /// (GL >= 3.3 and GLES >= 2.0 are expected to work).
 struct Shaders {
-    program: <Context as HasContext>::Program,
-    texture_uniform_location: <Context as HasContext>::UniformLocation,
-    matrix_uniform_location: <Context as HasContext>::UniformLocation,
+    program: GlProgram,
+    texture_uniform_location: GlUniformLocation,
+    matrix_uniform_location: GlUniformLocation,
     position_attribute_index: u32,
     uv_attribute_index: u32,
     color_attribute_index: u32,
@@ -1037,7 +1037,7 @@ fn prepare_font_atlas<T: TextureMap>(
     gl: &Context,
     mut fonts: imgui::FontAtlasRefMut,
     texture_map: &mut T,
-) -> Result<<Context as HasContext>::Texture, InitError> {
+) -> Result<GlTexture, InitError> {
     #![allow(clippy::cast_possible_wrap)]
 
     let atlas_texture = fonts.build_rgba32_texture();

--- a/imgui-glow-renderer/src/versions.rs
+++ b/imgui-glow-renderer/src/versions.rs
@@ -65,6 +65,13 @@ impl GlVersion {
         }
     }
 
+    /// Debug messages are provided by `glDebugMessageInsert`, which is only
+    /// present in OpenGL >= 4.3
+    #[cfg(feature = "debug_message_insert_support")]
+    pub fn debug_message_insert_support(self) -> bool {
+        self >= Self::gl(4, 3)
+    }
+
     /// Vertex array binding is provided by `glBindVertexArray`, which is
     /// not present in OpenGL (ES) <3.0
     #[cfg(feature = "bind_vertex_array_support")]
@@ -76,7 +83,7 @@ impl GlVersion {
     /// only present from OpenGL 3.2 and above.
     #[cfg(feature = "vertex_offset_support")]
     pub fn vertex_offset_support(self) -> bool {
-        !self.is_gles && self >= Self::gl(3, 2)
+        self >= Self::gl(3, 2)
     }
 
     /// Vertex arrays (e.g. `glBindVertexArray`) are supported from OpenGL 3.0

--- a/imgui-glow-renderer/src/versions.rs
+++ b/imgui-glow-renderer/src/versions.rs
@@ -1,0 +1,181 @@
+#![allow(clippy::must_use_candidate)]
+
+#[derive(PartialEq, Clone, Copy)]
+pub struct GlVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub is_gles: bool,
+}
+
+impl GlVersion {
+    pub const fn gl(major: u16, minor: u16) -> Self {
+        Self {
+            major,
+            minor,
+            is_gles: false,
+        }
+    }
+
+    pub const fn gles(major: u16, minor: u16) -> Self {
+        Self {
+            major,
+            minor,
+            is_gles: true,
+        }
+    }
+
+    pub fn read<G: glow::HasContext>(gl: &G) -> Self {
+        Self::parse(&unsafe { gl.get_parameter_string(glow::VERSION) })
+    }
+
+    /// Parse the OpenGL version from the version string queried from the driver
+    /// via the `GL_VERSION` enum.
+    ///
+    /// Version strings are documented to be in the form
+    /// `<major>.<minor>[.<release>][ <vendor specific information>]`
+    /// for full-fat OpenGL, and
+    /// `OpenGL ES <major>.<minor>[.<release>][ <vendor specific information>]`
+    /// for OpenGL ES.
+    ///
+    /// Examples based on strings found in the wild:
+    /// ```rust
+    /// # use glow_renderer::GlVersion;
+    /// let version = GlVersion::parse("4.6.0 NVIDIA 465.27");
+    /// assert!(!version.is_gles);
+    /// assert_eq!(version.major, 4);
+    /// assert_eq!(version.minor, 6);
+    /// let version = GlVersion::parse("OpenGL ES 3.2 NVIDIA 465.27");
+    /// assert!(version.is_gles);
+    /// assert_eq!(version.major, 3);
+    /// assert_eq!(version.minor, 2);
+    /// ```
+    pub fn parse(gl_version_string: &str) -> Self {
+        let (version_string, is_gles) = gl_version_string
+            .strip_prefix("OpenGL ES ")
+            .map_or_else(|| (gl_version_string, false), |version| (version, true));
+
+        let mut parts = version_string.split(|c: char| !c.is_numeric());
+        let major = parts.next().unwrap_or("0").parse().unwrap_or(0);
+        let minor = parts.next().unwrap_or("0").parse().unwrap_or(0);
+
+        Self {
+            major,
+            minor,
+            is_gles,
+        }
+    }
+
+    /// Vertex array binding is provided by `glBindVertexArray`, which is
+    /// not present in OpenGL (ES) <3.0
+    #[cfg(feature = "bind_vertex_array_support")]
+    pub fn bind_vertex_array_support(self) -> bool {
+        self.major >= 3
+    }
+
+    /// Vertex offset support is provided by `glDrawElementsBaseVertex`, which is
+    /// only present from OpenGL 3.2 and above.
+    #[cfg(feature = "vertex_offset_support")]
+    pub fn vertex_offset_support(self) -> bool {
+        !self.is_gles && self >= Self::gl(3, 2)
+    }
+
+    /// Vertex arrays (e.g. `glBindVertexArray`) are supported from OpenGL 3.0
+    /// and OpenGL ES 3.0
+    #[cfg(feature = "vertex_array_support")]
+    pub fn vertex_array_support(self) -> bool {
+        self >= Self::gl(3, 0) || self >= Self::gles(3, 0)
+    }
+
+    /// Separate binding of sampler (`glBindSampler`) is supported from OpenGL
+    /// 3.2 or ES 3.0
+    #[cfg(feature = "bind_sampler_support")]
+    pub fn bind_sampler_support(self) -> bool {
+        self >= GlVersion::gl(3, 2) || self >= GlVersion::gles(3, 0)
+    }
+
+    /// Setting the clip origin (`GL_CLIP_ORIGIN`) is suppoted from OpenGL 4.5
+    #[cfg(feature = "clip_origin_support")]
+    pub fn clip_origin_support(self) -> bool {
+        self >= GlVersion::gl(4, 5)
+    }
+
+    #[cfg(feature = "polygon_mode_support")]
+    pub fn polygon_mode_support(self) -> bool {
+        !self.is_gles
+    }
+
+    #[cfg(feature = "primitive_restart_support")]
+    pub fn primitive_restart_support(self) -> bool {
+        self >= GlVersion::gl(3, 1)
+    }
+}
+
+impl PartialOrd for GlVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if self.is_gles == other.is_gles {
+            Some(
+                self.major
+                    .cmp(&other.major)
+                    .then(self.minor.cmp(&other.minor)),
+            )
+        } else {
+            None
+        }
+    }
+}
+
+pub struct GlslVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub is_gles: bool,
+}
+
+impl GlslVersion {
+    pub fn read<G: glow::HasContext>(gl: &G) -> Self {
+        Self::parse(&unsafe { gl.get_parameter_string(glow::SHADING_LANGUAGE_VERSION) })
+    }
+
+    /// Parse the OpenGL version from the version string queried from the driver
+    /// via the `GL_SHADING_LANGUAGE_VERSION` enum.
+    ///
+    /// Version strings are documented to be in the form
+    /// `<major>.<minor>[.<release>][ <vendor specific information>]`
+    /// for full-fat OpenGL, and
+    /// `OpenGL ES GLSL ES <major>.<minor>[.<release>][ <vendor specific information>]`
+    /// for OpenGL ES (however, strings omitting that prefix have been observed).
+    ///
+    /// Examples based on strings found in the wild:
+    /// ```rust
+    /// # use glow_renderer::GlslVersion;
+    /// let version = GlslVersion::parse("4.60 NVIDIA");
+    /// assert!(!version.is_gles);
+    /// assert_eq!(version.major, 4);
+    /// assert_eq!(version.minor, 6);
+    /// let version = GlslVersion::parse("OpenGL ES GLSL ES 3.20");
+    /// assert!(version.is_gles);
+    /// assert_eq!(version.major, 3);
+    /// assert_eq!(version.minor, 2);
+    /// ```
+    pub fn parse(gl_shading_language_version: &str) -> Self {
+        let (version_string, is_gles) = gl_shading_language_version
+            .strip_prefix("OpenGL ES GLSL ES ")
+            .map_or_else(
+                || (gl_shading_language_version, false),
+                |version| (version, true),
+            );
+
+        let mut parts = version_string.split(|c: char| !c.is_numeric());
+        let major = parts.next().unwrap_or("0").parse().unwrap_or(0);
+        let minor = parts.next().unwrap_or("0").parse().unwrap_or(0);
+
+        // The minor version has been observed specified as both a single- or
+        // double-digit version
+        let minor = if minor >= 10 { minor / 10 } else { minor };
+
+        Self {
+            major,
+            minor,
+            is_gles,
+        }
+    }
+}

--- a/imgui-glow-renderer/src/versions.rs
+++ b/imgui-glow-renderer/src/versions.rs
@@ -39,7 +39,7 @@ impl GlVersion {
     ///
     /// Examples based on strings found in the wild:
     /// ```rust
-    /// # use glow_renderer::GlVersion;
+    /// # use imgui_glow_renderer::versions::GlVersion;
     /// let version = GlVersion::parse("4.6.0 NVIDIA 465.27");
     /// assert!(!version.is_gles);
     /// assert_eq!(version.major, 4);
@@ -153,7 +153,7 @@ impl GlslVersion {
     ///
     /// Examples based on strings found in the wild:
     /// ```rust
-    /// # use glow_renderer::GlslVersion;
+    /// # use imgui_glow_renderer::versions::GlslVersion;
     /// let version = GlslVersion::parse("4.60 NVIDIA");
     /// assert!(!version.is_gles);
     /// assert_eq!(version.major, 4);


### PR DESCRIPTION
Apologies if this is a bit over-complicated, it got away from me a bit. However, the vast majority of the OpenGL logic is based on the [upstream example](https://github.com/ocornut/imgui/blob/fe245914114588f272b0924538fdd43f6c127a26/backends/imgui_impl_opengl3.cpp), so I hope it is mostly correct.

Where it differs are in three traits (`ContextStateManager`, `ShaderProvider`, and `TextureMap`) which users can implement to customise how the renderer behaves. It also supports either owning the OpenGL context, or borrowing it when needed. But, as the `01_basic.rs` example shows, basic usage remains simple.

Hopefully the examples and code are relatively self-explanatory. I started writing docs, but then I got a compiler crash while running `cargo doc`, so I just sort of stopped.

Happy to change/fix as needed. Any testing would be great -- I've only tested on Linux with nvidia drivers.