### PR TITLE
fix typo in Ui::button documentation

### DIFF
--- a/imgui/src/color.rs
+++ b/imgui/src/color.rs
@@ -5,7 +5,7 @@
 /// bytes). For clarity: we don't support an equivalent to the
 /// `IMGUI_USE_BGRA_PACKED_COLOR` define.
 ///
-/// This used to be named `ImColor32`, but was renamed to avoid confusion with
+/// This used to be named `ImColor`, but was renamed to avoid confusion with
 /// the type with that name in the C++ API (which uses 32 bits per channel).
 ///
 /// While it doesn't provide methods to access the fields, they can be accessed

--- a/imgui/src/widget/misc.rs
+++ b/imgui/src/widget/misc.rs
@@ -26,7 +26,6 @@ impl<'ui> Ui<'ui> {
     /// This is the equivalent of [button_with_size](Self::button_with_size)
     /// with `size` set to `[0.0, 0.0]`, which will size the button to the
     /// label's width in the current style.
-    /// the current style.
     #[doc(alias = "Button")]
     pub fn button(&self, label: impl AsRef<str>) -> bool {
         self.button_with_size(label, [0.0, 0.0])


### PR DESCRIPTION
These are simple fixes to a typos in the documentation.