### PR TITLE
0.8 patch: Ensure misc/freetype/* is included in packaged crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
             ${{ runner.os }}-target-lint-
       - run: cargo clippy --workspace --all-targets
       # supported winit versions
-      - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --all-features --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-19 --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-20 --all-targets
       - run: cargo clippy --manifest-path imgui-winit-support/Cargo.toml --no-default-features --features winit-22 --all-targets

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -11,7 +11,18 @@ categories = ["gui", "external-ffi-bindings"]
 build = "build.rs"
 links = "imgui"
 # exclude json, lua, and the imgui subdirs (imgui/examples, imgui/docs, etc)
-exclude = ["third-party/*.json", "third-party/*.lua", "third-party/imgui/*/"]
+# ..but we need imgui/misc/freetype/ for the freetype feature
+exclude = [
+    "third-party/*.json",
+    "third-party/*.lua",
+    "third-party/imgui/backends/",
+    "third-party/imgui/docs/",
+    "third-party/imgui/examples/",
+    "third-party/imgui/misc/cpp/",
+    "third-party/imgui/misc/debuggers/",
+    "third-party/imgui/misc/fonts/",
+    "third-party/imgui/misc/single_file/",
+]
 
 [dependencies]
 chlorine = "1.0.7"


### PR DESCRIPTION
Required for "--features freetype" to work when using via crates.io

Closes #594
Closes #589