### PR TITLE
Restoring "Include imgui/misc/freetype/ in crate package" from 0.8.x release

### DIFF
--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -10,8 +10,20 @@ license = "MIT/Apache-2.0"
 categories = ["gui", "external-ffi-bindings"]
 build = "build.rs"
 links = "imgui"
-# exclude .json, .lua from imgui dirs - they are intermediate artifacts from cimgui generator
-exclude = ["third-party/imgui-*/*.json", "third-party/imgui-*/*.lua"]
+
+# exclude json, lua, and the imgui subdirs (imgui/examples, imgui/docs, etc)
+# ..but we need imgui/misc/freetype/ for the freetype feature
+exclude = [
+    "third-party/*.json",
+    "third-party/*.lua",
+    "third-party/imgui/backends/",
+    "third-party/imgui/docs/",
+    "third-party/imgui/examples/",
+    "third-party/imgui/misc/cpp/",
+    "third-party/imgui/misc/debuggers/",
+    "third-party/imgui/misc/fonts/",
+    "third-party/imgui/misc/single_file/",
+]
 
 [dependencies]
 chlorine = "1.0.7"


### PR DESCRIPTION
In trying to straighten things out for #665 I noticed one of the bugfixes release in `0.8.something` wasn't in the main branch - specifically the change for #595

This reapplies this fix to main branch, allowing the "--features freetype" to work when using via crates.io