### PR TITLE
Implement `imgui-sdl2-support` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "imgui-sys",
     "imgui-glium-renderer",
     "imgui-glow-renderer",
+    "imgui-sdl2-support",
     "imgui-winit-support",
     "imgui-examples",
     "xtask",

--- a/imgui-sdl2-support/Cargo.toml
+++ b/imgui-sdl2-support/Cargo.toml
@@ -11,4 +11,9 @@ categories = ["gui"]
 
 [dependencies]
 imgui = { version = "0.8.1-alpha.0", path = "../imgui" }
-sdl2 = "0.34"
+sdl2 = "^0.34.5"
+
+[dev-dependencies]
+glow = "0.10.0"
+imgui-glow-renderer = { version = "0.8.1-alpha.0", path = "../imgui-glow-renderer" }
+sdl2 = { version = "^0.34.5", features = ["bundled", "static-link"] }

--- a/imgui-sdl2-support/Cargo.toml
+++ b/imgui-sdl2-support/Cargo.toml
@@ -11,3 +11,4 @@ categories = ["gui"]
 
 [dependencies]
 imgui = { version = "0.8.1-alpha.0", path = "../imgui" }
+sdl2 = "0.34"

--- a/imgui-sdl2-support/Cargo.toml
+++ b/imgui-sdl2-support/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "imgui-sdl2-support"
+version = "0.8.1-alpha.0"
+edition = "2018"
+authors = ["The imgui-rs Developers"]
+description = "sdl2 support code for the imgui crate"
+homepage = "https://github.com/imgui-rs/imgui-rs"
+repository = "https://github.com/imgui-rs/imgui-rs"
+license = "MIT/Apache-2.0"
+categories = ["gui"]
+
+[dependencies]
+imgui = { version = "0.8.1-alpha.0", path = "../imgui" }

--- a/imgui-sdl2-support/LICENSE-APACHE
+++ b/imgui-sdl2-support/LICENSE-APACHE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/imgui-sdl2-support/LICENSE-MIT
+++ b/imgui-sdl2-support/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright (c) 2015-2020 The imgui-rs Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/imgui-sdl2-support/examples/basic.rs
+++ b/imgui-sdl2-support/examples/basic.rs
@@ -1,0 +1,80 @@
+use glow::HasContext;
+use imgui::Context;
+use imgui_glow_renderer::AutoRenderer;
+use imgui_sdl2_support::SdlPlatform;
+use sdl2::{event::Event, video::Window};
+
+fn glow_context(window: &Window) -> glow::Context {
+    unsafe {
+        glow::Context::from_loader_function(|s| window.subsystem().gl_get_proc_address(s) as _)
+    }
+}
+
+fn main() {
+    let sdl = sdl2::init().unwrap();
+    let video_subsystem = sdl.video().unwrap();
+
+    let window = video_subsystem
+        .window("Hello imgui-rs!", 1280, 720)
+        .allow_highdpi()
+        .opengl()
+        .position_centered()
+        .build()
+        .unwrap();
+
+    let gl_context = window.gl_create_context().unwrap();
+    window.gl_make_current(&gl_context).unwrap();
+    window.subsystem().gl_set_swap_interval(1).unwrap();
+
+    let gl = glow_context(&window);
+
+    let mut imgui = Context::create();
+
+    imgui.set_ini_filename(None);
+    imgui.set_log_filename(None);
+
+    let mut platform = SdlPlatform::init(&mut imgui);
+
+    imgui
+        .fonts()
+        .add_font(&[imgui::FontSource::DefaultFontData { config: None }]);
+
+    let mut renderer = AutoRenderer::initialize(gl, &mut imgui).unwrap();
+    let mut last_frame = std::time::Instant::now();
+
+    let mut event_pump = sdl.event_pump().unwrap();
+
+    'main: loop {
+        for event in event_pump.poll_iter() {
+            platform.handle_event(imgui.io_mut(), &window, &event);
+
+            match event {
+                Event::Quit { .. } => break 'main,
+
+                _ => {}
+            }
+        }
+        platform.prepare_frame(imgui.io_mut(), &window, &event_pump);
+
+        let now = std::time::Instant::now();
+
+        imgui
+            .io_mut()
+            .update_delta_time(now.duration_since(last_frame));
+
+        last_frame = now;
+
+        let ui = imgui.frame();
+
+        ui.show_demo_window(&mut true);
+
+        platform.prepare_render(&ui, &window);
+        let draw_data = ui.render();
+
+        // This is the only extra render step to add
+        unsafe { renderer.gl_context().clear(glow::COLOR_BUFFER_BIT) };
+        renderer.render(draw_data).expect("error rendering imgui");
+
+        window.gl_swap_window();
+    }
+}

--- a/imgui-sdl2-support/src/lib.rs
+++ b/imgui-sdl2-support/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/imgui-sdl2-support/src/lib.rs
+++ b/imgui-sdl2-support/src/lib.rs
@@ -1,7 +1,239 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+use std::{cell::Cell, cmp::Ordering};
+
+use imgui::{BackendFlags, ConfigFlags, Context, Io, Key, MouseCursor, Ui};
+use sdl2::{
+    event::Event,
+    keyboard::{Mod, Scancode},
+    mouse::{Cursor, MouseButton, MouseState, SystemCursor},
+    video::Window,
+    EventPump,
+};
+
+/// State of a single mouse button. Used so that we can detect cases where mouse
+/// press and release occur on the same frame (seems surprisingly frequent on
+/// macOS now...)
+#[derive(Debug, Clone, Default)]
+struct Button {
+    pressed_this_frame: Cell<bool>,
+    state: Cell<bool>,
+}
+
+impl Button {
+    // we can use this in an array initializer, unlike `Default::default()` or a
+    // `const fn new()`.
+    #[allow(clippy::declare_interior_mutable_const)]
+    const INIT: Button = Self {
+        pressed_this_frame: Cell::new(false),
+        state: Cell::new(false),
+    };
+
+    fn set(&self, pressed: bool) {
+        self.state.set(pressed);
+        if pressed {
+            self.pressed_this_frame.set(true);
+        }
+    }
+
+    fn get(&self) -> bool {
+        // If we got a press this frame, record it even if we got a release
+        // too — this way we don't drop mouse clicks where the release comes
+        // in on the same frame as the press. (This mirrors what Dear ImGUI
+        // seems to do in the `imgui_impl_*`)
+        self.pressed_this_frame.replace(false) || self.state.get()
+    }
+}
+
+fn to_sdl_cursor(cursor: MouseCursor) -> SystemCursor {
+    match cursor {
+        MouseCursor::Arrow => SystemCursor::Arrow,
+        MouseCursor::TextInput => SystemCursor::IBeam,
+        MouseCursor::ResizeAll => SystemCursor::SizeAll,
+        MouseCursor::ResizeNS => SystemCursor::SizeNS,
+        MouseCursor::ResizeEW => SystemCursor::SizeWE,
+        MouseCursor::ResizeNESW => SystemCursor::SizeNESW,
+        MouseCursor::ResizeNWSE => SystemCursor::SizeNWSE,
+        MouseCursor::Hand => SystemCursor::Hand,
+        MouseCursor::NotAllowed => SystemCursor::No,
+    }
+}
+
+pub struct SdlPlatform {
+    previous_cursor: Option<Cursor>,
+    mouse_buttons: [Button; 5],
+}
+
+impl SdlPlatform {
+    /// Initializes a SDL platform instance and configures imgui.
+    ///
+    /// This function configures imgui-rs in the following ways:
+    ///
+    /// * backend flags are updated
+    /// * keys are configured
+    /// * platform name is set
+    pub fn init(imgui: &mut Context) -> SdlPlatform {
+        let io = imgui.io_mut();
+
+        io.backend_flags.insert(BackendFlags::HAS_MOUSE_CURSORS);
+        io.backend_flags.insert(BackendFlags::HAS_SET_MOUSE_POS);
+
+        io[Key::Tab] = Scancode::Tab as _;
+        io[Key::LeftArrow] = Scancode::Left as _;
+        io[Key::RightArrow] = Scancode::Right as _;
+        io[Key::UpArrow] = Scancode::Up as _;
+        io[Key::DownArrow] = Scancode::Down as _;
+        io[Key::PageUp] = Scancode::PageUp as _;
+        io[Key::PageDown] = Scancode::PageDown as _;
+        io[Key::Home] = Scancode::Home as _;
+        io[Key::End] = Scancode::End as _;
+        io[Key::Insert] = Scancode::Insert as _;
+        io[Key::Delete] = Scancode::Delete as _;
+        io[Key::Backspace] = Scancode::Backspace as _;
+        io[Key::Space] = Scancode::Space as _;
+        io[Key::Enter] = Scancode::Return as _;
+        io[Key::Escape] = Scancode::Escape as _;
+        io[Key::KeyPadEnter] = Scancode::KpEnter as _;
+        io[Key::A] = Scancode::A as _;
+        io[Key::C] = Scancode::C as _;
+        io[Key::V] = Scancode::V as _;
+        io[Key::X] = Scancode::X as _;
+        io[Key::Y] = Scancode::Y as _;
+        io[Key::Z] = Scancode::Z as _;
+
+        imgui.set_platform_name(Some(format!(
+            "imgui-sdl2-support {}",
+            env!("CARGO_PKG_VERSION")
+        )));
+
+        SdlPlatform {
+            previous_cursor: None,
+            mouse_buttons: [Button::INIT; 5],
+        }
+    }
+
+    /// Handles a SDL event.
+    ///
+    /// This function performs the following actions (depends on the event):
+    ///
+    /// * keyboard state is updated
+    /// * mouse state is updated
+    pub fn handle_event(&mut self, io: &mut Io, window: &Window, event: &Event) {
+        /* ignore all events not affecting the provided window */
+        if let Some(id) = event.get_window_id() {
+            if window.id() != id {
+                return;
+            }
+        }
+
+        match *event {
+            Event::MouseWheel { x, y, .. } => {
+                match x.partial_cmp(&0) {
+                    Some(Ordering::Greater) => io.mouse_wheel_h += 1.0,
+                    Some(Ordering::Less) => io.mouse_wheel_h -= 1.0,
+                    _ => {}
+                }
+
+                match y.partial_cmp(&0) {
+                    Some(Ordering::Greater) => io.mouse_wheel += 1.0,
+                    Some(Ordering::Less) => io.mouse_wheel -= 1.0,
+                    _ => {}
+                }
+            }
+
+            Event::MouseButtonDown { mouse_btn, .. } => match mouse_btn {
+                MouseButton::Left => self.mouse_buttons[0].set(true),
+                MouseButton::Right => self.mouse_buttons[1].set(true),
+                MouseButton::Middle => self.mouse_buttons[2].set(true),
+                MouseButton::X1 => self.mouse_buttons[3].set(true),
+                MouseButton::X2 => self.mouse_buttons[4].set(true),
+
+                _ => {}
+            },
+
+            Event::MouseButtonUp { mouse_btn, .. } => match mouse_btn {
+                MouseButton::Left => self.mouse_buttons[0].set(false),
+                MouseButton::Right => self.mouse_buttons[1].set(false),
+                MouseButton::Middle => self.mouse_buttons[2].set(false),
+                MouseButton::X1 => self.mouse_buttons[3].set(false),
+                MouseButton::X2 => self.mouse_buttons[4].set(false),
+
+                _ => {}
+            },
+
+            Event::TextInput { ref text, .. } => {
+                text.chars().for_each(|c| io.add_input_character(c));
+            }
+
+            Event::KeyDown {
+                scancode: Some(key),
+                keymod,
+                ..
+            } => {
+                io.keys_down[key as usize] = true;
+
+                io.key_shift = keymod.contains(Mod::LSHIFTMOD | Mod::RSHIFTMOD);
+                io.key_ctrl = keymod.contains(Mod::LCTRLMOD | Mod::RCTRLMOD);
+                io.key_alt = keymod.contains(Mod::LALTMOD | Mod::RALTMOD);
+                io.key_super = keymod.contains(Mod::LGUIMOD | Mod::RGUIMOD);
+            }
+
+            Event::KeyUp {
+                scancode: Some(key),
+                keymod,
+                ..
+            } => {
+                io.keys_down[key as usize] = false;
+
+                io.key_shift = keymod.contains(Mod::LSHIFTMOD | Mod::RSHIFTMOD);
+                io.key_ctrl = keymod.contains(Mod::LCTRLMOD | Mod::RCTRLMOD);
+                io.key_alt = keymod.contains(Mod::LALTMOD | Mod::RALTMOD);
+                io.key_super = keymod.contains(Mod::LGUIMOD | Mod::RGUIMOD);
+            }
+
+            _ => {}
+        }
+    }
+
+    pub fn prepare_frame(&self, io: &mut Io, window: &Window, event_pump: &EventPump) {
+        let window_size = window.size();
+        let drawable_size = window.drawable_size();
+
+        io.display_size = [window_size.0 as f32, window_size.1 as f32];
+        io.display_framebuffer_scale = [
+            (drawable_size.0 as f32) / (window_size.0 as f32),
+            (drawable_size.1 as f32) / (window_size.1 as f32),
+        ];
+
+        for (io_down, button) in io.mouse_down.iter_mut().zip(&self.mouse_buttons) {
+            *io_down = button.get();
+        }
+
+        let mouse_state = MouseState::new(event_pump);
+        io.mouse_pos = [mouse_state.x() as f32, mouse_state.y() as f32];
+    }
+
+    pub fn prepare_render(&mut self, ui: &Ui, window: &Window) {
+        let io = ui.io();
+
+        if !io
+            .config_flags
+            .contains(ConfigFlags::NO_MOUSE_CURSOR_CHANGE)
+        {
+            let mouse_util = window.subsystem().sdl().mouse();
+
+            match ui.mouse_cursor() {
+                Some(mouse_cursor) if !io.mouse_draw_cursor => {
+                    let cursor = Cursor::from_system(to_sdl_cursor(mouse_cursor)).unwrap();
+                    cursor.set();
+
+                    mouse_util.show_cursor(true);
+                    self.previous_cursor = Some(cursor);
+                }
+
+                _ => {
+                    mouse_util.show_cursor(false);
+                    self.previous_cursor = None;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR implements a SDL 2 support crate for imgui-rs, similar to the existing `imgui-winit-support` crate. This is mainly due to the fact that the existing SDL 2 support crate is severely outdated and a "official" crate is beneficial. This also checks off the last point from the list at the end of #444.

Currently most things except locked/rounded DPI are implemented, and I don't think there is a straightforward way to implement that. Please let me know if there is something that has to be changed, or can be improved.