### PR TITLE
Test against Rust 1.48

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,21 @@ jobs:
   clippy:
     name: Run linter
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust: ["1.48"]
+
     env:
       RUSTFLAGS: -D warnings
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Checkout submodules
-        shell: bash
-        run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-          git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+        with: {submodules: true}
       - uses: hecrj/setup-rust-action@v1
         with:
           components: clippy
+          rust-version: ${{ matrix.rust }}
       - name: Cache cargo directories
         uses: actions/cache@v2
         with:
@@ -55,19 +56,19 @@ jobs:
   rustfmt:
     name: Check rustfmt
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust: ["1.48"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      # TODO: why not `with: {submodules: true}`
-      - name: Checkout submodules
-        shell: bash
-        run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-          git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+        with: {submodules: true}
       - uses: hecrj/setup-rust-action@v1
         with:
           components: rustfmt
+          rust-version: ${{ matrix.rust }}
       - run: cargo fmt --all -- --check
 
   test:
@@ -82,6 +83,7 @@ jobs:
         rust:
           - stable
           - beta
+          - "1.48"
         os:
           - ubuntu-latest
           - macos-latest

--- a/xtask/src/submodules.rs
+++ b/xtask/src/submodules.rs
@@ -188,7 +188,11 @@ fn git_submodule_update_init_recursive() -> Result<()> {
     static NO_PROGRESS_FLAG: AtomicBool = AtomicBool::new(false);
 
     fn do_git_smu(with_progress_flag: bool) -> Result<()> {
-        let flag = with_progress_flag.then(|| "--progress");
+        let flag = if with_progress_flag {
+            Some("--progress")
+        } else {
+            None
+        };
         xshell::cmd!("git submodule update --init --recursive {flag...}")
             .echo_cmd(crate::verbose())
             .run()?;


### PR DESCRIPTION
Currently Rust 1.48 is the minimum required by the project (excluding one usage of `bool::then` in one of the `xtask submodule` command), mainly due to the `#[doc(alias = ..)]` which was stabilized then

So I've added this version to be tested in CI, so use of any newer things can be noticed and, at the very least, noted in changelog for a new release (pending a policy being decided in #402)

Additionally clippy will be run from this version to avoid the linter-whackamole problem, when a new stable adds new lints and suddenly fails CI on previously-accepted code