### PR TITLE
Add missing fields to memory layout tests

### DIFF
--- a/imgui/src/fonts/font.rs
+++ b/imgui/src/fonts/font.rs
@@ -62,6 +62,7 @@ fn test_font_memory_layout() {
     assert_field_offset!(config_data_count, ConfigDataCount);
     assert_field_offset!(fallback_char, FallbackChar);
     assert_field_offset!(ellipsis_char, EllipsisChar);
+    assert_field_offset!(dot_char, DotChar);
     assert_field_offset!(dirty_lookup_tables, DirtyLookupTables);
     assert_field_offset!(scale, Scale);
     assert_field_offset!(ascent, Ascent);

--- a/imgui/src/io.rs
+++ b/imgui/src/io.rs
@@ -510,6 +510,7 @@ fn test_io_memory_layout() {
     assert_field_offset!(metrics_active_allocations, MetricsActiveAllocations);
     assert_field_offset!(mouse_delta, MouseDelta);
     assert_field_offset!(key_mods, KeyMods);
+    assert_field_offset!(key_mods_prev, KeyModsPrev);
     assert_field_offset!(mouse_pos_prev, MousePosPrev);
     assert_field_offset!(mouse_clicked_pos, MouseClickedPos);
     assert_field_offset!(mouse_clicked_time, MouseClickedTime);

--- a/imgui/src/style.rs
+++ b/imgui/src/style.rs
@@ -575,6 +575,7 @@ fn test_style_memory_layout() {
         };
     }
     assert_field_offset!(alpha, Alpha);
+    assert_field_offset!(disabled_alpha, DisabledAlpha);
     assert_field_offset!(window_padding, WindowPadding);
     assert_field_offset!(window_rounding, WindowRounding);
     assert_field_offset!(window_border_size, WindowBorderSize);


### PR DESCRIPTION
Adds fields introduced since ImGui 1.80 to memory layout tests.

These tests were incredibly useful for me recently, but they seem to be easy to forget.