### PR TITLE
disabled debug_message_insert_support on apple

### DIFF
--- a/imgui-glow-renderer/Cargo.toml
+++ b/imgui-glow-renderer/Cargo.toml
@@ -37,7 +37,7 @@ default = [
 ]
 # Enable checking for OpenGL extensions
 gl_extensions_support = []
-# Support for `glPrimitiveRestartIndex`
+# Support for `gl.debug_message_insert`
 debug_message_insert_support = []
 # Support for `glBindVertexArray`
 bind_vertex_array_support = []


### PR DESCRIPTION
Allows for mac to work out of the box in the `glow` renderer. The cfg bound is a bit messy, but should be fine.