### PR TITLE
Fix examples DPI scaling when scaling is non-integer

### DIFF
--- a/imgui-examples/examples/support/mod.rs
+++ b/imgui-examples/examples/support/mod.rs
@@ -46,7 +46,7 @@ pub fn init(title: &str) -> System {
     {
         let gl_window = display.gl_window();
         let window = gl_window.window();
-        platform.attach_window(imgui.io_mut(), window, HiDpiMode::Rounded);
+        platform.attach_window(imgui.io_mut(), window, HiDpiMode::Default);
     }
 
     let hidpi_factor = platform.hidpi_factor();

--- a/imgui-gfx-examples/examples/support/mod.rs
+++ b/imgui-gfx-examples/examples/support/mod.rs
@@ -64,7 +64,7 @@ pub fn init(title: &str) -> System {
     imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
 
     let render_sys = RenderSystem::init(&mut imgui, builder, &events_loop);
-    platform.attach_window(imgui.io_mut(), render_sys.window(), HiDpiMode::Rounded);
+    platform.attach_window(imgui.io_mut(), render_sys.window(), HiDpiMode::Default);
     System {
         events_loop,
         imgui,


### PR DESCRIPTION
I recently ran into an issue where DPI scaling on Windows wouldn't work properly if scaling by a non-integer value (125%, 150%, 175% etc). My program was based on the example's `support/mod.rs` file.

When you start the program (not changing DPI while program is already running), the GUI would be offset, and the hitboxes for the buttons wouldn't line up with the buttons themselves. I re-tested this on the imgui-rs hello-world example, and the same thing happened.

Changing the HiDpiMode to `HiDpiMode::Default` in `mod.rs` seems to fix the issue - non-integer scaling values work correctly when the program is started, and the UI is still usable if you change DPI while the program is running.

I'm not sure if this is the correct way to fix this problem though, so I'm leaving this as a draft PR.

I also changed the value in the `imgui-gfx-examples` folder, but I haven't tested that as I haven't got it to run on my computer.