### PR TITLE
Remove NO_ALPHA flag insertion in ColorPicker4::build

### DIFF
--- a/imgui/src/widget/color_editors.rs
+++ b/imgui/src/widget/color_editors.rs
@@ -886,8 +886,7 @@ where
     /// Builds the color picker.
     ///
     /// Returns true if the color value was changed.
-    pub fn build(mut self, ui: &Ui) -> bool {
-        self.flags.insert(ColorEditFlags::NO_ALPHA);
+    pub fn build(self, ui: &Ui) -> bool {
         let mut value: [f32; 4] = (*self.value).into().into();
         let ref_color = self.ref_color.map(|c| c.as_ptr()).unwrap_or(ptr::null());
 


### PR DESCRIPTION
`ColorEditFlags::NO_ALPHA` is used in `ColorPicker4::build` function, so there is no way to edit alpha value.  
It was probably copied from `ColorPicker3::build` and should be removed.