### PR TITLE
Remove im_str! usage from examples in docs

### DIFF
--- a/imgui/src/draw_list.rs
+++ b/imgui/src/draw_list.rs
@@ -426,7 +426,7 @@ impl<'ui> DrawListMut<'ui> {
     /// # use imgui::*;
     /// fn custom_button(ui: &Ui, img_id: TextureId) {
     ///     // Invisible button is good widget to customise with image
-    ///     ui.invisible_button(im_str!("custom_button"), [100.0, 20.0]);
+    ///     ui.invisible_button("custom_button", [100.0, 20.0]);
     ///
     ///     // Get draw list and draw image over invisible button
     ///     let draw_list = ui.get_window_draw_list();

--- a/imgui/src/lib.rs
+++ b/imgui/src/lib.rs
@@ -609,7 +609,7 @@ impl Ui {
     ///     ui.text("Hover over me");
     ///     if ui.is_item_hovered() {
     ///         ui.tooltip(|| {
-    ///             ui.text_colored([1.0, 0.0, 0.0, 1.0], im_str!("I'm red!"));
+    ///             ui.text_colored([1.0, 0.0, 0.0, 1.0], "I'm red!");
     ///         });
     ///     }
     /// }
@@ -676,7 +676,7 @@ impl Ui {
     /// fn user_interface(ui: &Ui) {
     ///     let disable_buttons = true;
     ///     let _d = ui.begin_disabled(disable_buttons);
-    ///     ui.button(im_str!("Dangerous button"));
+    ///     ui.button("Dangerous button");
     /// }
     /// ```
 
@@ -703,7 +703,7 @@ impl Ui {
     /// fn user_interface(ui: &Ui) {
     ///     let safe_mode = true;
     ///     ui.disabled(safe_mode, || {
-    ///         ui.button(im_str!("Dangerous button"));
+    ///         ui.button("Dangerous button");
     ///     });
     /// }
     /// ```

--- a/imgui/src/widget/slider.rs
+++ b/imgui/src/widget/slider.rs
@@ -196,8 +196,7 @@ where
     /// Constructs a new vertical slider builder with the given size and range.
     ///
     /// ```rust
-    /// # use imgui::im_str;
-    /// imgui::VerticalSlider::new(im_str!("Example"), [20.0, 20.0], i8::MIN, i8::MAX)
+    /// imgui::VerticalSlider::new("Example", [20.0, 20.0], i8::MIN, i8::MAX)
     ///     .range(4, 8)
     ///     // Remember to call .build(&ui)
     ///     ;
@@ -227,8 +226,7 @@ where
     /// Sets the range for the vertical slider.
     ///
     /// ```rust
-    /// # use imgui::im_str;
-    /// imgui::VerticalSlider::new(im_str!("Example"), [20.0, 20.0], i8::MIN, i8::MAX)
+    /// imgui::VerticalSlider::new("Example", [20.0, 20.0], i8::MIN, i8::MAX)
     ///     .range(4, 8)
     ///     // Remember to call .build(&ui)
     ///     ;
@@ -320,8 +318,7 @@ where
 {
     /// Sets the range in degrees (inclusive)
     /// ```rust
-    /// # use imgui::im_str;
-    /// imgui::AngleSlider::new(im_str!("Example"))
+    /// imgui::AngleSlider::new("Example")
     ///     .range_degrees(-20.0, 20.0)
     ///     // Remember to call .build(&ui)
     ///     ;

--- a/imgui/src/widget/tab.rs
+++ b/imgui/src/widget/tab.rs
@@ -6,12 +6,12 @@
 //! # let ui = ctx.frame();
 //!
 //! // During UI construction
-//! TabBar::new(im_str!("tabbar")).build(&ui, || {
-//!                   TabItem::new(im_str!("a tab")).build(&ui, || {
-//!                       ui.text(im_str!("tab content 1"));
+//! TabBar::new("tabbar").build(&ui, || {
+//!                   TabItem::new("a tab").build(&ui, || {
+//!                       ui.text("tab content 1");
 //!                   });
-//!                   TabItem::new(im_str!("2tab")).build(&ui, || {
-//!                       ui.text(im_str!("tab content 2"));
+//!                   TabItem::new("2tab").build(&ui, || {
+//!                       ui.text("tab content 2");
 //!                   });
 //!               });
 //! ```


### PR DESCRIPTION
This removes leftover `im_str!` calls within examples in docs. I believe I got them all, the only remaining mentions of `im_str` are in the changelog and the macro definition itself.

Fixes #617.