### PR TITLE
imgui-winit-support: Add basic touch input

### DIFF
--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -909,6 +909,15 @@ impl WinitPlatform {
                     _ => (),
                 }
             }
+            WindowEvent::Touch(touch) => {
+                let position = self.scale_pos_from_winit(window, touch.location);
+                io.mouse_pos = [position.x as f32, position.y as f32];
+                match touch.phase {
+                    TouchPhase::Started => self.mouse_buttons[0].set(true),
+                    TouchPhase::Ended => self.mouse_buttons[1].set(false),
+                    TouchPhase::Cancelled | TouchPhase::Moved => {}
+                }
+            }
             _ => (),
         }
     }
@@ -1014,6 +1023,16 @@ impl WinitPlatform {
                     _ => (),
                 }
             }
+            WindowEvent::Touch(touch) => {
+                let position = touch.location.to_logical(window.scale_factor());
+                let position = self.scale_pos_from_winit(window, position);
+                io.mouse_pos = [position.x as f32, position.y as f32];
+                match touch.phase {
+                    TouchPhase::Started => self.mouse_buttons[0].set(true),
+                    TouchPhase::Ended => self.mouse_buttons[1].set(false),
+                    TouchPhase::Cancelled | TouchPhase::Moved => {}
+                }
+            }
             _ => (),
         }
     }
@@ -1116,6 +1135,16 @@ impl WinitPlatform {
                         self.mouse_buttons[idx as usize].set(pressed)
                     }
                     _ => (),
+                }
+            }
+            WindowEvent::Touch(touch) => {
+                let position = touch.location.to_logical(window.scale_factor());
+                let position = self.scale_pos_from_winit(window, position);
+                io.mouse_pos = [position.x as f32, position.y as f32];
+                match touch.phase {
+                    TouchPhase::Started => self.mouse_buttons[0].set(true),
+                    TouchPhase::Ended => self.mouse_buttons[1].set(false),
+                    TouchPhase::Cancelled | TouchPhase::Moved => {}
                 }
             }
             _ => (),


### PR DESCRIPTION
Ignores the complexities of multitouch, but makes imgui usable directly through touch events.

If an app doesn't want this, it can easily filter out Touch events before passing their event stream to imgui-winit-support.

(EDIT: I also just realized that apps could simply convert touch events to mouse on their own before passing events to imgui-winit-support, so if I do that, this patch is no longer really necessary, making this low priority, but still might be useful to someone).