### PR TITLE
Fix keyboard modifiers in Winit with the new ImGui version.

### DIFF
--- a/imgui-sdl2-support/src/lib.rs
+++ b/imgui-sdl2-support/src/lib.rs
@@ -143,10 +143,10 @@ fn handle_key(io: &mut Io, key: &Scancode, pressed: bool) {
 
 /// Handle changes in the key modifier states.
 fn handle_key_modifier(io: &mut Io, keymod: &Mod) {
-    io.add_key_event(Key::ModShift, keymod.intersects(Mod::LSHIFTMOD | Mod::RSHIFTMOD));
-    io.add_key_event(Key::ModCtrl, keymod.intersects(Mod::LCTRLMOD | Mod::RCTRLMOD));
-    io.add_key_event(Key::ModAlt, keymod.intersects(Mod::LALTMOD | Mod::RALTMOD));
-    io.add_key_event(Key::ModSuper, keymod.intersects(Mod::LGUIMOD | Mod::RGUIMOD));
+    io.add_key_event(imgui::Key::ModShift, keymod.intersects(Mod::LSHIFTMOD | Mod::RSHIFTMOD));
+    io.add_key_event(imgui::Key::ModCtrl, keymod.intersects(Mod::LCTRLMOD | Mod::RCTRLMOD));
+    io.add_key_event(imgui::Key::ModAlt, keymod.intersects(Mod::LALTMOD | Mod::RALTMOD));
+    io.add_key_event(imgui::Key::ModSuper, keymod.intersects(Mod::LGUIMOD | Mod::RGUIMOD));
 }
 
 /// Map an imgui::MouseCursor to an equivalent sdl2::mouse::SystemCursor.

--- a/imgui-sdl2-support/src/lib.rs
+++ b/imgui-sdl2-support/src/lib.rs
@@ -143,10 +143,22 @@ fn handle_key(io: &mut Io, key: &Scancode, pressed: bool) {
 
 /// Handle changes in the key modifier states.
 fn handle_key_modifier(io: &mut Io, keymod: &Mod) {
-    io.add_key_event(imgui::Key::ModShift, keymod.intersects(Mod::LSHIFTMOD | Mod::RSHIFTMOD));
-    io.add_key_event(imgui::Key::ModCtrl, keymod.intersects(Mod::LCTRLMOD | Mod::RCTRLMOD));
-    io.add_key_event(imgui::Key::ModAlt, keymod.intersects(Mod::LALTMOD | Mod::RALTMOD));
-    io.add_key_event(imgui::Key::ModSuper, keymod.intersects(Mod::LGUIMOD | Mod::RGUIMOD));
+    io.add_key_event(
+        imgui::Key::ModShift,
+        keymod.intersects(Mod::LSHIFTMOD | Mod::RSHIFTMOD),
+    );
+    io.add_key_event(
+        imgui::Key::ModCtrl,
+        keymod.intersects(Mod::LCTRLMOD | Mod::RCTRLMOD),
+    );
+    io.add_key_event(
+        imgui::Key::ModAlt,
+        keymod.intersects(Mod::LALTMOD | Mod::RALTMOD),
+    );
+    io.add_key_event(
+        imgui::Key::ModSuper,
+        keymod.intersects(Mod::LGUIMOD | Mod::RGUIMOD),
+    );
 }
 
 /// Map an imgui::MouseCursor to an equivalent sdl2::mouse::SystemCursor.

--- a/imgui-sdl2-support/src/lib.rs
+++ b/imgui-sdl2-support/src/lib.rs
@@ -143,10 +143,10 @@ fn handle_key(io: &mut Io, key: &Scancode, pressed: bool) {
 
 /// Handle changes in the key modifier states.
 fn handle_key_modifier(io: &mut Io, keymod: &Mod) {
-    io.key_shift = keymod.intersects(Mod::LSHIFTMOD | Mod::RSHIFTMOD);
-    io.key_ctrl = keymod.intersects(Mod::LCTRLMOD | Mod::RCTRLMOD);
-    io.key_alt = keymod.intersects(Mod::LALTMOD | Mod::RALTMOD);
-    io.key_super = keymod.intersects(Mod::LGUIMOD | Mod::RGUIMOD);
+    io.add_key_event(Key::ModShift, keymod.intersects(Mod::LSHIFTMOD | Mod::RSHIFTMOD));
+    io.add_key_event(Key::ModCtrl, keymod.intersects(Mod::LCTRLMOD | Mod::RCTRLMOD));
+    io.add_key_event(Key::ModAlt, keymod.intersects(Mod::LALTMOD | Mod::RALTMOD));
+    io.add_key_event(Key::ModSuper, keymod.intersects(Mod::LGUIMOD | Mod::RGUIMOD));
 }
 
 /// Map an imgui::MouseCursor to an equivalent sdl2::mouse::SystemCursor.

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -399,10 +399,10 @@ impl WinitPlatform {
                 // not reliably send modifier states during certain events like ScreenCapture.
                 // Gotta let the people show off their pretty imgui widgets!
                 if let WindowEvent::ModifiersChanged(modifiers) = event {
-                    io.key_shift = modifiers.shift();
-                    io.key_ctrl = modifiers.ctrl();
-                    io.key_alt = modifiers.alt();
-                    io.key_super = modifiers.logo();
+                    io.add_key_event(Key::ModShift, modifiers.shift());
+                    io.add_key_event(Key::ModCtrl, modifiers.ctrl());
+                    io.add_key_event(Key::ModAlt, modifiers.alt());
+                    io.add_key_event(Key::ModSuper, modifiers.logo());
                 }
 
                 self.handle_window_event(io, window, event);

--- a/imgui/src/input/keyboard.rs
+++ b/imgui/src/input/keyboard.rs
@@ -147,6 +147,11 @@ pub enum Key {
     ReservedForModShift = sys::ImGuiKey_ReservedForModShift,
     ReservedForModAlt = sys::ImGuiKey_ReservedForModAlt,
     ReservedForModSuper = sys::ImGuiKey_ReservedForModSuper,
+    ModCtrl = sys::ImGuiMod_Ctrl,
+    ModShift = sys::ImGuiMod_Shift,
+    ModAlt = sys::ImGuiMod_Alt,
+    ModSuper = sys::ImGuiMod_Super,
+    ModShortcut = sys::ImGuiMod_Shortcut,
 }
 
 impl Key {


### PR DESCRIPTION
The recent update to DearImGui 1.89.2 was great, but I think it broke the handling of modifier keys.

The thing is that the values of `io.key_shift` and friends are updated in [`ImGui::UpdateKeyboardInputs()`](https://github.com/imgui-rs/imgui-rs/blob/main/imgui-sys/third-party/imgui-master/imgui/imgui.cpp#L8293) based on the values of the _pseudo keys_ such as `ImGuiMod_Ctrl`.

It looks like the [recommended way](https://github.com/imgui-rs/imgui-rs/blob/main/imgui-sys/third-party/imgui-master/imgui/imgui.cpp#L8289) to notify changes in the modifier keys is to just call `AddKeyEvent()`, as if it were a real key.