### PR TITLE
leave tree_node label None if not set

### DIFF
--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -389,13 +389,28 @@ fn show_test_window(ui: &Ui, state: &mut State, opened: &mut bool) {
         }
         if CollapsingHeader::new("Widgets").build(ui) {
             if let Some(_t) = ui.tree_node("Tree") {
-                for i in 0..5 {
+                let num_child = 4;
+                for i in 0..num_child {
                     if let Some(_t) = ui.tree_node(format!("Child {}", i)) {
                         ui.text("blah blah");
                         ui.same_line();
                         if ui.small_button("print") {
                             println!("Child {} pressed", i);
                         }
+                    }
+                }
+
+                {
+                    let tree_node_stack = ui.tree_node_config("##HideTreeNodeLabel")
+                        .allow_item_overlap(true)
+                        .push();
+                    ui.same_line();
+                    if ui.small_button(format!("Child {} is a button", num_child)) {
+                        println!("TreeNode Button pressed.");
+                    }
+
+                    if tree_node_stack.is_some() {
+                        ui.text("blah blah")
                     }
                 }
             }

--- a/imgui/src/widget/tree.rs
+++ b/imgui/src/widget/tree.rs
@@ -287,17 +287,16 @@ impl<'a, T: AsRef<str>, L: AsRef<str>> TreeNode<'a, T, L> {
                 sys::igSetNextItemOpen(self.opened, self.opened_cond as i32);
             }
             match self.id {
-                TreeNodeId::Str(id) => {
-                    let (id, label) = match self.label {
-                        Some(label) => self.ui.scratch_txt_two(id, label),
-                        None => {
-                            let v = self.ui.scratch_txt(id);
-                            (v, v)
-                        }
-                    };
-
-                    sys::igTreeNodeExStrStr(id, self.flags.bits() as i32, fmt_ptr(), label)
-                }
+                TreeNodeId::Str(id) => match self.label {
+                    Some(label) => {
+                        let (id, label) = self.ui.scratch_txt_two(id, label);
+                        sys::igTreeNodeExStrStr(id, self.flags.bits() as i32, fmt_ptr(), label)
+                    }
+                    None => {
+                        let id = self.ui.scratch_txt(id);
+                        sys::igTreeNodeExStr(id, self.flags.bits() as i32)
+                    }
+                },
                 TreeNodeId::Ptr(id) => sys::igTreeNodeExPtr(
                     id,
                     self.flags.bits() as i32,


### PR DESCRIPTION
This allows users to hide tree_node label. This change also added an
example of making tree_node as a button.