### PR TITLE
Handle window focus lost event

### DIFF
--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -941,7 +941,14 @@ impl WinitPlatform {
                     }
                     _ => (),
                 }
-            }
+            },
+            WindowEvent::Focused(newly_focused) => {
+                if !newly_focused {
+                    // Set focus-lost to avoid stuck keys (like 'alt'
+                    // when alt-tabbing)
+                    io.app_focus_lost = true;
+                }
+            },
             _ => (),
         }
     }
@@ -1052,6 +1059,13 @@ impl WinitPlatform {
                     _ => (),
                 }
             }
+            WindowEvent::Focused(newly_focused) => {
+                if !newly_focused {
+                    // Set focus-lost to avoid stuck keys (like 'alt'
+                    // when alt-tabbing)
+                    io.app_focus_lost = true;
+                }
+            }
             _ => (),
         }
     }
@@ -1159,6 +1173,13 @@ impl WinitPlatform {
                         self.mouse_buttons[idx as usize].set(pressed)
                     }
                     _ => (),
+                }
+            }
+            WindowEvent::Focused(newly_focused) => {
+                if !newly_focused {
+                    // Set focus-lost to avoid stuck keys (like 'alt'
+                    // when alt-tabbing)
+                    io.app_focus_lost = true;
                 }
             }
             _ => (),

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -941,14 +941,14 @@ impl WinitPlatform {
                     }
                     _ => (),
                 }
-            },
+            }
             WindowEvent::Focused(newly_focused) => {
                 if !newly_focused {
                     // Set focus-lost to avoid stuck keys (like 'alt'
                     // when alt-tabbing)
                     io.app_focus_lost = true;
                 }
-            },
+            }
             _ => (),
         }
     }

--- a/imgui/src/io.rs
+++ b/imgui/src/io.rs
@@ -339,7 +339,7 @@ pub struct Io {
     nav_inputs_down_duration: [f32; NavInput::COUNT + NavInput::INTERNAL_COUNT],
     nav_inputs_down_duration_prev: [f32; NavInput::COUNT + NavInput::INTERNAL_COUNT],
     pen_pressure: f32,
-    app_focus_lost: bool,
+    pub app_focus_lost: bool,
     input_queue_surrogate: sys::ImWchar16,
     input_queue_characters: ImVector<sys::ImWchar>,
 }

--- a/imgui/src/io.rs
+++ b/imgui/src/io.rs
@@ -339,6 +339,10 @@ pub struct Io {
     nav_inputs_down_duration: [f32; NavInput::COUNT + NavInput::INTERNAL_COUNT],
     nav_inputs_down_duration_prev: [f32; NavInput::COUNT + NavInput::INTERNAL_COUNT],
     pen_pressure: f32,
+
+    /// Clear buttons state when focus is lost (this is useful so
+    /// e.g. releasing Alt after focus loss on Alt-Tab doesn't trigger
+    /// the Alt menu toggle)
     pub app_focus_lost: bool,
     input_queue_surrogate: sys::ImWchar16,
     input_queue_characters: ImVector<sys::ImWchar>,


### PR DESCRIPTION
Avoids keys getting stuck when window loses focus (e.g alt+tab)

Need to make same changes to SDL2 support module also

Closes #602