### PR TITLE
Remove noisy println statements

### DIFF
--- a/imgui/src/clipboard.rs
+++ b/imgui/src/clipboard.rs
@@ -64,14 +64,9 @@ impl fmt::Debug for ClipboardContext {
 
 pub(crate) unsafe extern "C" fn get_clipboard_text(user_data: *mut c_void) -> *const c_char {
     let result = catch_unwind(|| {
-        println!("gettin!");
         let ctx = &mut *(user_data as *mut ClipboardContext);
-        println!("gettin!");
-
         match ctx.backend.get() {
             Some(text) => {
-                println!("gettin!");
-
                 ctx.last_value = CString::new(text).unwrap();
                 ctx.last_value.as_ptr()
             }


### PR DESCRIPTION
Removes what appears to be development/debug `println!` leftovers. 
Caused quite the confusion when working on clipboard integration in our project.