### PR TITLE
Removing im_str! marco

### DIFF
--- a/imgui/src/string.rs
+++ b/imgui/src/string.rs
@@ -74,36 +74,6 @@ impl UiBuffer {
     }
 }
 
-#[macro_export]
-#[deprecated = "all functions take AsRef<str> now -- use inline strings or `format` instead"]
-macro_rules! im_str {
-    ($e:literal $(,)?) => {{
-        const __INPUT: &str = concat!($e, "\0");
-        {
-            // Trigger a compile error if there's an interior NUL character.
-            const _CHECK_NUL: [(); 0] = [(); {
-                let bytes = __INPUT.as_bytes();
-                let mut i = 0;
-                let mut found_nul = 0;
-                while i < bytes.len() - 1 && found_nul == 0 {
-                    if bytes[i] == 0 {
-                        found_nul = 1;
-                    }
-                    i += 1;
-                }
-                found_nul
-            }];
-            const RESULT: &'static $crate::ImStr = unsafe {
-                $crate::__core::mem::transmute::<&'static [u8], &'static $crate::ImStr>(__INPUT.as_bytes())
-            };
-            RESULT
-        }
-    }};
-    ($e:literal, $($arg:tt)+) => ({
-        $crate::ImString::new(format!($e, $($arg)*))
-    });
-}
-
 /// A UTF-8 encoded, growable, implicitly nul-terminated string.
 #[derive(Clone, Hash, Ord, Eq, PartialOrd, PartialEq)]
 pub struct ImString(pub(crate) Vec<u8>);


### PR DESCRIPTION
Closes #576

Kind of in two minds about removing this

In favour of removing it:

- the macro is not necessary any more (`im_str!("blah")` can just replaced with `"blah"`, and doing this replacement even in a large code base wasn't particularly ardious)
- it's been deprecated since v0.8 which has been out about a year, so chances are most projects that might update to v0.9 would have already removed it to silence the annoying deprecation-warning

In favour of keeping it:
- The macro is relatively self-contained and not much burdent to keep around
- Nostalgia? ( :stuck_out_tongue: )