### PR TITLE
Run 'cargo package' in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,13 +153,13 @@ jobs:
 
       # Test the .crate sent to crates.io can be built
       - name: build .crate package (default)
-        run: cargo package -p imgui-sys && cargo package -p imgui
+        run: cargo package --no-verify -p imgui-sys && cargo package --no-verify -p imgui
       - name: build .crate package (docking)
-        run: cargo package -p imgui-sys --features docking && cargo package -p imgui --features docking
+        run: cargo package --no-verify -p imgui-sys --features docking && cargo package --no-verify -p imgui --features docking
       - name: build .crate package (freetype)
-        run: cargo package -p imgui-sys --features freetype && cargo package -p imgui --features freetype
+        run: cargo package --no-verify -p imgui-sys --features freetype && cargo package --no-verify -p imgui --features freetype
       - name: build .crate package (all)
-        run: cargo package -p imgui-sys --features docking,freetype && cargo package -p imgui --features docking,freetype
+        run: cargo package --no-verify -p imgui-sys --features docking,freetype && cargo package --no-verify -p imgui --features docking,freetype
 
       # Run unreasonably slow tests under release, but only the crates that have
       # them, and don't bother doing this on most platforms.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,13 +153,13 @@ jobs:
 
       # Test the .crate sent to crates.io can be built
       - name: build .crate package (default)
-        run: cargo package
+        run: cargo package -p imgui-sys && cargo package -p imgui
       - name: build .crate package (docking)
-        run: cargo package --features docking
+        run: cargo package -p imgui-sys --features docking && cargo package -p imgui --features docking
       - name: build .crate package (freetype)
-        run: cargo package --features freetype
+        run: cargo package -p imgui-sys --features freetype && cargo package -p imgui --features freetype
       - name: build .crate package (all)
-        run: cargo package --features freetype,docking
+        run: cargo package -p imgui-sys --features docking,freetype && cargo package -p imgui --features docking,freetype
 
       # Run unreasonably slow tests under release, but only the crates that have
       # them, and don't bother doing this on most platforms.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: ["1.54"]
+        rust: ["1.56"]
 
     env:
       RUSTFLAGS: -D warnings
@@ -82,7 +82,7 @@ jobs:
         rust:
           - stable
           - beta
-          - "1.54"
+          - "1.56"
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,16 @@ jobs:
       - name: build documentation
         run: cargo doc
 
+      # Test the .crate sent to crates.io can be built
+      - name: build .crate package (default)
+        run: cargo package
+      - name: build .crate package (docking)
+        run: cargo package --features docking
+      - name: build .crate package (freetype)
+        run: cargo package --features freetype
+      - name: build .crate package (all)
+        run: cargo package --features freetype,docking
+
       # Run unreasonably slow tests under release, but only the crates that have
       # them, and don't bother doing this on most platforms.
       - run: cargo test -p imgui --release -- --ignored


### PR DESCRIPTION
Should verify the .crate file sent to crates.io can at least be built, which should catch things like the docs.rs build failure, as discussed in #645 and #631