### PR TITLE
Clipper bugfix and iterator interface

### DIFF
--- a/imgui-examples/examples/long_list.rs
+++ b/imgui-examples/examples/long_list.rs
@@ -15,8 +15,10 @@ fn main() {
 
     let system = support::init(file!());
     system.main_loop(move |_, ui| {
+        // Show the C++ style API
         ui.window("Hello long world")
-            .size([300.0, 110.0], Condition::FirstUseEver)
+            .size([100.0, 500.0], Condition::FirstUseEver)
+            .position([10.0, 10.0], crate::Condition::Always)
             .build(|| {
                 let mut clipper = imgui::ListClipper::new(lots_of_words.len() as i32)
                     .items_height(ui.current_font_size())
@@ -25,6 +27,19 @@ fn main() {
                     for row_num in clipper.display_start()..clipper.display_end() {
                         ui.text(&lots_of_words[row_num as usize]);
                     }
+                }
+            });
+
+        // Show the more Rust'y iterator
+        ui.window("Hello long world (iterator API)")
+            .size([100.0, 500.0], Condition::FirstUseEver)
+            .position([150.0, 10.0], crate::Condition::Always)
+            .build(|| {
+                let clipper = imgui::ListClipper::new(lots_of_words.len() as i32)
+                    .items_height(ui.current_font_size())
+                    .begin(ui);
+                for row_num in clipper.iter() {
+                    ui.text(&lots_of_words[row_num as usize]);
                 }
             });
     });

--- a/imgui-examples/examples/long_table.rs
+++ b/imgui-examples/examples/long_table.rs
@@ -40,11 +40,11 @@ fn main() {
                     // Create clipper with st
                     let clip = imgui::ListClipper::new(num_rows).begin(ui);
                     for row_num in clip.iter() {
-                            ui.table_next_row();
-                            for col_num in 0..num_cols {
-                                ui.table_set_column_index(col_num);
-                                ui.text(format!("Hello {},{}", col_num, row_num));
-                            }
+                        ui.table_next_row();
+                        for col_num in 0..num_cols {
+                            ui.table_set_column_index(col_num);
+                            ui.text(format!("Hello {},{}", col_num, row_num));
+                        }
                     }
                 }
             });

--- a/imgui-examples/examples/long_table.rs
+++ b/imgui-examples/examples/long_table.rs
@@ -1,0 +1,52 @@
+use imgui::*;
+
+mod support;
+
+fn main() {
+    let system = support::init(file!());
+
+    system.main_loop(move |_, ui| {
+        ui.show_demo_window(&mut true);
+
+        ui.window("Table with list clipper")
+            .size([800.0, 700.0], Condition::FirstUseEver)
+            .build(|| {
+                let num_cols = 3;
+                let num_rows = 1000;
+
+                let flags = imgui::TableFlags::ROW_BG
+                    | imgui::TableFlags::RESIZABLE
+                    | imgui::TableFlags::BORDERS_H
+                    | imgui::TableFlags::BORDERS_V; //| imgui::TableFlags::SCROLL_Y;
+
+                if let Some(_t) = ui.begin_table_with_sizing(
+                    "longtable",
+                    num_cols,
+                    flags,
+                    [300.0, 100.0],
+                    /*inner width=*/ 0.0,
+                ) {
+                    ui.table_setup_column("A");
+                    ui.table_setup_column("B");
+                    ui.table_setup_column("C");
+
+                    // Freeze first row so headers are visible even
+                    // when scrolling
+                    ui.table_setup_scroll_freeze(num_cols, 1);
+
+                    // Done with headers row
+                    ui.table_headers_row();
+
+                    // Create clipper with st
+                    let clip = imgui::ListClipper::new(num_rows).begin(ui);
+                    for row_num in clip.iter() {
+                            ui.table_next_row();
+                            for col_num in 0..num_cols {
+                                ui.table_set_column_index(col_num);
+                                ui.text(format!("Hello {},{}", col_num, row_num));
+                            }
+                    }
+                }
+            });
+    });
+}

--- a/imgui/src/list_clipper.rs
+++ b/imgui/src/list_clipper.rs
@@ -92,7 +92,7 @@ impl<'ui> ListClipperToken<'ui> {
                 panic!("ListClipperToken::step called after it has previously returned false");
             }
             let ret = unsafe { sys::ImGuiListClipper_Step(self.list_clipper) };
-            if ret {
+            if !ret {
                 self.consumed_workaround = true;
             }
             ret

--- a/imgui/src/list_clipper.rs
+++ b/imgui/src/list_clipper.rs
@@ -194,7 +194,7 @@ fn cpp_style_usage() {
 
     // Create clipper
     let clip = ListClipper::new(1000);
-    let mut tok = clip.begin(&ui);
+    let mut tok = clip.begin(ui);
 
     let mut ticks = 0;
 
@@ -236,7 +236,7 @@ fn iterator_usage() {
 
     let mut ticks = 0;
 
-    let tok = clip.begin(&ui);
+    let tok = clip.begin(ui);
     for row_num in tok.iter() {
         dbg!(row_num);
         ui.text("...");


### PR DESCRIPTION
Closes #610

Adds a hard-to-misuse iterator wrapper around the list clipper interface. Retains the step/display_start/display_end API for consistency with C++ and it is slightly more flexible which might be important in a few circumstances (where you want to draw the entire start..end chunk in a single call)

Main part missing currently is I haven't backported the upstream bugfix preventing "clipper.end(); clipper.step()` from segfaulting because of a null pointer (with the changes mentioned in #610 it will crash via assert() instead)

However this now only crashes if the user calls end and step explicitly - previously it was crashing if user just called `.end()` (because the drop token was incorrectly calling `step()`) - sort of undecided if it's worth backporting the change given this is a lesser used feature, and it's in an error path. Might be better to add a temporary internal check for double-end and panic - we can them remove it in future imgui release