### PR TITLE
add vcpkg-rs for locating freetype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,17 +136,23 @@ jobs:
       - name: docking feature
         run: cargo test --workspace --all-targets --features docking
 
-      - name: freetype feature
+      - name: freetype feature (non-Windows, pkg-config)
         if: matrix.os != 'windows-latest'
         run: cargo test --workspace --all-targets --features freetype
 
-      - name: all features
+      - name: freetype and docking (non-Windows, pkg-config)
         if: matrix.os != 'windows-latest'
-        run: cargo test --workspace --all-targets --features docking,freetype
+        run: cargo test --workspace --all-targets --features freetype,docking
 
-      - name: doc tests
-        run: cargo test --workspace --doc
+      - name: freetype feature (Windows, vcpkg)
+        if: matrix.os == 'windows-latest'
+        run: cargo test --workspace --all-targets --features freetype,use-vcpkg
 
+      - name: freetype and docking (Windows, vcpkg)
+        if: matrix.os == 'windows-latest'
+        run: cargo test --workspace --all-targets --features freetype,docking,use-vcpkg
+
+      - run: cargo test --workspace --doc
       # run to check for lint problems
       - name: build documentation
         run: cargo doc

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -39,4 +39,5 @@ vcpkg = { version="0.2.15", optional=true }
 default = []
 wasm = []
 docking = []
-freetype = ["pkg-config", "vcpkg"]
+freetype = ["pkg-config"]
+use-vcpkg = ["vcpkg"]

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -33,9 +33,10 @@ cfg-if = "1"
 [build-dependencies]
 cc = "1.0"
 pkg-config = { version="0.3", optional=true }
+vcpkg = { version="0.2.15", optional=true }
 
 [features]
 default = []
 wasm = []
-freetype = ["pkg-config"]
 docking = []
+freetype = ["pkg-config", "vcpkg"]

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -11,22 +11,16 @@ const DEFINES: &[(&str, Option<&str>)] = &[
 
 #[cfg(feature = "freetype")]
 fn find_freetype() -> Vec<impl AsRef<std::path::Path>> {
-    let err_pkg_config;
-    let err_vcpkg;
+    #[cfg(not(feature = "use-vcpkg"))]
     match pkg_config::Config::new().find("freetype2") {
         Ok(freetype) => return freetype.include_paths,
-        Err(err) => err_pkg_config = err,
+        Err(err) => panic!("cannot find freetype: {}", err),
     }
+    #[cfg(feature = "use-vcpkg")]
     match vcpkg::find_package("freetype") {
         Ok(freetype) => return freetype.include_paths,
-        Err(err) => err_vcpkg = err,
+        Err(err) => panic!("cannot find freetype: {}", err),
     }
-    panic!(
-        "cannot find freetype:\n\
-    - pkg-config failed with: {}\n\
-    - vcpkg failed with: {}",
-        err_pkg_config, err_vcpkg
-    );
 }
 
 // Output define args for compiler

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -9,30 +9,31 @@ const DEFINES: &[(&str, Option<&str>)] = &[
     ("IMGUI_DISABLE_OSX_FUNCTIONS", None),
 ];
 
+#[cfg(feature = "freetype")]
+fn find_freetype() -> Vec<impl AsRef<std::path::Path>> {
+    let err_pkg_config;
+    let err_vcpkg;
+    match pkg_config::Config::new().find("freetype2") {
+        Ok(freetype) => return freetype.include_paths,
+        Err(err) => err_pkg_config = err,
+    }
+    match vcpkg::find_package("freetype") {
+        Ok(freetype) => return freetype.include_paths,
+        Err(err) => err_vcpkg = err,
+    }
+    panic!(
+        "cannot find freetype:\n\
+    - pkg-config failed with: {}\n\
+    - vcpkg failed with: {}",
+        err_pkg_config, err_vcpkg
+    );
+}
+
 // Output define args for compiler
 fn main() -> std::io::Result<()> {
     // Root of imgui-sys
     let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    #[cfg(feature = "freetype")]
-    fn find_freetype() -> Vec<impl AsRef<std::path::Path>> {
-        let err_pkg_config;
-        let err_vcpkg;
-        match pkg_config::Config::new().find("freetype2") {
-            Ok(freetype) => return freetype.include_paths,
-            Err(err) => err_pkg_config = err,
-        }
-        match vcpkg::find_package("freetype") {
-            Ok(freetype) => return freetype.include_paths,
-            Err(err) => err_vcpkg = err,
-        }
-        panic!(
-            "cannot find freetype:\n\
-        - pkg-config failed with: {}\n\
-        - vcpkg failed with: {}",
-            err_pkg_config, err_vcpkg
-        );
-    }
     println!(
         "cargo:THIRD_PARTY={}",
         manifest_dir.join("third-party").display()

--- a/imgui-sys/build.rs
+++ b/imgui-sys/build.rs
@@ -13,12 +13,12 @@ const DEFINES: &[(&str, Option<&str>)] = &[
 fn find_freetype() -> Vec<impl AsRef<std::path::Path>> {
     #[cfg(not(feature = "use-vcpkg"))]
     match pkg_config::Config::new().find("freetype2") {
-        Ok(freetype) => return freetype.include_paths,
+        Ok(freetype) => freetype.include_paths,
         Err(err) => panic!("cannot find freetype: {}", err),
     }
     #[cfg(feature = "use-vcpkg")]
     match vcpkg::find_package("freetype") {
-        Ok(freetype) => return freetype.include_paths,
+        Ok(freetype) => freetype.include_paths,
         Err(err) => panic!("cannot find freetype: {}", err),
     }
 }

--- a/imgui-sys/third-party/imgui-docking/cimgui.cpp
+++ b/imgui-sys/third-party/imgui-docking/cimgui.cpp
@@ -4927,7 +4927,11 @@ CIMGUI_API void igDebugRenderViewportThumbnail(ImDrawList* draw_list,ImGuiViewpo
 }
 CIMGUI_API const ImFontBuilderIO* igImFontAtlasGetBuilderForStbTruetype()
 {
+#ifdef IMGUI_ENABLE_FREETYPE
+    return static_cast<const ImFontBuilderIO*>(0);
+#else
     return ImFontAtlasGetBuilderForStbTruetype();
+#endif
 }
 CIMGUI_API void igImFontAtlasBuildInit(ImFontAtlas* atlas)
 {


### PR DESCRIPTION
Should solve #562 and #566.

I used the method I proposed [here](https://github.com/imgui-rs/imgui-rs/issues/566#issuecomment-987711170) (using `vcpkg` in addition to `pkg-config`). It builds and links properly with my local settings, but I'm not entirely sure whether or not it runs correctly (the program looks correct, though).

This PR chose to base on the tag `v0.8.0` (instead of `HEAD`) on purpose, so that it is possible to test and compare the result with the latest published release on `crates.io`. If needed, I can rebase it onto `HEAD`.