### PR TITLE
winit-support: fix dpi handling in attach_window() when not in defaul…

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -34,6 +34,8 @@
 
 - Added `docking` feature which builds against the upstream docking branch. Only basic API is exposed currently, just enough to enable the docking `imgui_context.io_mut().config_flags |= imgui::ConfigFlags::DOCKING_ENABLE;` - a safe API for programtically docking windows and so on will be added later (until then the internal docking API can be accessed, `imgui::sys::igDockBuilderDockWindow` and so on)
 
+- Fixed dpi related issues when not in `HiDpiMode::Default` mode. The wrong scale factor was used when converting winit physical size to logical size, causing the imgui display size to be incorrect.
+
 ## [0.8.0] - 2021-09-17
 
 Welcome to the `0.8.0` update. This is one of the largest updates imgui-rs has ever seen; it will generate errors in a `0.7` project, but hopefully it should be both quick to fix, and enjoyable to update. See our [release page](https://github.com/imgui-rs/imgui-rs/releases/tag/v0.8.0) for more information and a list of contributors to this cycle. Thank you to everyone who uses `imgui-rs`, files issues, and spend their time and effort to PR new changes into the codebase. Because of all that effort, this is by far the best `imgui-rs` has looked!

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -535,7 +535,7 @@ impl WinitPlatform {
         self.hidpi_mode = hidpi_mode;
         self.hidpi_factor = hidpi_factor;
         io.display_framebuffer_scale = [hidpi_factor as f32, hidpi_factor as f32];
-        let logical_size = window.inner_size().to_logical(hidpi_factor);
+        let logical_size = window.inner_size().to_logical(window.scale_factor());
         let logical_size = self.scale_size_from_winit(window, logical_size);
         io.display_size = [logical_size.width as f32, logical_size.height as f32];
     }
@@ -976,7 +976,7 @@ impl WinitPlatform {
                 self.hidpi_factor = hidpi_factor;
                 io.display_framebuffer_scale = [hidpi_factor as f32, hidpi_factor as f32];
                 // Window size might change too if we are using DPI rounding
-                let logical_size = window.inner_size().to_logical(scale_factor);
+                let logical_size = window.inner_size().to_logical(window.scale_factor());
                 let logical_size = self.scale_size_from_winit(window, logical_size);
                 io.display_size = [logical_size.width as f32, logical_size.height as f32];
             }
@@ -1084,7 +1084,7 @@ impl WinitPlatform {
                 self.hidpi_factor = hidpi_factor;
                 io.display_framebuffer_scale = [hidpi_factor as f32, hidpi_factor as f32];
                 // Window size might change too if we are using DPI rounding
-                let logical_size = window.inner_size().to_logical(scale_factor);
+                let logical_size = window.inner_size().to_logical(window.scale_factor());
                 let logical_size = self.scale_size_from_winit(window, logical_size);
                 io.display_size = [logical_size.width as f32, logical_size.height as f32];
             }


### PR DESCRIPTION
…t mode

attach_window() was using the imgui scale factor when converting
winit physical size to logical size instead of the winit scale factor.

This would cause the imgui display size to be incorrect when not using the
HiDpiMode::Default mode (in default mode the imgui and winit scale factors
are the same and the issue goes unnoticed).

Note that handle_window_event() has similar (and correct) logic when handling WindowEvent::Resized events.
This also explain why the issue went mostly undiscovered as winit tends to
generate quite a bunch of resize events that would hide the miscalculation
done in attach_window().

A similar issue was also fixed in the WindowEvent::ScaleFactorChanged handling code.

should fix https://github.com/imgui-rs/imgui-rs/issues/441