### PR TITLE
Update slider example #565

### DIFF
--- a/imgui-examples/examples/slider.rs
+++ b/imgui-examples/examples/slider.rs
@@ -49,7 +49,7 @@ fn example_1(ui: &Ui, state: &mut State) {
 
         // However for larger data-types, it's usually best to specify
         // a much smaller range. The following slider is hard to use.
-        Slider::new("Full range f32 value", -f32::MIN/2.0, f32::MAX/2.0)
+        Slider::new("Full range f32 value", f32::MIN/2.0, f32::MAX/2.0)
             .build(ui, &mut state.f32_value);
         // Note the `... / 2.0` - anything larger is not supported by
         // the upstream C++ library

--- a/imgui-examples/examples/slider.rs
+++ b/imgui-examples/examples/slider.rs
@@ -43,23 +43,39 @@ fn example_1(ui: &Ui, state: &mut State) {
         ui.text("Unsigned: u8 u16 u32 u64");
         ui.text("Floats:   f32 f64");
 
-        Slider::new("u8 value", 0, 255)
+        // Full ranges can be specified with Rust's `::MIN/MAX` constants
+        Slider::new("u8 value", u8::MIN, u8::MAX)
             .build(ui, &mut state.u8_value);
 
-        Slider::new("f32 value", -f32::MIN, f32::MAX)
+        // However for larger data-types, it's usually best to specify
+        // a much smaller range. The following slider is hard to use.
+        Slider::new("Full range f32 value", -f32::MIN/2.0, f32::MAX/2.0)
             .build(ui, &mut state.f32_value);
+        // Note the `... / 2.0` - anything larger is not supported by
+        // the upstream C++ library
+        ui.text("Note that for 32-bit/64-bit types, sliders are always limited to half of the natural type range!");
 
+        // Most of the time, it's best to specify the range
         ui.separator();
         ui.text("Slider range can be limited:");
         Slider::new("i32 value with range", -999, 999)
             .build(ui, &mut state.i32_value);
-        ui.text("Note that for 32-bit/64-bit types, sliders are always limited to half of the natural type range!");
+        Slider::new("f32 value", -10.0, 10.0)
+            .build(ui, &mut state.f32_value);
 
         ui.separator();
         ui.text("Value formatting can be customized with a C-style printf string:");
         Slider::new("f64 value with custom formatting", -999_999_999.0, 999_999_999.0)
             .display_format("%09.0f")
             .build(ui, &mut state.f64_formatted);
+
+        // This formatting impacts the increments the slider operates in:
+        Slider::new("f32 with %.01f", 0.0, 1.0)
+            .display_format("%.01f")
+            .build(ui, &mut state.f32_value);
+        Slider::new("Same f32 with %.05f", 0.0, 1.0)
+            .display_format("%.05f")
+            .build(ui, &mut state.f32_value);
 
         ui.separator();
         ui.text("Vertical sliders require a size parameter but otherwise work in a similar way:");

--- a/imgui-examples/examples/slider.rs
+++ b/imgui-examples/examples/slider.rs
@@ -69,7 +69,7 @@ fn example_1(ui: &Ui, state: &mut State) {
             .display_format("%09.0f")
             .build(ui, &mut state.f64_formatted);
 
-        // This formatting impacts the increments the slider operates in:
+        // The display format changes the increments the slider operates in:
         Slider::new("f32 with %.01f", 0.0, 1.0)
             .display_format("%.01f")
             .build(ui, &mut state.f32_value);

--- a/imgui/src/widget/slider.rs
+++ b/imgui/src/widget/slider.rs
@@ -67,6 +67,11 @@ where
     ///
     /// It is safe, though up to C++ Dear ImGui, on how to handle when
     /// `min > max`.
+    ///
+    /// Note for f32 and f64 sliders, Dear ImGui limits the available
+    /// range to half their full range (e.g `-f32::MIN/2.0 .. f32::MAX/2.0`)
+    /// Specifying a value above this will cause an abort.
+    /// For large ranged values, consider using [`Ui::input_scalar`] instead
     #[inline]
     pub fn range(mut self, min: Data, max: Data) -> Self {
         self.min = min;

--- a/imgui/src/widget/slider.rs
+++ b/imgui/src/widget/slider.rs
@@ -69,7 +69,7 @@ where
     /// `min > max`.
     ///
     /// Note for f32 and f64 sliders, Dear ImGui limits the available
-    /// range to half their full range (e.g `-f32::MIN/2.0 .. f32::MAX/2.0`)
+    /// range to half their full range (e.g `f32::MIN/2.0 .. f32::MAX/2.0`)
     /// Specifying a value above this will cause an abort.
     /// For large ranged values, consider using [`Ui::input_scalar`] instead
     #[inline]


### PR DESCRIPTION
I've updated the slider example to use the limited range, however the pointlessly-giant range slider doesn't seem to work correctly:

![sliderbug](https://user-images.githubusercontent.com/509/141882192-05052a0a-8d7a-4637-aea3-3e33ad8e51fc.gif)

Not too sure what this might be caused by - any idea @sanbox-irl ?

It might be an upstream ~problem, as the "Dear ImGui Demo" `Widgets > Data types > Sliders` section doesn't include a "slider float full" example (only a "high" which goes from 1e-10 to 1e10). If so we should probably just remove this full-range-f32 from teh example as it's a bit academic