### PR TITLE
Add "freetype" feature

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -61,6 +61,8 @@ with the exception of the current default winit feature/dep version. Additionall
       - If you're using `DEP_IMGUI_DEFINE_`s for this already, then no change is needed.
     - If you're using `.cargo/config` to apply a build script override and link against a prebuilt `Dear Imgui` (or something else along these lines), you need to ensure you link with a version that was built using `-DIMGUI_USE_WCHAR32`.
 
+- Support for the freetype font rasterizer. Enabled by the non-default `freetype` feature, e.g `imgui = {version = "...", features=["freetype"]})`
+
 ## [0.7.0] - 2021-02-04
 
 - Upgrade to [Dear ImGui v1.80](https://github.com/ocornut/imgui/releases/tag/v1.80). (Note that the new table functionality is not yet supported, however)

--- a/README.markdown
+++ b/README.markdown
@@ -47,6 +47,7 @@ Window::new(im_str!("Hello world"))
   for more information and justification for this design.
 - Easy integration with Glium / pre-ll gfx (renderer)
 - Easy integration with winit (backend platform)
+- Optional support for the freetype font rasterizer
 
 ## Choosing a backend platform and a renderer
 

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -18,7 +18,9 @@ chlorine = "1.0.7"
 
 [build-dependencies]
 cc = "1.0"
+pkg-config = { version="0.3", optional=true }
 
 [features]
 default = []
 wasm = []
+freetype = ["pkg-config"]

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -48,6 +48,20 @@ fn main() -> io::Result<()> {
             build.define(key, *value);
         }
 
+        // Freetype font rasterizer feature
+        if std::env::var_os("CARGO_FEATURE_FREETYPE").is_some() {
+            let freetype = pkg_config::Config::new().find("freetype2").unwrap();
+            for include in freetype.include_paths.iter() {
+                build.include(include);
+            }
+            build.define("IMGUI_ENABLE_FREETYPE", None);
+            println!("cargo:DEFINE_{}={}", "IMGUI_ENABLE_FREETYPE", "");
+
+            // imgui_freetype.cpp needs access to imgui.h
+            build.include(
+                manifest_dir.join("third-party/imgui/"));
+        }
+
         let compiler = build.get_compiler();
         // Avoid the if-supported flag functions for easy cases, as they're
         // kinda costly.

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -49,7 +49,7 @@ fn main() -> io::Result<()> {
         }
 
         // Freetype font rasterizer feature
-        #[cfg(feature = "feature")]
+        #[cfg(feature = "freetype")]
         {
             let freetype = pkg_config::Config::new().find("freetype2").unwrap();
             for include in freetype.include_paths.iter() {

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -56,7 +56,7 @@ fn main() -> io::Result<()> {
                 build.include(include);
             }
             build.define("IMGUI_ENABLE_FREETYPE", None);
-            println!("cargo:DEFINE_{}={}", "IMGUI_ENABLE_FREETYPE", "");
+            println!("cargo:DEFINE_IMGUI_ENABLE_FREETYPE=");
 
             // imgui_freetype.cpp needs access to imgui.h
             build.include(manifest_dir.join("third-party/imgui/"));

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -49,7 +49,8 @@ fn main() -> io::Result<()> {
         }
 
         // Freetype font rasterizer feature
-        if std::env::var_os("CARGO_FEATURE_FREETYPE").is_some() {
+        #[cfg(feature = "feature")]
+        {
             let freetype = pkg_config::Config::new().find("freetype2").unwrap();
             for include in freetype.include_paths.iter() {
                 build.include(include);

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -59,8 +59,7 @@ fn main() -> io::Result<()> {
             println!("cargo:DEFINE_{}={}", "IMGUI_ENABLE_FREETYPE", "");
 
             // imgui_freetype.cpp needs access to imgui.h
-            build.include(
-                manifest_dir.join("third-party/imgui/"));
+            build.include(manifest_dir.join("third-party/imgui/"));
         }
 
         let compiler = build.get_compiler();

--- a/imgui-sys/include_all_imgui.cpp
+++ b/imgui-sys/include_all_imgui.cpp
@@ -9,4 +9,8 @@
 #include "./third-party/imgui/imgui_tables.cpp"
 #include "./third-party/cimgui.cpp"
 
+#ifdef IMGUI_ENABLE_FREETYPE
+#include "./third-party/imgui/misc/freetype/imgui_freetype.cpp"
+#endif
+
 

--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -19,6 +19,7 @@ parking_lot = "0.11"
 
 [features]
 wasm = ["imgui-sys/wasm"]
+freetype = ["imgui-sys/freetype"]
 
 [dev-dependencies]
 memoffset = "0.6"


### PR DESCRIPTION
Quick attempt at #359 - adds feature to enable the [freetype font rasterizer](https://github.com/ocornut/imgui/tree/d0c6dd9bafcfb0845153080fe00d74e62ad28c86/misc/freetype)

Not tested much beyond "seems to work" comparing before/after with:
```
cargo run --example multiple_fonts --features freetype
```
..which requires `libfreetype6-dev` on Debian. No idea how it'll get on under other platforms, particularly Windows

There is one compiler warning:

```
warning: ./third-party/imgui/misc/freetype/imgui_freetype.cpp:357:8: warning: ‘ImFontBuildSrcGlyphFT’ has a field ‘ImFontBuildSrcGlyphFT::Info’ whose type uses the anonymous namespace [-Wsubobject-linkage]
warning:  struct ImFontBuildSrcGlyphFT
warning:         ^~~~~~~~~~~~~~~~~~~~~
warning: ./third-party/imgui/misc/freetype/imgui_freetype.cpp:366:8: warning: ‘ImFontBuildSrcDataFT’ has a field ‘ImFontBuildSrcDataFT::Font’ whose type uses the anonymous namespace [-Wsubobject-linkage]
warning:  struct ImFontBuildSrcDataFT
warning:         ^~~~~~~~~~~~~~~~~~~~
```
..which I think is an upstream thing