### PR TITLE
Fix glow renderer not working for minor version = 0

### DIFF
--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -932,9 +932,8 @@ void main() {
         }
 
         let vertex_source = format!(
-            "#version {major}{minor}{es_extras}\n{body}",
-            major = major,
-            minor = minor * 10,
+            "#version {version}{es_extras}\n{body}",
+            version = major * 100 + minor * 10,
             es_extras = if is_gles {
                 " es\nprecision mediump float;"
             } else {
@@ -943,9 +942,8 @@ void main() {
             body = VERTEX_BODY,
         );
         let fragment_source = format!(
-            "#version {major}{minor}{es_extras}{defines}\n{body}",
-            major = major,
-            minor = minor * 10,
+            "#version {version}{es_extras}{defines}\n{body}",
+            version = major * 100 + minor * 10,
             es_extras = if is_gles {
                 " es\nprecision mediump float;"
             } else {


### PR DESCRIPTION
Fix for #598

This PR just changes `imgui-glow-renderer::Shaders::get_shader_sources` to use `major * 100 + minor * 10` to calculate the `#version` number.
This makes 4.0 work correctly for me.