### PR TITLE
TextCallbackData::selection causes problems when selecting from right to left

### DIFF
--- a/imgui/src/input_widget.rs
+++ b/imgui/src/input_widget.rs
@@ -1051,7 +1051,20 @@ impl TextCallbackData {
     /// This Range is given in `usize` so that it might be used in indexing
     /// operations more easily. To quickly grab the selected text, use [selected](Self::selected).
     pub fn selection(&self) -> Range<usize> {
-        unsafe { (*(self.0)).SelectionStart as usize..(*(self.0)).SelectionEnd as usize }
+        let (start, end) = unsafe {
+            (
+                (*(self.0)).SelectionStart as usize,
+                (*(self.0)).SelectionEnd as usize,
+            )
+        };
+        // Avoid returning a range with start > end, which would be problematic. For example, it
+        // would cause panics when used to index the string buffer and would also cause Self::has_selection
+        // to return a false negative.
+        if start < end {
+            start..end
+        } else {
+            end..start
+        }
     }
 
     /// Returns the selected text directly. Note that if no text is selected,


### PR DESCRIPTION
Currently, when working with callbacks on an `InputText`, it's possible for `TextCallbackData::selection()` to return a range with `start` > `end`, eg. when selecting text by dragging from right to left. One resulting problem is that when you do this, `TextCallbackData::has_selection()` will return false, because the implementation is simply 
```rust 
pub fn has_selection(&self) -> bool {
    !self.selection().is_empty()
}
```
with stdlib's implementation of `Range::is_empty()` being
```rust
pub fn is_empty(&self) -> bool {
    !(self.start < self.end)
}
```
A bigger problem is that calling `TextCallbackData::selected()` with the selection in this state will cause a guaranteed panic, because the selection range is used to index the input buffer.

This MR provides one possible solution by ensuring the `Range` returned by `TextCallbackData::selection()` always satisfies `start` <= `end`. 