### PR TITLE
Update MSRV to 1.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: ["1.54"]
+        rust: ["1.56"]
 
     env:
       RUSTFLAGS: -D warnings
@@ -82,7 +82,7 @@ jobs:
         rust:
           - stable
           - beta
-          - "1.54"
+          - "1.56"
         os:
           - ubuntu-latest
           - macos-latest

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- MSRV is now **1.54**. We soft-updated to this in 0.8.0 with a feature `min-const-generics`, which has now been removed (and as such, we resume having no default features).
+- MSRV is now **1.56**. We soft-updated to this to Rust 1.54 in the v0.8.0 release (with a feature `min-const-generics`), which has now been removed (and as such, we resume having no default features). Rust 1.56 is required for some indirect dependencies which now use the Rust 2021 edition
 
 - Upgraded from Dear ImGui 1.84.2 to 1.86. See [the 1.85](https://github.com/ocornut/imgui/releases/tag/v1.85) and [the 1.86](https://github.com/ocornut/imgui/releases/tag/v1.86) release notes
 

--- a/README.markdown
+++ b/README.markdown
@@ -51,7 +51,7 @@ Additionally, the following are no longer maintained, but might work still:
 
 ## Minimum Support Rust Version (MSRV)
 
-The MSRV for `imgui-rs` and all of the backend crates is **1.54**. We update our MSRV periodically, and issue a minor bump for it.
+The MSRV for `imgui-rs` and all of the backend crates is **1.56**. We update our MSRV periodically, and issue a minor bump for it.
 
 ## Choosing a backend platform and a renderer
 


### PR DESCRIPTION
As noted in #658 - indirect dependency now requires 2021 edition, which forces us to 1.56

Noted in the changelog, and CI

We could probably workaround this in some way (and technically people can pin that dep back and it'll still work in 1.54).. but given we have minimal reason to be conservative with our MSRV (imgui-rs isn't a widely used low-level libray thing like serde or whatever), just bumping it to "lowest version which doesn't cause us trouble" is a good compromise