### PR TITLE
Fix incorrectly copy-pasted documentation for InputTextFlags.CALLBACK_EDIT

### DIFF
--- a/imgui/src/input_widget.rs
+++ b/imgui/src/input_widget.rs
@@ -28,7 +28,8 @@ bitflags!(
         const CALLBACK_COMPLETION = sys::ImGuiInputTextFlags_CallbackCompletion;
         /// Call user function on pressing Up/Down arrows (for history handling)
         const CALLBACK_HISTORY = sys::ImGuiInputTextFlags_CallbackHistory;
-        /// Call user function on pressing Up/Down arrows (for history handling)
+        /// Callback on any edit (note that InputText() already returns true on edit, the callback
+        /// is useful mainly to manipulate the underlying buffer while focus is active)
         const CALLBACK_EDIT = sys::ImGuiInputTextFlags_CallbackEdit;
         /// Call user function every time. User code may query cursor position, modify text buffer.
         const CALLBACK_ALWAYS = sys::ImGuiInputTextFlags_CallbackAlways;


### PR DESCRIPTION
The doc comment for `InputTextFlags.CALLBACK_EDIT` was incorrectly copy-pasted from CALLBACK_HISTORY, this updates it to use the imgui documentation like the other values.