### PR TITLE
Backport text-input bug fixes for 0.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23/default --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-24/default --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-25/default --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-26/default --all-targets
+      
   rustfmt:
     name: Check rustfmt
     runs-on: ubuntu-latest

--- a/imgui-examples/examples/text_input.rs
+++ b/imgui-examples/examples/text_input.rs
@@ -1,0 +1,26 @@
+use imgui::*;
+
+mod support;
+
+fn main() {
+    let system = support::init(file!());
+    let mut stable_str = String::new();
+
+    system.main_loop(move |_, ui| {
+        if let Some(_window) = imgui::Window::new("Input text callbacks")
+            .size([500.0, 300.0], Condition::FirstUseEver)
+            .begin(ui)
+        {
+            if ui.input_text("input stable", &mut stable_str).build() {
+                dbg!(&stable_str);
+            }
+
+            let mut per_frame_buf = String::new();
+            ui.input_text("input per frame", &mut per_frame_buf).build();
+
+            if ui.is_item_deactivated_after_edit() {
+                dbg!(&per_frame_buf);
+            }
+        }
+    });
+}

--- a/imgui-gfx-renderer/Cargo.toml
+++ b/imgui-gfx-renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-gfx-renderer"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = ["The imgui-rs Developers"]
 description = "gfx renderer for the imgui crate"

--- a/imgui-glium-renderer/Cargo.toml
+++ b/imgui-glium-renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-glium-renderer"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = ["The imgui-rs Developers"]
 description = "Glium renderer for the imgui crate"

--- a/imgui-glow-renderer/Cargo.toml
+++ b/imgui-glow-renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-glow-renderer"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = ["jmaargh and the imgui-rs Developers"]
 description = "glow renderer for the imgui crate"

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-sys"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = ["The imgui-rs Developers"]
 description = "Raw FFI bindings to dear imgui"

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-winit-support"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = ["The imgui-rs Developers"]
 description = "winit support code for the imgui crate"

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -17,6 +17,7 @@ winit-22 = { version = "0.22", package = "winit", optional = true }
 winit-23 = { version = "0.23", package = "winit", default-features = false, optional = true }
 winit-24 = { version = "0.24", package = "winit", default-features = false, optional = true }
 winit-25 = { version = "0.25", package = "winit", default-features = false, optional = true }
+winit-26 = { version = "0.26", package = "winit", default-features = false, optional = true }
 
 [features]
 default = ["winit-25/default"]

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -133,26 +133,38 @@
 //! - Changing the default feature to the new latest `winit` version is *not* a
 //!   breaking change.
 
-#[cfg(feature = "winit-25")]
+#[cfg(feature = "winit-26")]
+use winit_26 as winit;
+
+#[cfg(all(not(any(feature = "winit-26")), feature = "winit-25"))]
 use winit_25 as winit;
 
-#[cfg(all(not(feature = "winit-25"), feature = "winit-24"))]
+#[cfg(all(
+    not(any(feature = "winit-26", feature = "winit-25")),
+    feature = "winit-24"
+))]
 use winit_24 as winit;
 
 #[cfg(all(
-    not(any(feature = "winit-25", feature = "winit-24")),
+    not(any(feature = "winit-26", feature = "winit-25", feature = "winit-24")),
     feature = "winit-23"
 ))]
 use winit_23 as winit;
 
 #[cfg(all(
-    not(any(feature = "winit-25", feature = "winit-24", feature = "winit-23")),
+    not(any(
+        feature = "winit-26",
+        feature = "winit-25",
+        feature = "winit-24",
+        feature = "winit-23"
+    )),
     feature = "winit-22",
 ))]
 use winit_22 as winit;
 
 #[cfg(all(
     not(any(
+        feature = "winit-26",
         feature = "winit-25",
         feature = "winit-24",
         feature = "winit-23",
@@ -164,6 +176,7 @@ use winit_20 as winit;
 
 #[cfg(all(
     not(any(
+        feature = "winit-26",
         feature = "winit-25",
         feature = "winit-24",
         feature = "winit-23",
@@ -181,6 +194,7 @@ use winit::dpi::{LogicalPosition, LogicalSize};
 
 #[cfg(all(
     not(any(
+        feature = "winit-26",
         feature = "winit-25",
         feature = "winit-24",
         feature = "winit-23",
@@ -195,6 +209,7 @@ use winit::{
 };
 
 #[cfg(any(
+    feature = "winit-26",
     feature = "winit-25",
     feature = "winit-24",
     feature = "winit-23",
@@ -218,6 +233,7 @@ use winit::{
     feature = "winit-23",
     feature = "winit-24",
     feature = "winit-25",
+    feature = "winit-26",
 )))]
 compile_error!("Please enable at least one version of `winit` (see documentation for details).");
 
@@ -258,6 +274,7 @@ fn check_multiple_winits() {
         (this likely indicates misconfiguration, see documentation for details)."
     );
     let feats = [
+        ("winit-26", cfg!(feature = "winit-26"), ""),
         ("winit-25", cfg!(feature = "winit-25"), " (default)"),
         ("winit-24", cfg!(feature = "winit-24"), ""),
         ("winit-23", cfg!(feature = "winit-23"), ""),
@@ -348,6 +365,7 @@ fn to_winit_cursor(cursor: imgui::MouseCursor) -> MouseCursor {
 impl CursorSettings {
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -370,7 +388,8 @@ impl CursorSettings {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26"
     ))]
     fn apply(&self, window: &Window) {
         match self.cursor {
@@ -478,6 +497,7 @@ impl WinitPlatform {
     /// * display size is set
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -508,6 +528,7 @@ impl WinitPlatform {
         feature = "winit-23",
         feature = "winit-24",
         feature = "winit-25",
+        feature = "winit-26",
     ))]
     pub fn attach_window(&mut self, io: &mut Io, window: &Window, hidpi_mode: HiDpiMode) {
         let (hidpi_mode, hidpi_factor) = hidpi_mode.apply(window.scale_factor());
@@ -530,6 +551,7 @@ impl WinitPlatform {
     /// your application to use the same logical coordinates as imgui-rs.
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -555,7 +577,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26"
     ))]
     pub fn scale_size_from_winit(
         &self,
@@ -575,6 +598,7 @@ impl WinitPlatform {
     /// your application to use the same logical coordinates as imgui-rs.
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -604,7 +628,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26"
     ))]
     pub fn scale_pos_from_winit(
         &self,
@@ -624,6 +649,7 @@ impl WinitPlatform {
     /// your application to use the same logical coordinates as imgui-rs.
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -653,7 +679,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26"
     ))]
     pub fn scale_pos_for_winit(
         &self,
@@ -676,6 +703,7 @@ impl WinitPlatform {
     /// * mouse state is updated
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -724,6 +752,7 @@ impl WinitPlatform {
     /// * mouse state is updated
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -779,7 +808,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26",
     ))]
     pub fn handle_event<T>(&mut self, io: &mut Io, window: &Window, event: &Event<T>) {
         match *event {
@@ -817,6 +847,7 @@ impl WinitPlatform {
     }
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -913,7 +944,12 @@ impl WinitPlatform {
         }
     }
     #[cfg(all(
-        not(any(feature = "winit-23", feature = "winit-24", feature = "winit-25")),
+        not(any(
+            feature = "winit-23",
+            feature = "winit-24",
+            feature = "winit-25",
+            feature = "winit-26"
+        )),
         any(feature = "winit-20", feature = "winit-22")
     ))]
     fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
@@ -1018,7 +1054,12 @@ impl WinitPlatform {
         }
     }
 
-    #[cfg(any(feature = "winit-23", feature = "winit-24", feature = "winit-25"))]
+    #[cfg(any(
+        feature = "winit-23",
+        feature = "winit-24",
+        feature = "winit-25",
+        feature = "winit-26"
+    ))]
     fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
         match *event {
             WindowEvent::Resized(physical_size) => {
@@ -1129,6 +1170,7 @@ impl WinitPlatform {
     /// * mouse cursor is repositioned (if requested by imgui-rs)
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -1160,7 +1202,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26",
     ))]
     pub fn prepare_frame(&self, io: &mut Io, window: &Window) -> Result<(), ExternalError> {
         self.copy_mouse_to_io(&mut io.mouse_down);

--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = ["The imgui-rs Developers"]
 description = "High-level Rust bindings to dear imgui"

--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -12,6 +12,9 @@ readme = "../README.markdown"
 
 exclude = ["/resources"]
 
+[package.metadata.docs.rs]
+features = ["freetype", "docking", "tables-api"]
+
 [dependencies]
 bitflags = "1"
 imgui-sys = { version = "0.8.0", path = "../imgui-sys" }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -48,6 +48,7 @@ fn lint_all() -> Result<()> {
         "winit-23/default",
         "winit-24/default",
         "winit-25/default",
+        "winit-26/default",
     ];
     for &winit in winits {
         xshell::cmd!("cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features {winit} --all-targets").run()?;


### PR DESCRIPTION
I didn't quite realize there was over 100 commits since v0.8.0 (:partying_face:), so I might have missed something but I think this covers the bugfixes relating to the text input bugs

Backports the following changes:

- 5cf67c22d423559b6d0f0e67e92083db39c27ed4
- 6faa7f090a34ef16b5c3880d988caa95babb1aba
- daea06108f5d7c60742b8d71b4a0977585ce5a76

Relates to #564 #546 #553

Also there didn't seem to be any existing conventions for release-maintenance branch naming (I would normally use `maint-0.8` but interferes in minor way with tab-complete for `main`)