### PR TITLE
Switch [f32; _] types in the public api to `mint` equivalents

### DIFF
--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -545,7 +545,7 @@ fn show_test_window(ui: &Ui, state: &mut State, opened: &mut bool) {
             ui.input_float3("input float3", &mut state.vec3f)
                 .build();
             ColorEdit3::new("color 1", &mut state.col1).build(ui);
-            ColorEdit3::new("color 2", &mut state.col2).build(ui);
+            ColorEdit4::new("color 2", &mut state.col2).build(ui);
 
             TreeNode::new("Multi-component Widgets").build(ui, || {
                 ui.input_float2("input float2", &mut state.vec2f)
@@ -601,19 +601,19 @@ fn show_test_window(ui: &Ui, state: &mut State, opened: &mut bool) {
                     "Click on the colored square to open a color picker.
 CTRL+click on individual component to input value.\n",
                 );
-                ColorEdit3::new("MyColor##1", &mut s.color)
+                ColorEdit4::new("MyColor##1", &mut s.color)
                     .flags(misc_flags)
                     .alpha(false)
                     .build(ui);
 
                 ui.text("Color widget HSV with Alpha:");
-                ColorEdit3::new("MyColor##2", &mut s.color)
+                ColorEdit4::new("MyColor##2", &mut s.color)
                     .flags(misc_flags)
                     .input_mode(ColorEditInputMode::HSV)
                     .build(ui);
 
                 ui.text("Color widget with Float Display:");
-                ColorEdit3::new("MyColor##2f", &mut s.color)
+                ColorEdit4::new("MyColor##2f", &mut s.color)
                     .flags(misc_flags)
                     .format(ColorFormat::Float)
                     .build(ui);
@@ -627,7 +627,7 @@ CTRL+click on individual component to input value.\n",
                      With the label(false) function you can pass a non-empty label which \
                      will only be used for the tooltip and picker popup.",
                 );
-                ColorEdit3::new("MyColor##3", &mut s.color)
+                ColorEdit4::new("MyColor##3", &mut s.color)
                     .flags(misc_flags)
                     .inputs(false)
                     .label(false)
@@ -642,13 +642,13 @@ CTRL+click on individual component to input value.\n",
                     ui.checkbox("With Ref Color", &mut s.ref_color);
                     if s.ref_color {
                         ui.same_line();
-                        ColorEdit3::new("##RefColor", &mut s.ref_color_v)
+                        ColorEdit4::new("##RefColor", &mut s.ref_color_v)
                             .flags(misc_flags)
                             .inputs(false)
                             .build(ui);
                     }
                 }
-                let mut b = ColorPicker3::new
+                let mut b = ColorPicker4::new
                     ("MyColor##4", &mut s.color)
                     .flags(misc_flags)
                     .alpha(s.alpha)
@@ -657,7 +657,7 @@ CTRL+click on individual component to input value.\n",
                     .display_rgb(true);
 
                 if s.ref_color {
-                    b = b.reference_color(&s.ref_color_v)
+                    b = b.reference_color(s.ref_color_v)
                 }
                 b.build(ui);
             });
@@ -806,7 +806,7 @@ CTRL+click on individual component to input value.\n",
                     let items = &["aaaa", "bbbb", "cccc", "dddd", "eeee"];
                     ui.combo_simple_string("Combo", &mut state.stacked_modals_item, items);
 
-                    ColorEdit3::new("color", &mut state.stacked_modals_color).build(ui);
+                    ColorEdit4::new("color", &mut state.stacked_modals_color).build(ui);
 
                     if ui.button("Add another modal..") {
                         ui.open_popup("Stacked 2")   ;

--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -544,8 +544,8 @@ fn show_test_window(ui: &Ui, state: &mut State, opened: &mut bool) {
             Drag::new("drag float").range(-1.0, 1.0).speed(0.001).build(ui, &mut state.f0);
             ui.input_float3("input float3", &mut state.vec3f)
                 .build();
-            ColorEdit::new("color 1", &mut state.col1).build(ui);
-            ColorEdit::new("color 2", &mut state.col2).build(ui);
+            ColorEdit3::new("color 1", &mut state.col1).build(ui);
+            ColorEdit3::new("color 2", &mut state.col2).build(ui);
 
             TreeNode::new("Multi-component Widgets").build(ui, || {
                 ui.input_float2("input float2", &mut state.vec2f)
@@ -601,19 +601,19 @@ fn show_test_window(ui: &Ui, state: &mut State, opened: &mut bool) {
                     "Click on the colored square to open a color picker.
 CTRL+click on individual component to input value.\n",
                 );
-                ColorEdit::new("MyColor##1", &mut s.color)
+                ColorEdit3::new("MyColor##1", &mut s.color)
                     .flags(misc_flags)
                     .alpha(false)
                     .build(ui);
 
                 ui.text("Color widget HSV with Alpha:");
-                ColorEdit::new("MyColor##2", &mut s.color)
+                ColorEdit3::new("MyColor##2", &mut s.color)
                     .flags(misc_flags)
                     .input_mode(ColorEditInputMode::HSV)
                     .build(ui);
 
                 ui.text("Color widget with Float Display:");
-                ColorEdit::new("MyColor##2f", &mut s.color)
+                ColorEdit3::new("MyColor##2f", &mut s.color)
                     .flags(misc_flags)
                     .format(ColorFormat::Float)
                     .build(ui);
@@ -627,7 +627,7 @@ CTRL+click on individual component to input value.\n",
                      With the label(false) function you can pass a non-empty label which \
                      will only be used for the tooltip and picker popup.",
                 );
-                ColorEdit::new("MyColor##3", &mut s.color)
+                ColorEdit3::new("MyColor##3", &mut s.color)
                     .flags(misc_flags)
                     .inputs(false)
                     .label(false)
@@ -642,13 +642,13 @@ CTRL+click on individual component to input value.\n",
                     ui.checkbox("With Ref Color", &mut s.ref_color);
                     if s.ref_color {
                         ui.same_line();
-                        ColorEdit::new("##RefColor", &mut s.ref_color_v)
+                        ColorEdit3::new("##RefColor", &mut s.ref_color_v)
                             .flags(misc_flags)
                             .inputs(false)
                             .build(ui);
                     }
                 }
-                let mut b = ColorPicker::new
+                let mut b = ColorPicker3::new
                     ("MyColor##4", &mut s.color)
                     .flags(misc_flags)
                     .alpha(s.alpha)
@@ -806,7 +806,7 @@ CTRL+click on individual component to input value.\n",
                     let items = &["aaaa", "bbbb", "cccc", "dddd", "eeee"];
                     ui.combo_simple_string("Combo", &mut state.stacked_modals_item, items);
 
-                    ColorEdit::new("color", &mut state.stacked_modals_color).build(ui);
+                    ColorEdit3::new("color", &mut state.stacked_modals_color).build(ui);
 
                     if ui.button("Add another modal..") {
                         ui.open_popup("Stacked 2")   ;
@@ -976,7 +976,7 @@ fn show_example_app_custom_rendering(ui: &Ui, state: &mut CustomRenderingState, 
         .build(|| {
             ui.text("Primitives");
             // TODO: Add DragFloat to change value of sz
-            ColorEdit::new("Color", &mut state.col).build(ui);
+            ColorEdit3::new("Color", &mut state.col).build(ui);
             let draw_list = ui.get_window_draw_list();
             let p = ui.cursor_screen_pos();
             let spacing = 8.0;

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["third-party/*.json", "third-party/*.lua", "third-party/imgui/*/"]
 
 [dependencies]
 chlorine = "1.0.7"
-mint = "0.5"
+mint = "0.5.6"
 
 [build-dependencies]
 cc = "1.0"

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["third-party/*.json", "third-party/*.lua", "third-party/imgui/*/"]
 
 [dependencies]
 chlorine = "1.0.7"
+mint = "0.5"
 
 [build-dependencies]
 cc = "1.0"

--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -77,6 +77,17 @@ impl From<mint::Vector2<f32>> for ImVec2 {
     }
 }
 
+impl From<mint::Vector4<f32>> for ImVec4 {
+    fn from(o: mint::Vector4<f32>) -> Self {
+        Self {
+            x: o.x,
+            y: o.y,
+            z: o.z,
+            w: o.w,
+        }
+    }
+}
+
 impl ImVec4 {
     #[inline]
     pub const fn new(x: f32, y: f32, z: f32, w: f32) -> ImVec4 {

--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -71,6 +71,12 @@ impl From<ImVec2> for (f32, f32) {
     }
 }
 
+impl From<mint::Vector2<f32>> for ImVec2 {
+    fn from(o: mint::Vector2<f32>) -> Self {
+        Self { x: o.x, y: o.y }
+    }
+}
+
 impl ImVec4 {
     #[inline]
     pub const fn new(x: f32, y: f32, z: f32, w: f32) -> ImVec4 {

--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["/resources"]
 [dependencies]
 bitflags = "1"
 imgui-sys = { version = "0.8.1-alpha.0", path = "../imgui-sys" }
+mint = "0.5.6"
 parking_lot = "0.11"
 
 [features]

--- a/imgui/src/color.rs
+++ b/imgui/src/color.rs
@@ -1,3 +1,5 @@
+use crate::math::MintVec4;
+
 /// Wraps u32 that represents a packed RGBA color. Mostly used by types in the
 /// low level custom drawing API, such as [`DrawListMut`](crate::DrawListMut).
 ///
@@ -217,6 +219,12 @@ impl From<u32> for ImColor32 {
     #[inline]
     fn from(color: u32) -> Self {
         ImColor32(color)
+    }
+}
+
+impl From<MintVec4> for ImColor32 {
+    fn from(v: MintVec4) -> Self {
+        Self::from_rgba_f32s(v.x, v.y, v.z, v.w)
     }
 }
 

--- a/imgui/src/draw_list.rs
+++ b/imgui/src/draw_list.rs
@@ -15,7 +15,7 @@
 
 use bitflags::bitflags;
 
-use crate::ImColor32;
+use crate::{math::MintVec2, ImColor32};
 use sys::ImDrawList;
 
 use super::Ui;
@@ -214,7 +214,12 @@ impl<'ui> ChannelsSplit<'ui> {
 impl<'ui> DrawListMut<'ui> {
     /// Returns a line from point `p1` to `p2` with color `c`.
     #[doc(alias = "AddLine")]
-    pub fn add_line<C>(&'ui self, p1: [f32; 2], p2: [f32; 2], c: C) -> Line<'ui>
+    pub fn add_line<C>(
+        &'ui self,
+        p1: impl Into<MintVec2>,
+        p2: impl Into<MintVec2>,
+        c: C,
+    ) -> Line<'ui>
     where
         C: Into<ImColor32>,
     {
@@ -224,7 +229,12 @@ impl<'ui> DrawListMut<'ui> {
     /// Returns a rectangle whose upper-left corner is at point `p1`
     /// and lower-right corner is at point `p2`, with color `c`.
     #[doc(alias = "AddRectFilled", alias = "AddRect")]
-    pub fn add_rect<C>(&'ui self, p1: [f32; 2], p2: [f32; 2], c: C) -> Rect<'ui>
+    pub fn add_rect<C>(
+        &'ui self,
+        p1: impl Into<MintVec2>,
+        p2: impl Into<MintVec2>,
+        c: C,
+    ) -> Rect<'ui>
     where
         C: Into<ImColor32>,
     {
@@ -239,8 +249,8 @@ impl<'ui> DrawListMut<'ui> {
     #[doc(alias = "AddRectFilledMultiColor")]
     pub fn add_rect_filled_multicolor<C1, C2, C3, C4>(
         &self,
-        p1: [f32; 2],
-        p2: [f32; 2],
+        p1: impl Into<MintVec2>,
+        p2: impl Into<MintVec2>,
         col_upr_left: C1,
         col_upr_right: C2,
         col_bot_right: C3,
@@ -254,8 +264,8 @@ impl<'ui> DrawListMut<'ui> {
         unsafe {
             sys::ImDrawList_AddRectFilledMultiColor(
                 self.draw_list,
-                p1.into(),
-                p2.into(),
+                p1.into().into(),
+                p2.into().into(),
                 col_upr_left.into().into(),
                 col_upr_right.into().into(),
                 col_bot_right.into().into(),
@@ -269,9 +279,9 @@ impl<'ui> DrawListMut<'ui> {
     #[doc(alias = "AddTriangleFilled", alias = "AddTriangle")]
     pub fn add_triangle<C>(
         &'ui self,
-        p1: [f32; 2],
-        p2: [f32; 2],
-        p3: [f32; 2],
+        p1: impl Into<MintVec2>,
+        p2: impl Into<MintVec2>,
+        p3: impl Into<MintVec2>,
         c: C,
     ) -> Triangle<'ui>
     where
@@ -282,7 +292,12 @@ impl<'ui> DrawListMut<'ui> {
 
     /// Returns a circle with the given `center`, `radius` and `color`.
     #[doc(alias = "AddCircleFilled", alias = "AddCircle")]
-    pub fn add_circle<C>(&'ui self, center: [f32; 2], radius: f32, color: C) -> Circle<'ui>
+    pub fn add_circle<C>(
+        &'ui self,
+        center: impl Into<MintVec2>,
+        radius: f32,
+        color: C,
+    ) -> Circle<'ui>
     where
         C: Into<ImColor32>,
     {
@@ -291,35 +306,39 @@ impl<'ui> DrawListMut<'ui> {
 
     /// Draw a text whose upper-left corner is at point `pos`.
     #[doc(alias = "AddText")]
-    pub fn add_text<C, T>(&self, pos: [f32; 2], col: C, text: T)
-    where
-        C: Into<ImColor32>,
-        T: AsRef<str>,
-    {
+    pub fn add_text(
+        &self,
+        pos: impl Into<MintVec2>,
+        col: impl Into<ImColor32>,
+        text: impl AsRef<str>,
+    ) {
         use std::os::raw::c_char;
 
         let text = text.as_ref();
         unsafe {
             let start = text.as_ptr() as *const c_char;
             let end = (start as usize + text.len()) as *const c_char;
-            sys::ImDrawList_AddText_Vec2(self.draw_list, pos.into(), col.into().into(), start, end)
+            sys::ImDrawList_AddText_Vec2(
+                self.draw_list,
+                pos.into().into(),
+                col.into().into(),
+                start,
+                end,
+            )
         }
     }
 
     /// Returns a Bezier curve stretching from `pos0` to `pos1`, whose
     /// curvature is defined by `cp0` and `cp1`.
     #[doc(alias = "AddBezier", alias = "AddBezierCubic")]
-    pub fn add_bezier_curve<C>(
+    pub fn add_bezier_curve(
         &'ui self,
-        pos0: [f32; 2],
-        cp0: [f32; 2],
-        cp1: [f32; 2],
-        pos1: [f32; 2],
-        color: C,
-    ) -> BezierCurve<'ui>
-    where
-        C: Into<ImColor32>,
-    {
+        pos0: impl Into<MintVec2>,
+        cp0: impl Into<MintVec2>,
+        cp1: impl Into<MintVec2>,
+        pos1: impl Into<MintVec2>,
+        color: impl Into<ImColor32>,
+    ) -> BezierCurve<'ui> {
         BezierCurve::new(self, pos0, cp0, cp1, pos1, color)
     }
 
@@ -328,11 +347,18 @@ impl<'ui> DrawListMut<'ui> {
     /// Clip all drawings done within the closure `f` in the given
     /// rectangle.
     #[doc(alias = "PushClipRect", alias = "PopClipRect")]
-    pub fn with_clip_rect<F>(&self, min: [f32; 2], max: [f32; 2], f: F)
+    pub fn with_clip_rect<F>(&self, min: impl Into<MintVec2>, max: impl Into<MintVec2>, f: F)
     where
         F: FnOnce(),
     {
-        unsafe { sys::ImDrawList_PushClipRect(self.draw_list, min.into(), max.into(), false) }
+        unsafe {
+            sys::ImDrawList_PushClipRect(
+                self.draw_list,
+                min.into().into(),
+                max.into().into(),
+                false,
+            )
+        }
         f();
         unsafe { sys::ImDrawList_PopClipRect(self.draw_list) }
     }
@@ -343,11 +369,17 @@ impl<'ui> DrawListMut<'ui> {
     /// rectangle. Intersect with all clipping rectangle previously on
     /// the stack.
     #[doc(alias = "PushClipRect", alias = "PopClipRect")]
-    pub fn with_clip_rect_intersect<F>(&self, min: [f32; 2], max: [f32; 2], f: F)
-    where
+    pub fn with_clip_rect_intersect<F>(
+        &self,
+        min: impl Into<MintVec2>,
+        max: impl Into<MintVec2>,
+        f: F,
+    ) where
         F: FnOnce(),
     {
-        unsafe { sys::ImDrawList_PushClipRect(self.draw_list, min.into(), max.into(), true) }
+        unsafe {
+            sys::ImDrawList_PushClipRect(self.draw_list, min.into().into(), max.into().into(), true)
+        }
         f();
         unsafe { sys::ImDrawList_PopClipRect(self.draw_list) }
     }
@@ -376,8 +408,8 @@ impl<'ui> DrawListMut<'ui> {
     pub fn add_image(
         &'ui self,
         texture_id: TextureId,
-        p_min: [f32; 2],
-        p_max: [f32; 2],
+        p_min: impl Into<MintVec2>,
+        p_max: impl Into<MintVec2>,
     ) -> Image<'_> {
         Image::new(self, texture_id, p_min, p_max)
     }
@@ -388,10 +420,10 @@ impl<'ui> DrawListMut<'ui> {
     pub fn add_image_quad(
         &'ui self,
         texture_id: TextureId,
-        p1: [f32; 2],
-        p2: [f32; 2],
-        p3: [f32; 2],
-        p4: [f32; 2],
+        p1: impl Into<MintVec2>,
+        p2: impl Into<MintVec2>,
+        p3: impl Into<MintVec2>,
+        p4: impl Into<MintVec2>,
     ) -> ImageQuad<'_> {
         ImageQuad::new(self, texture_id, p1, p2, p3, p4)
     }
@@ -400,8 +432,8 @@ impl<'ui> DrawListMut<'ui> {
     pub fn add_image_rounded(
         &'ui self,
         texture_id: TextureId,
-        p_min: [f32; 2],
-        p_max: [f32; 2],
+        p_min: impl Into<MintVec2>,
+        p_max: impl Into<MintVec2>,
         rounding: f32,
     ) -> ImageRounded<'_> {
         ImageRounded::new(self, texture_id, p_min, p_max, rounding)
@@ -419,13 +451,18 @@ pub struct Line<'ui> {
 }
 
 impl<'ui> Line<'ui> {
-    fn new<C>(draw_list: &'ui DrawListMut<'_>, p1: [f32; 2], p2: [f32; 2], c: C) -> Self
+    fn new<C>(
+        draw_list: &'ui DrawListMut<'_>,
+        p1: impl Into<MintVec2>,
+        p2: impl Into<MintVec2>,
+        c: C,
+    ) -> Self
     where
         C: Into<ImColor32>,
     {
         Self {
-            p1,
-            p2,
+            p1: p1.into().into(),
+            p2: p2.into().into(),
             color: c.into(),
             thickness: 1.0,
             draw_list,
@@ -466,13 +503,18 @@ pub struct Rect<'ui> {
 }
 
 impl<'ui> Rect<'ui> {
-    fn new<C>(draw_list: &'ui DrawListMut<'_>, p1: [f32; 2], p2: [f32; 2], c: C) -> Self
+    fn new<C>(
+        draw_list: &'ui DrawListMut<'_>,
+        p1: impl Into<MintVec2>,
+        p2: impl Into<MintVec2>,
+        c: C,
+    ) -> Self
     where
         C: Into<ImColor32>,
     {
         Self {
-            p1,
-            p2,
+            p1: p1.into().into(),
+            p2: p2.into().into(),
             color: c.into(),
             rounding: 0.0,
             flags: DrawFlags::ROUND_CORNERS_ALL,
@@ -569,18 +611,18 @@ pub struct Triangle<'ui> {
 impl<'ui> Triangle<'ui> {
     fn new<C>(
         draw_list: &'ui DrawListMut<'_>,
-        p1: [f32; 2],
-        p2: [f32; 2],
-        p3: [f32; 2],
+        p1: impl Into<MintVec2>,
+        p2: impl Into<MintVec2>,
+        p3: impl Into<MintVec2>,
         c: C,
     ) -> Self
     where
         C: Into<ImColor32>,
     {
         Self {
-            p1,
-            p2,
-            p3,
+            p1: p1.into().into(),
+            p2: p2.into().into(),
+            p3: p3.into().into(),
             color: c.into(),
             thickness: 1.0,
             filled: false,
@@ -641,12 +683,17 @@ pub struct Circle<'ui> {
 
 impl<'ui> Circle<'ui> {
     /// Typically constructed by [`DrawListMut::add_circle`]
-    pub fn new<C>(draw_list: &'ui DrawListMut<'_>, center: [f32; 2], radius: f32, color: C) -> Self
+    pub fn new<C>(
+        draw_list: &'ui DrawListMut<'_>,
+        center: impl Into<MintVec2>,
+        radius: f32,
+        color: C,
+    ) -> Self
     where
         C: Into<ImColor32>,
     {
         Self {
-            center,
+            center: center.into().into(),
             radius,
             color: color.into(),
             num_segments: 0,
@@ -720,20 +767,20 @@ impl<'ui> BezierCurve<'ui> {
     /// Typically constructed by [`DrawListMut::add_bezier_curve`]
     pub fn new<C>(
         draw_list: &'ui DrawListMut<'_>,
-        pos0: [f32; 2],
-        cp0: [f32; 2],
-        cp1: [f32; 2],
-        pos1: [f32; 2],
+        pos0: impl Into<MintVec2>,
+        cp0: impl Into<MintVec2>,
+        cp1: impl Into<MintVec2>,
+        pos1: impl Into<MintVec2>,
         c: C,
     ) -> Self
     where
         C: Into<ImColor32>,
     {
         Self {
-            pos0,
-            cp0,
-            cp1,
-            pos1,
+            pos0: pos0.into().into(),
+            cp0: cp0.into().into(),
+            cp1: cp1.into().into(),
+            pos1: pos1.into().into(),
             color: c.into(),
             thickness: 1.0,
             num_segments: None,
@@ -789,13 +836,13 @@ impl<'ui> Image<'ui> {
     pub fn new(
         draw_list: &'ui DrawListMut<'_>,
         texture_id: TextureId,
-        p_min: [f32; 2],
-        p_max: [f32; 2],
+        p_min: impl Into<MintVec2>,
+        p_max: impl Into<MintVec2>,
     ) -> Self {
         Self {
             texture_id,
-            p_min,
-            p_max,
+            p_min: p_min.into().into(),
+            p_max: p_max.into().into(),
             uv_min: [0.0, 0.0],
             uv_max: [1.0, 1.0],
             col: [1.0, 1.0, 1.0, 1.0].into(),
@@ -804,13 +851,13 @@ impl<'ui> Image<'ui> {
     }
 
     /// Set uv_min (default `[0.0, 0.0]`)
-    pub fn uv_min(mut self, uv_min: [f32; 2]) -> Self {
-        self.uv_min = uv_min;
+    pub fn uv_min(mut self, uv_min: impl Into<MintVec2>) -> Self {
+        self.uv_min = uv_min.into().into();
         self
     }
     /// Set uv_max (default `[1.0, 1.0]`)
-    pub fn uv_max(mut self, uv_max: [f32; 2]) -> Self {
-        self.uv_max = uv_max;
+    pub fn uv_max(mut self, uv_max: impl Into<MintVec2>) -> Self {
+        self.uv_max = uv_max.into().into();
         self
     }
 
@@ -862,17 +909,17 @@ impl<'ui> ImageQuad<'ui> {
     pub fn new(
         draw_list: &'ui DrawListMut<'_>,
         texture_id: TextureId,
-        p1: [f32; 2],
-        p2: [f32; 2],
-        p3: [f32; 2],
-        p4: [f32; 2],
+        p1: impl Into<MintVec2>,
+        p2: impl Into<MintVec2>,
+        p3: impl Into<MintVec2>,
+        p4: impl Into<MintVec2>,
     ) -> Self {
         Self {
             texture_id,
-            p1,
-            p2,
-            p3,
-            p4,
+            p1: p1.into().into(),
+            p2: p2.into().into(),
+            p3: p3.into().into(),
+            p4: p4.into().into(),
             uv1: [0.0, 0.0],
             uv2: [1.0, 0.0],
             uv3: [1.0, 1.0],
@@ -890,11 +937,17 @@ impl<'ui> ImageQuad<'ui> {
     /// uv3: [1, 1],
     /// uv4: [0, 1],
     /// ```
-    pub fn uv(mut self, uv1: [f32; 2], uv2: [f32; 2], uv3: [f32; 2], uv4: [f32; 2]) -> Self {
-        self.uv1 = uv1;
-        self.uv2 = uv2;
-        self.uv3 = uv3;
-        self.uv4 = uv4;
+    pub fn uv(
+        mut self,
+        uv1: impl Into<MintVec2>,
+        uv2: impl Into<MintVec2>,
+        uv3: impl Into<MintVec2>,
+        uv4: impl Into<MintVec2>,
+    ) -> Self {
+        self.uv1 = uv1.into().into();
+        self.uv2 = uv2.into().into();
+        self.uv3 = uv3.into().into();
+        self.uv4 = uv4.into().into();
         self
     }
 
@@ -949,14 +1002,14 @@ impl<'ui> ImageRounded<'ui> {
     pub fn new(
         draw_list: &'ui DrawListMut<'_>,
         texture_id: TextureId,
-        p_min: [f32; 2],
-        p_max: [f32; 2],
+        p_min: impl Into<MintVec2>,
+        p_max: impl Into<MintVec2>,
         rounding: f32,
     ) -> Self {
         Self {
             texture_id,
-            p_min,
-            p_max,
+            p_min: p_min.into().into(),
+            p_max: p_max.into().into(),
             uv_min: [0.0, 0.0],
             uv_max: [1.0, 1.0],
             col: [1.0, 1.0, 1.0, 1.0].into(),
@@ -967,13 +1020,13 @@ impl<'ui> ImageRounded<'ui> {
     }
 
     /// Set uv_min (default `[0.0, 0.0]`)
-    pub fn uv_min(mut self, uv_min: [f32; 2]) -> Self {
-        self.uv_min = uv_min;
+    pub fn uv_min(mut self, uv_min: impl Into<MintVec2>) -> Self {
+        self.uv_min = uv_min.into().into();
         self
     }
     /// Set uv_max (default `[1.0, 1.0]`)
-    pub fn uv_max(mut self, uv_max: [f32; 2]) -> Self {
-        self.uv_max = uv_max;
+    pub fn uv_max(mut self, uv_max: impl Into<MintVec2>) -> Self {
+        self.uv_max = uv_max.into().into();
         self
     }
 

--- a/imgui/src/input/mouse.rs
+++ b/imgui/src/input/mouse.rs
@@ -1,5 +1,6 @@
 use std::ptr;
 
+use crate::math::MintVec2;
 use crate::sys;
 use crate::Ui;
 
@@ -133,8 +134,12 @@ impl<'ui> Ui<'ui> {
     ///
     /// Clipped by current clipping settings, but disregards other factors like focus, window
     /// ordering, modal popup blocking.
-    pub fn is_mouse_hovering_rect(&self, r_min: [f32; 2], r_max: [f32; 2]) -> bool {
-        unsafe { sys::igIsMouseHoveringRect(r_min.into(), r_max.into(), true) }
+    pub fn is_mouse_hovering_rect(
+        &self,
+        r_min: impl Into<MintVec2>,
+        r_max: impl Into<MintVec2>,
+    ) -> bool {
+        unsafe { sys::igIsMouseHoveringRect(r_min.into().into(), r_max.into().into(), true) }
     }
     /// Returns the mouse position backed up at the time of opening a popup
     #[doc(alias = "GetMousePosOnOpeningCurrentPopup")]
@@ -221,8 +226,8 @@ impl<'ui> Ui<'ui> {
         unsafe { sys::igIsMousePosValid(ptr::null()) }
     }
     #[doc(alias = "IsMousePosValid")]
-    pub fn is_mouse_pos_valid(&self, mouse_pos: [f32; 2]) -> bool {
-        unsafe { sys::igIsMousePosValid(&mouse_pos.into()) }
+    pub fn is_mouse_pos_valid(&self, mouse_pos: impl Into<MintVec2>) -> bool {
+        unsafe { sys::igIsMousePosValid(&mouse_pos.into().into()) }
     }
 }
 

--- a/imgui/src/input_widget.rs
+++ b/imgui/src/input_widget.rs
@@ -2,6 +2,7 @@ use bitflags::bitflags;
 use std::ops::Range;
 use std::os::raw::{c_char, c_int, c_void};
 
+use crate::math::*;
 use crate::sys;
 use crate::Ui;
 
@@ -360,12 +361,12 @@ impl<'ui, 'p, L: AsRef<str>> InputTextMultiline<'ui, 'p, L, PassthroughCallback>
     /// your string.
     /// 3. Truncations by ImGui appear to be done primarily by insertions of `\0` to the truncation point.
     /// We will handle this for you and edit the string "properly" too, but this might show up in callbacks.
-    pub fn new(ui: &'ui Ui<'ui>, label: L, buf: &'p mut String, size: [f32; 2]) -> Self {
+    pub fn new(ui: &'ui Ui<'ui>, label: L, buf: &'p mut String, size: impl Into<MintVec2>) -> Self {
         InputTextMultiline {
             label,
             buf,
             flags: InputTextFlags::CALLBACK_RESIZE,
-            size,
+            size: size.into().into(),
             callback_handler: PassthroughCallback,
             ui,
         }
@@ -552,17 +553,22 @@ impl<'ui, 'p, L: AsRef<str>> InputFloat<'ui, 'p, L> {
 }
 
 macro_rules! impl_input_floatn {
-    ($InputFloatN:ident, $N:expr, $igInputFloatN:ident) => {
+    ($InputFloatN:ident, $MINT_TARGET:ident, $N:expr, $igInputFloatN:ident) => {
         #[must_use]
-        pub struct $InputFloatN<'ui, 'p, L> {
+        pub struct $InputFloatN<'ui, 'p, L, T = [f32; $N]> {
             label: L,
-            value: &'p mut [f32; $N],
+            value: &'p mut T,
             flags: InputTextFlags,
             ui: &'ui Ui<'ui>,
         }
 
-        impl<'ui, 'p, L: AsRef<str>> $InputFloatN<'ui, 'p, L> {
-            pub fn new(ui: &'ui Ui<'ui>, label: L, value: &'p mut [f32; $N]) -> Self {
+        impl<'ui, 'p, L, T> $InputFloatN<'ui, 'p, L, T>
+        where
+            L: AsRef<str>,
+            T: From<$MINT_TARGET> + Copy,
+            $MINT_TARGET: From<T>,
+        {
+            pub fn new(ui: &'ui Ui<'ui>, label: L, value: &'p mut T) -> Self {
                 $InputFloatN {
                     label,
                     value,
@@ -572,14 +578,24 @@ macro_rules! impl_input_floatn {
             }
 
             pub fn build(self) -> bool {
-                unsafe {
+                let value: $MINT_TARGET = $MINT_TARGET::from(*self.value);
+                let mut value: [f32; $N] = value.into();
+
+                let changed = unsafe {
                     sys::$igInputFloatN(
                         self.ui.scratch_txt(self.label),
-                        self.value.as_mut_ptr(),
+                        value.as_mut_ptr(),
                         b"%.3f\0".as_ptr() as *const _,
                         self.flags.bits() as i32,
                     )
+                };
+
+                if changed {
+                    let value: $MINT_TARGET = value.into();
+                    *self.value = value.into();
                 }
+
+                changed
             }
 
             impl_text_flags!($InputFloatN);
@@ -587,22 +603,27 @@ macro_rules! impl_input_floatn {
     };
 }
 
-impl_input_floatn!(InputFloat2, 2, igInputFloat2);
-impl_input_floatn!(InputFloat3, 3, igInputFloat3);
-impl_input_floatn!(InputFloat4, 4, igInputFloat4);
+impl_input_floatn!(InputFloat2, MintVec2, 2, igInputFloat2);
+impl_input_floatn!(InputFloat3, MintVec3, 3, igInputFloat3);
+impl_input_floatn!(InputFloat4, MintVec4, 4, igInputFloat4);
 
 macro_rules! impl_input_intn {
-    ($InputIntN:ident, $N:expr, $igInputIntN:ident) => {
+    ($InputIntN:ident, $MINT_TARGET:ident, $N:expr, $igInputIntN:ident) => {
         #[must_use]
-        pub struct $InputIntN<'ui, 'p, L> {
+        pub struct $InputIntN<'ui, 'p, L, T> {
             label: L,
-            value: &'p mut [i32; $N],
+            value: &'p mut T,
             flags: InputTextFlags,
             ui: &'ui Ui<'ui>,
         }
 
-        impl<'ui, 'p, L: AsRef<str>> $InputIntN<'ui, 'p, L> {
-            pub fn new(ui: &'ui Ui<'ui>, label: L, value: &'p mut [i32; $N]) -> Self {
+        impl<'ui, 'p, L, T> $InputIntN<'ui, 'p, L, T>
+        where
+            L: AsRef<str>,
+            T: From<$MINT_TARGET> + Copy,
+            $MINT_TARGET: From<T>,
+        {
+            pub fn new(ui: &'ui Ui<'ui>, label: L, value: &'p mut T) -> Self {
                 $InputIntN {
                     label,
                     value,
@@ -612,13 +633,23 @@ macro_rules! impl_input_intn {
             }
 
             pub fn build(self) -> bool {
-                unsafe {
+                let value: $MINT_TARGET = $MINT_TARGET::from(*self.value);
+                let mut value: [i32; $N] = value.into();
+
+                let changed = unsafe {
                     sys::$igInputIntN(
                         self.ui.scratch_txt(self.label),
-                        self.value.as_mut_ptr(),
+                        value.as_mut_ptr(),
                         self.flags.bits() as i32,
                     )
+                };
+
+                if changed {
+                    let value: $MINT_TARGET = value.into();
+                    *self.value = value.into();
                 }
+
+                changed
             }
 
             impl_text_flags!($InputIntN);
@@ -626,9 +657,9 @@ macro_rules! impl_input_intn {
     };
 }
 
-impl_input_intn!(InputInt2, 2, igInputInt2);
-impl_input_intn!(InputInt3, 3, igInputInt3);
-impl_input_intn!(InputInt4, 4, igInputInt4);
+impl_input_intn!(InputInt2, MintIVec2, 2, igInputInt2);
+impl_input_intn!(InputInt3, MintIVec3, 3, igInputInt3);
+impl_input_intn!(InputInt4, MintIVec4, 4, igInputInt4);
 
 bitflags!(
     /// Callback flags for an `InputText` widget. These correspond to

--- a/imgui/src/input_widget.rs
+++ b/imgui/src/input_widget.rs
@@ -553,9 +553,9 @@ impl<'ui, 'p, L: AsRef<str>> InputFloat<'ui, 'p, L> {
 }
 
 macro_rules! impl_input_floatn {
-    ($InputFloatN:ident, $MINT_TARGET:ident, $N:expr, $igInputFloatN:ident) => {
+    ($InputFloatN:ident, $MINT_TARGET:ty, $N:expr, $igInputFloatN:ident) => {
         #[must_use]
-        pub struct $InputFloatN<'ui, 'p, L, T = [f32; $N]> {
+        pub struct $InputFloatN<'ui, 'p, L, T> {
             label: L,
             value: &'p mut T,
             flags: InputTextFlags,
@@ -565,8 +565,8 @@ macro_rules! impl_input_floatn {
         impl<'ui, 'p, L, T> $InputFloatN<'ui, 'p, L, T>
         where
             L: AsRef<str>,
-            T: From<$MINT_TARGET> + Copy,
-            $MINT_TARGET: From<T>,
+            T: Copy + Into<$MINT_TARGET>,
+            $MINT_TARGET: Into<T> + Into<[f32; $N]>,
         {
             pub fn new(ui: &'ui Ui<'ui>, label: L, value: &'p mut T) -> Self {
                 $InputFloatN {
@@ -578,7 +578,7 @@ macro_rules! impl_input_floatn {
             }
 
             pub fn build(self) -> bool {
-                let value: $MINT_TARGET = $MINT_TARGET::from(*self.value);
+                let value: $MINT_TARGET = (*self.value).into();
                 let mut value: [f32; $N] = value.into();
 
                 let changed = unsafe {
@@ -620,8 +620,8 @@ macro_rules! impl_input_intn {
         impl<'ui, 'p, L, T> $InputIntN<'ui, 'p, L, T>
         where
             L: AsRef<str>,
-            T: From<$MINT_TARGET> + Copy,
-            $MINT_TARGET: From<T>,
+            T: Copy + Into<$MINT_TARGET>,
+            $MINT_TARGET: Into<T> + Into<[i32; $N]>,
         {
             pub fn new(ui: &'ui Ui<'ui>, label: L, value: &'p mut T) -> Self {
                 $InputIntN {
@@ -633,7 +633,7 @@ macro_rules! impl_input_intn {
             }
 
             pub fn build(self) -> bool {
-                let value: $MINT_TARGET = $MINT_TARGET::from(*self.value);
+                let value: $MINT_TARGET = (*self.value).into();
                 let mut value: [i32; $N] = value.into();
 
                 let changed = unsafe {

--- a/imgui/src/layout.rs
+++ b/imgui/src/layout.rs
@@ -1,3 +1,4 @@
+use crate::math::MintVec2;
 use crate::sys;
 use crate::Ui;
 
@@ -64,8 +65,8 @@ impl<'ui> Ui<'ui> {
     ///
     /// Can be used to move the cursor on the window.
     #[doc(alias = "Dummy")]
-    pub fn dummy(&self, size: [f32; 2]) {
-        unsafe { sys::igDummy(size.into()) }
+    pub fn dummy(&self, size: impl Into<MintVec2>) {
+        unsafe { sys::igDummy(size.into().into()) }
     }
 
     /// Moves content position to the right by `Style::indent_spacing`
@@ -126,8 +127,8 @@ impl<'ui> Ui<'ui> {
     ///
     /// This sets the point on which the next widget will be drawn.
     #[doc(alias = "SetCursorPos")]
-    pub fn set_cursor_pos(&self, pos: [f32; 2]) {
-        unsafe { sys::igSetCursorPos(pos.into()) };
+    pub fn set_cursor_pos(&self, pos: impl Into<MintVec2>) {
+        unsafe { sys::igSetCursorPos(pos.into().into()) };
     }
     /// Returns the initial cursor position (in window coordinates)
     #[doc(alias = "GetCursorStartPos")]
@@ -147,8 +148,8 @@ impl<'ui> Ui<'ui> {
     }
     /// Sets the cursor position (in absolute screen coordinates)
     #[doc(alias = "SetCursorScreenPos")]
-    pub fn set_cursor_screen_pos(&self, pos: [f32; 2]) {
-        unsafe { sys::igSetCursorScreenPos(pos.into()) }
+    pub fn set_cursor_screen_pos(&self, pos: impl Into<MintVec2>) {
+        unsafe { sys::igSetCursorScreenPos(pos.into().into()) }
     }
     /// Vertically aligns text baseline so that it will align properly to regularly frame items.
     ///

--- a/imgui/src/lib.rs
+++ b/imgui/src/lib.rs
@@ -48,6 +48,7 @@ pub use self::widget::tree::*;
 pub use self::window::child_window::*;
 pub use self::window::*;
 use internal::RawCast;
+use math::*;
 
 #[macro_use]
 mod string;
@@ -68,6 +69,7 @@ pub mod internal;
 mod io;
 mod layout;
 mod list_clipper;
+mod math;
 mod plothistogram;
 mod plotlines;
 mod popups;
@@ -81,7 +83,6 @@ mod test;
 mod utils;
 mod widget;
 mod window;
-mod math;
 
 // Used by macros. Underscores are just to make it clear it's not part of the
 // public API.
@@ -388,27 +389,43 @@ impl<'ui> Ui<'ui> {
     ) -> InputFloat<'ui, 'p, L> {
         InputFloat::new(self, label, value)
     }
-    pub fn input_float2<'p, L: AsRef<str>>(
+    #[doc(alias = "InputFloat2")]
+    pub fn input_float2<'p, L, T>(
         &'ui self,
         label: L,
-        value: &'p mut [f32; 2],
-    ) -> InputFloat2<'ui, 'p, L> {
+        value: &'p mut T,
+    ) -> InputFloat2<'ui, 'p, L, T>
+    where
+        L: AsRef<str>,
+        T: From<MintVec2> + Copy,
+        MintVec2: From<T>,
+    {
         InputFloat2::new(self, label, value)
     }
     #[doc(alias = "InputFloat3")]
-    pub fn input_float3<'p, L: AsRef<str>>(
+    pub fn input_float3<'p, L, T>(
         &'ui self,
         label: L,
-        value: &'p mut [f32; 3],
-    ) -> InputFloat3<'ui, 'p, L> {
+        value: &'p mut T,
+    ) -> InputFloat3<'ui, 'p, L, T>
+    where
+        L: AsRef<str>,
+        T: From<MintVec3> + Copy,
+        MintVec3: From<T>,
+    {
         InputFloat3::new(self, label, value)
     }
     #[doc(alias = "InputFloat4")]
-    pub fn input_float4<'p, L: AsRef<str>>(
+    pub fn input_float4<'p, L, T>(
         &'ui self,
         label: L,
-        value: &'p mut [f32; 4],
-    ) -> InputFloat4<'ui, 'p, L> {
+        value: &'p mut T,
+    ) -> InputFloat4<'ui, 'p, L, T>
+    where
+        L: AsRef<str>,
+        T: From<MintVec4> + Copy,
+        MintVec4: From<T>,
+    {
         InputFloat4::new(self, label, value)
     }
     #[doc(alias = "InputInt")]
@@ -420,27 +437,30 @@ impl<'ui> Ui<'ui> {
         InputInt::new(self, label, value)
     }
     #[doc(alias = "InputInt2")]
-    pub fn input_int2<'p, L: AsRef<str>>(
-        &'ui self,
-        label: L,
-        value: &'p mut [i32; 2],
-    ) -> InputInt2<'ui, 'p, L> {
+    pub fn input_int2<'p, L, T>(&'ui self, label: L, value: &'p mut T) -> InputInt2<'ui, 'p, L, T>
+    where
+        L: AsRef<str>,
+        T: From<MintIVec2> + Copy,
+        MintIVec2: From<T>,
+    {
         InputInt2::new(self, label, value)
     }
     #[doc(alias = "InputInt3")]
-    pub fn input_int3<'p, L: AsRef<str>>(
-        &'ui self,
-        label: L,
-        value: &'p mut [i32; 3],
-    ) -> InputInt3<'ui, 'p, L> {
+    pub fn input_int3<'p, L, T>(&'ui self, label: L, value: &'p mut T) -> InputInt3<'ui, 'p, L, T>
+    where
+        L: AsRef<str>,
+        T: From<MintIVec3> + Copy,
+        MintIVec3: From<T>,
+    {
         InputInt3::new(self, label, value)
     }
     #[doc(alias = "InputInt4")]
-    pub fn input_int4<'p, L: AsRef<str>>(
-        &'ui self,
-        label: L,
-        value: &'p mut [i32; 4],
-    ) -> InputInt4<'ui, 'p, L> {
+    pub fn input_int4<'p, L, T>(&'ui self, label: L, value: &'p mut T) -> InputInt4<'ui, 'p, L, T>
+    where
+        L: AsRef<str>,
+        T: From<MintIVec4> + Copy,
+        MintIVec4: From<T>,
+    {
         InputInt4::new(self, label, value)
     }
 }

--- a/imgui/src/lib.rs
+++ b/imgui/src/lib.rs
@@ -81,6 +81,7 @@ mod test;
 mod utils;
 mod widget;
 mod window;
+mod math;
 
 // Used by macros. Underscores are just to make it clear it's not part of the
 // public API.

--- a/imgui/src/lib.rs
+++ b/imgui/src/lib.rs
@@ -397,8 +397,8 @@ impl<'ui> Ui<'ui> {
     ) -> InputFloat2<'ui, 'p, L, T>
     where
         L: AsRef<str>,
-        T: From<MintVec2> + Copy,
-        MintVec2: From<T>,
+        T: Copy + Into<MintVec2>,
+        MintVec2: Into<T> + Into<[f32; 2]>,
     {
         InputFloat2::new(self, label, value)
     }
@@ -410,8 +410,8 @@ impl<'ui> Ui<'ui> {
     ) -> InputFloat3<'ui, 'p, L, T>
     where
         L: AsRef<str>,
-        T: From<MintVec3> + Copy,
-        MintVec3: From<T>,
+        T: Copy + Into<MintVec3>,
+        MintVec3: Into<T> + Into<[f32; 3]>,
     {
         InputFloat3::new(self, label, value)
     }
@@ -423,8 +423,8 @@ impl<'ui> Ui<'ui> {
     ) -> InputFloat4<'ui, 'p, L, T>
     where
         L: AsRef<str>,
-        T: From<MintVec4> + Copy,
-        MintVec4: From<T>,
+        T: Copy + Into<MintVec4>,
+        MintVec4: Into<T> + Into<[f32; 4]>,
     {
         InputFloat4::new(self, label, value)
     }
@@ -440,8 +440,8 @@ impl<'ui> Ui<'ui> {
     pub fn input_int2<'p, L, T>(&'ui self, label: L, value: &'p mut T) -> InputInt2<'ui, 'p, L, T>
     where
         L: AsRef<str>,
-        T: From<MintIVec2> + Copy,
-        MintIVec2: From<T>,
+        T: Copy + Into<MintIVec2>,
+        MintIVec2: Into<T> + Into<[i32; 2]>,
     {
         InputInt2::new(self, label, value)
     }
@@ -449,8 +449,8 @@ impl<'ui> Ui<'ui> {
     pub fn input_int3<'p, L, T>(&'ui self, label: L, value: &'p mut T) -> InputInt3<'ui, 'p, L, T>
     where
         L: AsRef<str>,
-        T: From<MintIVec3> + Copy,
-        MintIVec3: From<T>,
+        T: Copy + Into<MintIVec3>,
+        MintIVec3: Into<T> + Into<[i32; 3]>,
     {
         InputInt3::new(self, label, value)
     }
@@ -458,8 +458,8 @@ impl<'ui> Ui<'ui> {
     pub fn input_int4<'p, L, T>(&'ui self, label: L, value: &'p mut T) -> InputInt4<'ui, 'p, L, T>
     where
         L: AsRef<str>,
-        T: From<MintIVec4> + Copy,
-        MintIVec4: From<T>,
+        T: Copy + Into<MintIVec4>,
+        MintIVec4: Into<T> + Into<[i32; 4]>,
     {
         InputInt4::new(self, label, value)
     }

--- a/imgui/src/math.rs
+++ b/imgui/src/math.rs
@@ -1,3 +1,7 @@
 pub(crate) type MintVec2 = mint::Vector2<f32>;
 pub(crate) type MintVec3 = mint::Vector3<f32>;
 pub(crate) type MintVec4 = mint::Vector4<f32>;
+
+pub(crate) type MintIVec2 = mint::Vector2<i32>;
+pub(crate) type MintIVec3 = mint::Vector3<i32>;
+pub(crate) type MintIVec4 = mint::Vector4<i32>;

--- a/imgui/src/math.rs
+++ b/imgui/src/math.rs
@@ -1,0 +1,1 @@
+pub type MintVec2 = mint::Vector2<f32>;

--- a/imgui/src/math.rs
+++ b/imgui/src/math.rs
@@ -1,1 +1,3 @@
-pub type MintVec2 = mint::Vector2<f32>;
+pub(crate) type MintVec2 = mint::Vector2<f32>;
+pub(crate) type MintVec3 = mint::Vector3<f32>;
+pub(crate) type MintVec4 = mint::Vector4<f32>;

--- a/imgui/src/plothistogram.rs
+++ b/imgui/src/plothistogram.rs
@@ -62,8 +62,8 @@ impl<'ui, 'p, Label: AsRef<str>, Overlay: AsRef<str>> PlotHistogram<'ui, 'p, Lab
         self
     }
 
-    pub fn graph_size(mut self, graph_size: [f32; 2]) -> Self {
-        self.graph_size = graph_size;
+    pub fn graph_size(mut self, graph_size: impl Into<crate::MintVec2>) -> Self {
+        self.graph_size = graph_size.into().into();
         self
     }
 

--- a/imgui/src/plotlines.rs
+++ b/imgui/src/plotlines.rs
@@ -62,8 +62,8 @@ impl<'ui, 'p, Label: AsRef<str>, Overlay: AsRef<str>> PlotLines<'ui, 'p, Label, 
         self
     }
 
-    pub fn graph_size(mut self, graph_size: [f32; 2]) -> Self {
-        self.graph_size = graph_size;
+    pub fn graph_size(mut self, graph_size: impl Into<crate::MintVec2>) -> Self {
+        self.graph_size = graph_size.into().into();
         self
     }
 

--- a/imgui/src/render/draw_data.rs
+++ b/imgui/src/render/draw_data.rs
@@ -1,6 +1,7 @@
 use std::slice;
 
 use crate::internal::{RawCast, RawWrapper};
+use crate::math::MintVec2;
 use crate::render::renderer::TextureId;
 use crate::sys;
 
@@ -72,7 +73,7 @@ impl DrawData {
     /// Can be used if your final output buffer is at a different scale than imgui-rs expects, or
     /// if there is a difference between your window resolution and framebuffer resolution.
     #[doc(alias = "ScaleClipRects")]
-    pub fn scale_clip_rects(&mut self, fb_scale: [f32; 2]) {
+    pub fn scale_clip_rects(&mut self, fb_scale: MintVec2) {
         unsafe {
             sys::ImDrawData_ScaleClipRects(self.raw_mut(), fb_scale.into());
         }

--- a/imgui/src/stacks.rs
+++ b/imgui/src/stacks.rs
@@ -5,6 +5,7 @@ use std::ptr;
 use crate::context::Context;
 use crate::fonts::atlas::FontId;
 use crate::internal::RawCast;
+use crate::math::MintVec4;
 use crate::style::{StyleColor, StyleVar};
 use crate::sys;
 use crate::{Id, Ui};
@@ -61,9 +62,9 @@ impl<'ui> Ui<'ui> {
     pub fn push_style_color(
         &self,
         style_color: StyleColor,
-        color: [f32; 4],
+        color: impl Into<MintVec4>,
     ) -> ColorStackToken<'_> {
-        unsafe { sys::igPushStyleColor_Vec4(style_color as i32, color.into()) };
+        unsafe { sys::igPushStyleColor_Vec4(style_color as i32, color.into().into()) };
         ColorStackToken::new(self)
     }
 

--- a/imgui/src/utils.rs
+++ b/imgui/src/utils.rs
@@ -2,7 +2,8 @@
 use bitflags::bitflags;
 
 use crate::input::mouse::MouseButton;
-use crate::style::{Style, StyleColor};
+use crate::math::MintVec2;
+use crate::style::StyleColor;
 use crate::sys;
 use crate::Ui;
 
@@ -143,13 +144,17 @@ impl<'ui> Ui<'ui> {
 impl<'ui> Ui<'ui> {
     /// Returns `true` if the rectangle (of given size, starting from cursor position) is visible
     #[doc(alias = "IsRectVisibleNil")]
-    pub fn is_cursor_rect_visible(&self, size: [f32; 2]) -> bool {
-        unsafe { sys::igIsRectVisible_Nil(size.into()) }
+    pub fn is_cursor_rect_visible(&self, size: impl Into<MintVec2>) -> bool {
+        unsafe { sys::igIsRectVisible_Nil(size.into().into()) }
     }
     /// Returns `true` if the rectangle (in screen coordinates) is visible
     #[doc(alias = "IsRectVisibleNilVec2")]
-    pub fn is_rect_visible(&self, rect_min: [f32; 2], rect_max: [f32; 2]) -> bool {
-        unsafe { sys::igIsRectVisible_Vec2(rect_min.into(), rect_max.into()) }
+    pub fn is_rect_visible(
+        &self,
+        rect_min: impl Into<MintVec2>,
+        rect_max: impl Into<MintVec2>,
+    ) -> bool {
+        unsafe { sys::igIsRectVisible_Vec2(rect_min.into().into(), rect_max.into().into()) }
     }
     /// Returns the global imgui-rs time.
     ///
@@ -173,19 +178,20 @@ impl<'ui> Ui<'ui> {
     pub fn style_color(&self, style_color: StyleColor) -> [f32; 4] {
         self.ctx.style()[style_color]
     }
-    /// Returns a shared reference to the current [`Style`].
-    ///
-    /// ## Safety
-    ///
-    /// This function is tagged as `unsafe` because pushing via
-    /// [`push_style_color`](crate::Ui::push_style_color) or
-    /// [`push_style_var`](crate::Ui::push_style_var) or popping via
-    /// [`ColorStackToken::pop`](crate::ColorStackToken::pop) or
-    /// [`StyleStackToken::pop`](crate::StyleStackToken::pop) will modify the values in the returned
-    /// shared reference. Therefore, you should not retain this reference across calls to push and
-    /// pop. The [`clone_style`](Ui::clone_style) version may instead be used to avoid `unsafe`.
-    #[doc(alias = "GetStyle")]
-    pub unsafe fn style(&self) -> &Style {
-        self.ctx.style()
-    }
+}
+
+/// Returns a shared reference to the current [`Style`].
+///
+/// ## Safety
+///
+/// This function is tagged as `unsafe` because pushing via
+/// [`push_style_color`](crate::Ui::push_style_color) or
+/// [`push_style_var`](crate::Ui::push_style_var) or popping via
+/// [`ColorStackToken::pop`](crate::ColorStackToken::pop) or
+/// [`StyleStackToken::pop`](crate::StyleStackToken::pop) will modify the values in the returned
+/// shared reference. Therefore, you should not retain this reference across calls to push and
+/// pop. The [`clone_style`](Ui::clone_style) version may instead be used to avoid `unsafe`.
+#[doc(alias = "GetStyle")]
+pub unsafe fn style(&self) -> &Style {
+    self.ctx.style()
 }

--- a/imgui/src/utils.rs
+++ b/imgui/src/utils.rs
@@ -5,6 +5,7 @@ use crate::input::mouse::MouseButton;
 use crate::math::MintVec2;
 use crate::style::StyleColor;
 use crate::sys;
+use crate::Style;
 use crate::Ui;
 
 bitflags! {
@@ -178,20 +179,20 @@ impl<'ui> Ui<'ui> {
     pub fn style_color(&self, style_color: StyleColor) -> [f32; 4] {
         self.ctx.style()[style_color]
     }
-}
 
-/// Returns a shared reference to the current [`Style`].
-///
-/// ## Safety
-///
-/// This function is tagged as `unsafe` because pushing via
-/// [`push_style_color`](crate::Ui::push_style_color) or
-/// [`push_style_var`](crate::Ui::push_style_var) or popping via
-/// [`ColorStackToken::pop`](crate::ColorStackToken::pop) or
-/// [`StyleStackToken::pop`](crate::StyleStackToken::pop) will modify the values in the returned
-/// shared reference. Therefore, you should not retain this reference across calls to push and
-/// pop. The [`clone_style`](Ui::clone_style) version may instead be used to avoid `unsafe`.
-#[doc(alias = "GetStyle")]
-pub unsafe fn style(&self) -> &Style {
-    self.ctx.style()
+    /// Returns a shared reference to the current [`Style`].
+    ///
+    /// ## Safety
+    ///
+    /// This function is tagged as `unsafe` because pushing via
+    /// [`push_style_color`](crate::Ui::push_style_color) or
+    /// [`push_style_var`](crate::Ui::push_style_var) or popping via
+    /// [`ColorStackToken::pop`](crate::ColorStackToken::pop) or
+    /// [`StyleStackToken::pop`](crate::StyleStackToken::pop) will modify the values in the returned
+    /// shared reference. Therefore, you should not retain this reference across calls to push and
+    /// pop. The [`clone_style`](Ui::clone_style) version may instead be used to avoid `unsafe`.
+    #[doc(alias = "GetStyle")]
+    pub unsafe fn style(&self) -> &Style {
+        self.ctx.style()
+    }
 }

--- a/imgui/src/widget/color_editors.rs
+++ b/imgui/src/widget/color_editors.rs
@@ -195,8 +195,8 @@ pub struct ColorEdit3<'a, T, C> {
 impl<'a, T, C> ColorEdit3<'a, T, C>
 where
     T: AsRef<str>,
-    MintVec3: From<C>,
-    C: From<MintVec3> + Copy,
+    C: Copy + Into<MintVec3>,
+    MintVec3: Into<C> + Into<[f32; 3]>,
 {
     /// Constructs a new color editor builder.
     #[doc(alias = "ColorEdit3")]
@@ -377,8 +377,8 @@ pub struct ColorEdit4<'a, T, C> {
 impl<'a, T, C> ColorEdit4<'a, T, C>
 where
     T: AsRef<str>,
-    MintVec4: From<C>,
-    C: From<MintVec4> + Copy,
+    C: Copy + Into<MintVec4>,
+    MintVec4: Into<C> + Into<[f32; 4]>,
 {
     /// Constructs a new color editor builder.
     #[doc(alias = "ColorEdit4")]
@@ -556,8 +556,8 @@ pub struct ColorPicker3<'a, Label, Color> {
 impl<'a, Label, Color> ColorPicker3<'a, Label, Color>
 where
     Label: AsRef<str>,
-    MintVec3: From<Color>,
-    Color: From<MintVec3> + Copy,
+    Color: Copy + Into<MintVec3>,
+    MintVec3: Into<Color> + Into<[f32; 3]>,
 {
     /// Constructs a new color picker builder.
     #[doc(alias = "ColorPicker3")]
@@ -696,7 +696,7 @@ where
     /// Returns true if the color value was changed.
     pub fn build(mut self, ui: &Ui<'_>) -> bool {
         self.flags.insert(ColorEditFlags::NO_ALPHA);
-        let mut value: [f32; 3] = MintVec3::from(*self.value).into();
+        let mut value: [f32; 3] = (*self.value).into().into();
         let changed = unsafe {
             sys::igColorPicker3(
                 ui.scratch_txt(self.label),
@@ -741,8 +741,8 @@ pub struct ColorPicker4<'a, Label, Color> {
 impl<'a, Label, Color> ColorPicker4<'a, Label, Color>
 where
     Label: AsRef<str>,
-    MintVec4: From<Color>,
-    Color: From<MintVec4> + Copy,
+    Color: Copy + Into<MintVec4>,
+    MintVec4: Into<Color> + Into<[f32; 4]>,
 {
     /// Constructs a new color picker builder.
     #[doc(alias = "ColorPicker4")]
@@ -888,7 +888,7 @@ where
     /// Returns true if the color value was changed.
     pub fn build(mut self, ui: &Ui<'_>) -> bool {
         self.flags.insert(ColorEditFlags::NO_ALPHA);
-        let mut value: [f32; 4] = MintVec4::from(*self.value).into();
+        let mut value: [f32; 4] = (*self.value).into().into();
         let ref_color = self.ref_color.map(|c| c.as_ptr()).unwrap_or(ptr::null());
 
         let changed = unsafe {

--- a/imgui/src/widget/color_editors.rs
+++ b/imgui/src/widget/color_editors.rs
@@ -179,7 +179,7 @@ bitflags! {
 /// # let mut imgui = Context::create();
 /// # let ui = imgui.frame();
 /// # let mut color = [0.0, 0.0, 0.0, 1.0];
-/// let ce = ColorEdit::new(im_str!("color_edit"), &mut color);
+/// let ce = ColorEdit4::new("color_edit", &mut color);
 /// if ce.build(&ui) {
 ///   println!("The color was changed");
 /// }
@@ -361,7 +361,7 @@ where
 /// # let mut imgui = Context::create();
 /// # let ui = imgui.frame();
 /// # let mut color = [0.0, 0.0, 0.0, 1.0];
-/// let ce = ColorEdit::new(im_str!("color_edit"), &mut color);
+/// let ce = ColorEdit4::new("color_edit", &mut color);
 /// if ce.build(&ui) {
 ///   println!("The color was changed");
 /// }
@@ -540,7 +540,7 @@ where
 /// # let mut imgui = Context::create();
 /// # let ui = imgui.frame();
 /// # let mut color = [0.0, 0.0, 0.0, 1.0];
-/// let cp = ColorPicker::new(im_str!("color_picker"), &mut color);
+/// let cp = ColorPicker4::new("color_picker", &mut color);
 /// if cp.build(&ui) {
 ///   println!("A color was picked");
 /// }
@@ -724,7 +724,7 @@ where
 /// # let mut imgui = Context::create();
 /// # let ui = imgui.frame();
 /// # let mut color = [0.0, 0.0, 0.0, 1.0];
-/// let cp = ColorPicker::new(im_str!("color_picker"), &mut color);
+/// let cp = ColorPicker4::new("color_picker", &mut color);
 /// if cp.build(&ui) {
 ///   println!("A color was picked");
 /// }

--- a/imgui/src/widget/image.rs
+++ b/imgui/src/widget/image.rs
@@ -1,5 +1,7 @@
 use std::os::raw::c_void;
 
+use crate::math::MintVec2;
+use crate::math::MintVec4;
 use crate::render::renderer::TextureId;
 use crate::sys;
 use crate::Ui;
@@ -19,10 +21,10 @@ pub struct Image {
 impl Image {
     /// Creates a new image builder with the given texture and size
     #[doc(alias = "Image")]
-    pub const fn new(texture_id: TextureId, size: [f32; 2]) -> Image {
+    pub fn new(texture_id: TextureId, size: impl Into<MintVec2>) -> Image {
         Image {
             texture_id,
-            size,
+            size: size.into().into(),
             uv0: [0.0, 0.0],
             uv1: [1.0, 1.0],
             tint_col: [1.0, 1.0, 1.0, 1.0],
@@ -30,28 +32,29 @@ impl Image {
         }
     }
     /// Sets the image size
-    pub const fn size(mut self, size: [f32; 2]) -> Self {
-        self.size = size;
+    #[deprecated(note = "just set the size in the `new` constructor.")]
+    pub fn size(mut self, size: impl Into<MintVec2>) -> Self {
+        self.size = size.into().into();
         self
     }
     /// Sets uv0 (default `[0.0, 0.0]`)
-    pub const fn uv0(mut self, uv0: [f32; 2]) -> Self {
-        self.uv0 = uv0;
+    pub fn uv0(mut self, uv0: impl Into<MintVec2>) -> Self {
+        self.uv0 = uv0.into().into();
         self
     }
     /// Sets uv1 (default `[1.0, 1.0]`)
-    pub const fn uv1(mut self, uv1: [f32; 2]) -> Self {
-        self.uv1 = uv1;
+    pub fn uv1(mut self, uv1: impl Into<MintVec2>) -> Self {
+        self.uv1 = uv1.into().into();
         self
     }
     /// Sets the tint color (default: no tint color)
-    pub const fn tint_col(mut self, tint_col: [f32; 4]) -> Self {
-        self.tint_col = tint_col;
+    pub fn tint_col(mut self, tint_col: impl Into<MintVec4>) -> Self {
+        self.tint_col = tint_col.into().into();
         self
     }
     /// Sets the border color (default: no border)
-    pub const fn border_col(mut self, border_col: [f32; 4]) -> Self {
-        self.border_col = border_col;
+    pub fn border_col(mut self, border_col: impl Into<MintVec4>) -> Self {
+        self.border_col = border_col.into().into();
         self
     }
     /// Builds the image
@@ -85,10 +88,10 @@ pub struct ImageButton {
 impl ImageButton {
     /// Creates a new image button builder with the given texture and size
     #[doc(alias = "ImageButton")]
-    pub fn new(texture_id: TextureId, size: [f32; 2]) -> ImageButton {
+    pub fn new(texture_id: TextureId, size: impl Into<MintVec2>) -> ImageButton {
         ImageButton {
             texture_id,
-            size,
+            size: size.into().into(),
             uv0: [0.0, 0.0],
             uv1: [1.0, 1.0],
             frame_padding: -1,
@@ -96,19 +99,21 @@ impl ImageButton {
             tint_col: [1.0, 1.0, 1.0, 1.0],
         }
     }
+
     /// Sets the image button size
-    pub fn size(mut self, size: [f32; 2]) -> Self {
-        self.size = size;
+    #[deprecated(note = "just set the size in the `new` constructor.")]
+    pub fn size(mut self, size: impl Into<MintVec2>) -> Self {
+        self.size = size.into().into();
         self
     }
     /// Sets uv0 (default `[0.0, 0.0]`)
-    pub fn uv0(mut self, uv0: [f32; 2]) -> Self {
-        self.uv0 = uv0;
+    pub fn uv0(mut self, uv0: impl Into<MintVec2>) -> Self {
+        self.uv0 = uv0.into().into();
         self
     }
     /// Sets uv1 (default `[1.0, 1.0]`)
-    pub fn uv1(mut self, uv1: [f32; 2]) -> Self {
-        self.uv1 = uv1;
+    pub fn uv1(mut self, uv1: impl Into<MintVec2>) -> Self {
+        self.uv1 = uv1.into().into();
         self
     }
     /// Sets the frame padding (default: uses frame padding from style).
@@ -121,13 +126,13 @@ impl ImageButton {
         self
     }
     /// Sets the background color (default: no background color)
-    pub fn background_col(mut self, bg_col: [f32; 4]) -> Self {
-        self.bg_col = bg_col;
+    pub fn background_col(mut self, bg_col: impl Into<MintVec4>) -> Self {
+        self.bg_col = bg_col.into().into();
         self
     }
     /// Sets the tint color (default: no tint color)
-    pub fn tint_col(mut self, tint_col: [f32; 4]) -> Self {
-        self.tint_col = tint_col;
+    pub fn tint_col(mut self, tint_col: impl Into<MintVec4>) -> Self {
+        self.tint_col = tint_col.into().into();
         self
     }
     /// Builds the image button

--- a/imgui/src/widget/list_box.rs
+++ b/imgui/src/widget/list_box.rs
@@ -8,7 +8,7 @@ use crate::Ui;
 #[must_use]
 pub struct ListBox<T> {
     label: T,
-    size: sys::ImVec2,
+    size: [f32; 2],
 }
 
 impl<T: AsRef<str>> ListBox<T> {
@@ -17,7 +17,7 @@ impl<T: AsRef<str>> ListBox<T> {
     pub fn new(label: T) -> ListBox<T> {
         ListBox {
             label,
-            size: sys::ImVec2::zero(),
+            size: [0.0, 0.0],
         }
     }
 
@@ -28,8 +28,8 @@ impl<T: AsRef<str>> ListBox<T> {
     ///
     /// Default: [0.0, 0.0], in which case the combobox calculates a sensible width and height
     #[inline]
-    pub fn size(mut self, size: [f32; 2]) -> Self {
-        self.size = sys::ImVec2::new(size[0], size[1]);
+    pub fn size(mut self, size: impl Into<crate::math::MintVec2>) -> Self {
+        self.size = size.into().into();
         self
     }
     /// Creates a list box and starts appending to it.
@@ -40,7 +40,8 @@ impl<T: AsRef<str>> ListBox<T> {
     /// Returns `None` if the list box is not open and no content should be rendered.
     #[must_use]
     pub fn begin<'ui>(self, ui: &Ui<'ui>) -> Option<ListBoxToken<'ui>> {
-        let should_render = unsafe { sys::igBeginListBox(ui.scratch_txt(self.label), self.size) };
+        let should_render =
+            unsafe { sys::igBeginListBox(ui.scratch_txt(self.label), self.size.into()) };
         if should_render {
             Some(ListBoxToken::new(ui))
         } else {

--- a/imgui/src/widget/misc.rs
+++ b/imgui/src/widget/misc.rs
@@ -1,6 +1,7 @@
 use bitflags::bitflags;
 use std::ops::{BitAnd, BitAndAssign, BitOrAssign, Not};
 
+use crate::math::MintVec2;
 use crate::sys;
 use crate::{Direction, Ui};
 
@@ -38,8 +39,8 @@ impl<'ui> Ui<'ui> {
     /// Setting `size` as `[0.0, 0.0]` will size the button to the label's width in
     /// the current style.
     #[doc(alias = "Button")]
-    pub fn button_with_size(&self, label: impl AsRef<str>, size: [f32; 2]) -> bool {
-        unsafe { sys::igButton(self.scratch_txt(label), size.into()) }
+    pub fn button_with_size(&self, label: impl AsRef<str>, size: impl Into<MintVec2>) -> bool {
+        unsafe { sys::igButton(self.scratch_txt(label), size.into().into()) }
     }
     /// Renders a small clickable button that is easy to embed in text.
     ///
@@ -52,8 +53,8 @@ impl<'ui> Ui<'ui> {
     ///
     /// Returns true if this button was clicked.
     #[doc(alias = "InvisibleButton")]
-    pub fn invisible_button(&self, id: impl AsRef<str>, size: [f32; 2]) -> bool {
-        unsafe { sys::igInvisibleButton(self.scratch_txt(id), size.into(), 0) }
+    pub fn invisible_button(&self, id: impl AsRef<str>, size: impl Into<MintVec2>) -> bool {
+        unsafe { sys::igInvisibleButton(self.scratch_txt(id), size.into().into(), 0) }
     }
     /// Renders a widget with button behaviour without the visual look.
     ///
@@ -62,10 +63,16 @@ impl<'ui> Ui<'ui> {
     pub fn invisible_button_flags(
         &self,
         id: impl AsRef<str>,
-        size: [f32; 2],
+        size: impl Into<MintVec2>,
         flags: ButtonFlags,
     ) -> bool {
-        unsafe { sys::igInvisibleButton(self.scratch_txt(id), size.into(), flags.bits() as i32) }
+        unsafe {
+            sys::igInvisibleButton(
+                self.scratch_txt(id),
+                size.into().into(),
+                flags.bits() as i32,
+            )
+        }
     }
     /// Renders a square button with an arrow shape.
     ///

--- a/imgui/src/widget/progress_bar.rs
+++ b/imgui/src/widget/progress_bar.rs
@@ -1,3 +1,4 @@
+use crate::math::MintVec2;
 use crate::sys;
 // use crate::ImStr;
 use crate::Ui;
@@ -55,8 +56,8 @@ impl<T: AsRef<str>> ProgressBar<T> {
     /// Negative values will automatically align to the end of the axis, zero will let the progress
     /// bar choose a size, and positive values will use the given size.
     #[inline]
-    pub fn size(mut self, size: [f32; 2]) -> Self {
-        self.size = size;
+    pub fn size(mut self, size: impl Into<MintVec2>) -> Self {
+        self.size = size.into().into();
         self
     }
 

--- a/imgui/src/widget/selectable.rs
+++ b/imgui/src/widget/selectable.rs
@@ -1,5 +1,6 @@
 use bitflags::bitflags;
 
+use crate::math::MintVec2;
 use crate::sys;
 use crate::Ui;
 
@@ -100,8 +101,8 @@ impl<T: AsRef<str>> Selectable<T> {
     /// - `> 0.0`: use given height
     /// - `= 0.0`: use label height
     #[inline]
-    pub fn size(mut self, size: [f32; 2]) -> Self {
-        self.size = size;
+    pub fn size(mut self, size: impl Into<MintVec2>) -> Self {
+        self.size = size.into().into();
         self
     }
     /// Builds the selectable.

--- a/imgui/src/widget/slider.rs
+++ b/imgui/src/widget/slider.rs
@@ -2,6 +2,7 @@ use bitflags::bitflags;
 use std::os::raw::c_void;
 
 use crate::internal::DataTypeKind;
+use crate::math::MintVec2;
 use crate::sys;
 use crate::Ui;
 
@@ -161,10 +162,10 @@ where
     /// It is safe, though up to C++ Dear ImGui, on how to handle when
     /// `min > max`.
     #[doc(alias = "VSliderScalar")]
-    pub fn new(label: Label, size: [f32; 2], min: Data, max: Data) -> Self {
+    pub fn new(label: Label, size: impl Into<MintVec2>, min: Data, max: Data) -> Self {
         VerticalSlider {
             label,
-            size,
+            size: size.into().into(),
             min,
             max,
             display_format: None,

--- a/imgui/src/widget/text.rs
+++ b/imgui/src/widget/text.rs
@@ -1,5 +1,6 @@
 use std::os::raw::c_char;
 
+use crate::math::MintVec4;
 // use crate::string::ImStr;
 use crate::style::StyleColor;
 use crate::Ui;
@@ -24,7 +25,7 @@ impl<'ui> Ui<'ui> {
         }
     }
     /// Renders simple text using the given text color
-    pub fn text_colored<T: AsRef<str>>(&self, color: [f32; 4], text: T) {
+    pub fn text_colored<T: AsRef<str>>(&self, color: impl Into<MintVec4>, text: T) {
         let style = self.push_style_color(StyleColor::Text, color);
         self.text(text);
         style.end();

--- a/imgui/src/window/child_window.rs
+++ b/imgui/src/window/child_window.rs
@@ -1,5 +1,6 @@
 use std::f32;
 
+use crate::math::MintVec2;
 use crate::sys;
 use crate::window::WindowFlags;
 use crate::Ui;
@@ -47,8 +48,8 @@ impl<'ui, Label: AsRef<str>> ChildWindow<'ui, Label> {
     /// - `= 0.0`: use remaining host window size
     /// - `< 0.0`: use remaining host window size minus abs(size)
     #[inline]
-    pub fn size(mut self, size: [f32; 2]) -> Self {
-        self.size = size;
+    pub fn size(mut self, size: impl Into<MintVec2>) -> Self {
+        self.size = size.into().into();
         self
     }
     /// Sets the window content size, which can be used to enforce scrollbars.
@@ -57,8 +58,8 @@ impl<'ui, Label: AsRef<str>> ChildWindow<'ui, Label> {
     /// 0.0 to leave the size automatic.
     #[inline]
     #[doc(alias = "SetNextWindowContentSize")]
-    pub fn content_size(mut self, size: [f32; 2]) -> Self {
-        self.content_size = size;
+    pub fn content_size(mut self, size: impl Into<MintVec2>) -> Self {
+        self.content_size = size.into().into();
         self
     }
     /// Sets the window focused state, which can be used to bring the window to front


### PR DESCRIPTION
This is a larger effort that I'm only just starting. I'm not sure this is the right decision (using language primitives like arrays has a lovely simplicity), but *especially* for handling sizing in complex layouts, I'm always using a real math lib (basically always `glam`), and all the `.into` calls are irksome.

The plan here is that we take `mint` types as *inputs* but still return `[f32; _]` as *outputs* (for example, in getters).

If anyone has opinions on this, I'd love to hear them