### PR TITLE
decided to feature gate the tables API

### DIFF
--- a/imgui-examples/Cargo.toml
+++ b/imgui-examples/Cargo.toml
@@ -13,6 +13,6 @@ publish = false
 clipboard = "0.5"
 glium = { version = "0.30", default-features = true }
 image = "0.23"
-imgui = { path = "../imgui" }
+imgui = { path = "../imgui", features = ["tables-api"] }
 imgui-glium-renderer = { path = "../imgui-glium-renderer" }
 imgui-winit-support = { path = "../imgui-winit-support" }

--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -23,6 +23,9 @@ default = ["min-const-generics"]
 wasm = ["imgui-sys/wasm"]
 freetype = ["imgui-sys/freetype"]
 min-const-generics = []
+# this api is in beta in the upstream imgui crate. See issue #524 for more info.
+# it should be stable and fine to use though.
+tables-api = []
 
 [dev-dependencies]
 memoffset = "0.6"

--- a/imgui/src/lib.rs
+++ b/imgui/src/lib.rs
@@ -34,6 +34,8 @@ pub use self::render::renderer::*;
 pub use self::stacks::*;
 pub use self::string::*;
 pub use self::style::*;
+
+#[cfg(feature = "tables-api")]
 pub use self::tables::*;
 pub use self::utils::*;
 pub use self::widget::color_editors::*;
@@ -77,6 +79,7 @@ mod popups;
 mod render;
 mod stacks;
 mod style;
+#[cfg(feature = "tables-api")]
 mod tables;
 #[cfg(test)]
 mod test;
@@ -289,6 +292,9 @@ impl<T> From<*mut T> for Id<'static> {
 }
 
 impl<'a> Id<'a> {
+    // this is used in the tables-api and possibly elsewhere,
+    // but not with just default features...
+    #[allow(dead_code)]
     fn as_imgui_id(&self) -> sys::ImGuiID {
         unsafe {
             match self {


### PR DESCRIPTION
I have decided, for 0.8.0, to feature gate the Tables API. It's technically still in Beta, which slightly bothers me, and I dislike that it's trivial to cause a null deref error, which gives a bad crash (ie, no stacktrace).

I have no made this part of the default features, so users will need to opt into it. For the record, I will personally be using it in my own projects -- I think it's fine, just has some rough edges that would be nice to see removed.
