### PR TITLE
Fix error in clipboard.rs

### DIFF
--- a/imgui-examples/examples/support/clipboard.rs
+++ b/imgui-examples/examples/support/clipboard.rs
@@ -4,7 +4,7 @@ use imgui::ClipboardBackend;
 pub struct ClipboardSupport(pub ClipboardContext);
 
 pub fn init() -> Option<ClipboardSupport> {
-    ClipboardContext::new().ok().map(ClipboardSupport)
+    ClipboardProvider::new().ok().map(ClipboardSupport)
 }
 
 impl ClipboardBackend for ClipboardSupport {


### PR DESCRIPTION
There is no `new` in `ClipboardContext`.
`ClipboardProvider` is not used, and there is `new`, thus `ClipboardProvider` seems to be correct.