### PR TITLE
Use nohash_hasher for the texture map

### DIFF
--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -21,6 +21,7 @@ imgui-sys = { version = "0.8.1-alpha.0", path = "../imgui-sys" }
 mint = "0.5.6"
 parking_lot = "0.12"
 cfg-if = "1"
+nohash-hasher = "0.2.0"
 
 [features]
 wasm = ["imgui-sys/wasm"]

--- a/imgui/src/render/renderer.rs
+++ b/imgui/src/render/renderer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use nohash_hasher::IntMap;
 
 /// An opaque texture identifier
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -56,16 +56,16 @@ fn test_texture_id_memory_layout() {
 /// Generic texture mapping for use by renderers.
 #[derive(Debug, Default)]
 pub struct Textures<T> {
-    textures: HashMap<usize, T>,
+    textures: IntMap<usize, T>,
     next: usize,
 }
 
 impl<T> Textures<T> {
-    // TODO: hasher like rustc_hash::FxHashMap or something would let this be
+    // TODO: once std exposes a `const fn` constructor for HashMap this can be
     // `const fn`
     pub fn new() -> Self {
         Textures {
-            textures: HashMap::new(),
+            textures: IntMap::default(),
             next: 0,
         }
     }


### PR DESCRIPTION
Contrary to the existing comment, this does not yet allow `Textures::new` to become a `const fn`. `hashbrown` has  `const fn with_hasher`, but it's not yet exposed from `std` and I wanted to avoid adding a dependency on `hashbrown` without at least asking first.

In one of the projects I'm working on I'm not able/willing to use the default hasher, so I've had to be somewhat selective with dependencies. In imgui-rs' case I'd love to see the hasher replaced with `nohash_hasher` or `fxhash` since that'd mean I'm not required to maintain my own fork of it, but I understand if that isn't something that others also care about.

I'm opening this PR mostly so that if you have nothing against merging it I'm not stuck with an unnecessary fork. As a bonus it also makes the transition to `const` one step smaller once std marks `with_hasher` as `const`.