### PR TITLE
Support winit-0.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-23/default --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-24/default --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-25/default --all-targets
+      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-26/default --all-targets
 
   rustfmt:
     name: Check rustfmt

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -21,7 +21,7 @@ winit-26 = { version = "0.26", package = "winit", default-features = false, opti
 
 [features]
 default = ["winit-25/default"]
-test = ["winit-23/default", "winit-24/default", "winit-25/default"]
+test = ["winit-23/default", "winit-24/default", "winit-25/default", "winit-26/default"]
 
 # This is phrased as a negative (unlike most features) so that it needs to be
 # explicitly disabled (and `default-features = false` won't do it). To avoid

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -17,6 +17,7 @@ winit-22 = { version = "0.22", package = "winit", optional = true }
 winit-23 = { version = "0.23", package = "winit", default-features = false, optional = true }
 winit-24 = { version = "0.24", package = "winit", default-features = false, optional = true }
 winit-25 = { version = "0.25", package = "winit", default-features = false, optional = true }
+winit-26 = { version = "0.26", package = "winit", default-features = false, optional = true }
 
 [features]
 default = ["winit-25/default"]

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -133,26 +133,38 @@
 //! - Changing the default feature to the new latest `winit` version is *not* a
 //!   breaking change.
 
-#[cfg(feature = "winit-25")]
+#[cfg(feature = "winit-26")]
+use winit_26 as winit;
+
+#[cfg(all(not(any(feature = "winit-26")), feature = "winit-25"))]
 use winit_25 as winit;
 
-#[cfg(all(not(feature = "winit-25"), feature = "winit-24"))]
+#[cfg(all(
+    not(any(feature = "winit-26", feature = "winit-25")),
+    feature = "winit-24"
+))]
 use winit_24 as winit;
 
 #[cfg(all(
-    not(any(feature = "winit-25", feature = "winit-24")),
+    not(any(feature = "winit-26", feature = "winit-25", feature = "winit-24")),
     feature = "winit-23"
 ))]
 use winit_23 as winit;
 
 #[cfg(all(
-    not(any(feature = "winit-25", feature = "winit-24", feature = "winit-23")),
+    not(any(
+        feature = "winit-26",
+        feature = "winit-25",
+        feature = "winit-24",
+        feature = "winit-23"
+    )),
     feature = "winit-22",
 ))]
 use winit_22 as winit;
 
 #[cfg(all(
     not(any(
+        feature = "winit-26",
         feature = "winit-25",
         feature = "winit-24",
         feature = "winit-23",
@@ -164,6 +176,7 @@ use winit_20 as winit;
 
 #[cfg(all(
     not(any(
+        feature = "winit-26",
         feature = "winit-25",
         feature = "winit-24",
         feature = "winit-23",
@@ -181,6 +194,7 @@ use winit::dpi::{LogicalPosition, LogicalSize};
 
 #[cfg(all(
     not(any(
+        feature = "winit-26",
         feature = "winit-25",
         feature = "winit-24",
         feature = "winit-23",
@@ -195,6 +209,7 @@ use winit::{
 };
 
 #[cfg(any(
+    feature = "winit-26",
     feature = "winit-25",
     feature = "winit-24",
     feature = "winit-23",
@@ -218,6 +233,7 @@ use winit::{
     feature = "winit-23",
     feature = "winit-24",
     feature = "winit-25",
+    feature = "winit-26",
 )))]
 compile_error!("Please enable at least one version of `winit` (see documentation for details).");
 
@@ -258,6 +274,7 @@ fn check_multiple_winits() {
         (this likely indicates misconfiguration, see documentation for details)."
     );
     let feats = [
+        ("winit-26", cfg!(feature = "winit-26"), ""),
         ("winit-25", cfg!(feature = "winit-25"), " (default)"),
         ("winit-24", cfg!(feature = "winit-24"), ""),
         ("winit-23", cfg!(feature = "winit-23"), ""),
@@ -348,6 +365,7 @@ fn to_winit_cursor(cursor: imgui::MouseCursor) -> MouseCursor {
 impl CursorSettings {
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -370,7 +388,8 @@ impl CursorSettings {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26"
     ))]
     fn apply(&self, window: &Window) {
         match self.cursor {
@@ -478,6 +497,7 @@ impl WinitPlatform {
     /// * display size is set
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -508,6 +528,7 @@ impl WinitPlatform {
         feature = "winit-23",
         feature = "winit-24",
         feature = "winit-25",
+        feature = "winit-26",
     ))]
     pub fn attach_window(&mut self, io: &mut Io, window: &Window, hidpi_mode: HiDpiMode) {
         let (hidpi_mode, hidpi_factor) = hidpi_mode.apply(window.scale_factor());
@@ -530,6 +551,7 @@ impl WinitPlatform {
     /// your application to use the same logical coordinates as imgui-rs.
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -555,7 +577,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26"
     ))]
     pub fn scale_size_from_winit(
         &self,
@@ -575,6 +598,7 @@ impl WinitPlatform {
     /// your application to use the same logical coordinates as imgui-rs.
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -604,7 +628,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26"
     ))]
     pub fn scale_pos_from_winit(
         &self,
@@ -624,6 +649,7 @@ impl WinitPlatform {
     /// your application to use the same logical coordinates as imgui-rs.
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -653,7 +679,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26"
     ))]
     pub fn scale_pos_for_winit(
         &self,
@@ -676,6 +703,7 @@ impl WinitPlatform {
     /// * mouse state is updated
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -724,6 +752,7 @@ impl WinitPlatform {
     /// * mouse state is updated
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -779,7 +808,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26",
     ))]
     pub fn handle_event<T>(&mut self, io: &mut Io, window: &Window, event: &Event<T>) {
         match *event {
@@ -817,6 +847,7 @@ impl WinitPlatform {
     }
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -913,7 +944,12 @@ impl WinitPlatform {
         }
     }
     #[cfg(all(
-        not(any(feature = "winit-23", feature = "winit-24", feature = "winit-25")),
+        not(any(
+            feature = "winit-23",
+            feature = "winit-24",
+            feature = "winit-25",
+            feature = "winit-26"
+        )),
         any(feature = "winit-20", feature = "winit-22")
     ))]
     fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
@@ -1018,7 +1054,12 @@ impl WinitPlatform {
         }
     }
 
-    #[cfg(any(feature = "winit-23", feature = "winit-24", feature = "winit-25"))]
+    #[cfg(any(
+        feature = "winit-23",
+        feature = "winit-24",
+        feature = "winit-25",
+        feature = "winit-26"
+    ))]
     fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
         match *event {
             WindowEvent::Resized(physical_size) => {
@@ -1129,6 +1170,7 @@ impl WinitPlatform {
     /// * mouse cursor is repositioned (if requested by imgui-rs)
     #[cfg(all(
         not(any(
+            feature = "winit-26",
             feature = "winit-25",
             feature = "winit-24",
             feature = "winit-23",
@@ -1160,7 +1202,8 @@ impl WinitPlatform {
         feature = "winit-22",
         feature = "winit-23",
         feature = "winit-24",
-        feature = "winit-25"
+        feature = "winit-25",
+        feature = "winit-26",
     ))]
     pub fn prepare_frame(&self, io: &mut Io, window: &Window) -> Result<(), ExternalError> {
         self.copy_mouse_to_io(&mut io.mouse_down);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -51,6 +51,7 @@ fn lint_all() -> Result<()> {
         "winit-23/default",
         "winit-24/default",
         "winit-25/default",
+        "winit-26/default",
     ];
     for &winit in winits {
         xshell::cmd!("cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features {winit} --all-targets").run()?;


### PR DESCRIPTION
This adds winit 0.26 support to imgui-winit-support as non-default. This is a non-breaking change and I've tested all versions of winit with the crate.

I have bumped the version number, as it would be greatly appreciated a patch version could be released. This is currently the last blocking piece of updating my project to winit 0.26.