### PR TITLE
Removing note in README about being under new management.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,8 +5,6 @@
 [![Documentation on docs.rs](https://docs.rs/imgui/badge.svg)](https://docs.rs/imgui)
 [![Wrapped Dear ImGui Version](https://img.shields.io/badge/Dear%20ImGui%20Version-1.84.2-blue.svg)](https://github.com/ocornut/imgui)
 
-(Recently under new maintenance, things subject to change)
-
 ![Hello world](hello_world.png)
 
 ```rust


### PR DESCRIPTION
Noticed that a line in the README stating that the project was under new maintenance had been there a while.

Checked the git blame showed it had been there for ~1.5 years, figured a PR to change it wouldn't be out of line.