### PR TITLE
Fix handling of modifier keys in winit-support

### DIFF
--- a/imgui-glow-renderer/src/lib.rs
+++ b/imgui-glow-renderer/src/lib.rs
@@ -285,9 +285,10 @@ impl Renderer {
         #[cfg(feature = "bind_vertex_array_support")]
         if self.gl_version.bind_vertex_array_support() {
             unsafe {
-                self.vertex_array_object = Some(gl
-                    .create_vertex_array()
-                    .map_err(|err| format!("Error creating vertex array object: {}", err))?);
+                self.vertex_array_object = Some(
+                    gl.create_vertex_array()
+                        .map_err(|err| format!("Error creating vertex array object: {}", err))?,
+                );
                 gl.bind_vertex_array(self.vertex_array_object);
             }
         }
@@ -572,7 +573,9 @@ impl TextureMap for SimpleTextureMap {
     #[inline(always)]
     fn gl_texture(&self, imgui_texture: imgui::TextureId) -> Option<glow::Texture> {
         #[allow(clippy::cast_possible_truncation)]
-        Some(glow::NativeTexture(NonZeroU32::new(imgui_texture.id() as _).unwrap()))
+        Some(glow::NativeTexture(
+            NonZeroU32::new(imgui_texture.id() as _).unwrap(),
+        ))
     }
 }
 
@@ -646,7 +649,10 @@ impl GlStateBackup {
     fn post_init(&mut self, gl: &Context) {
         #[allow(clippy::cast_sign_loss)]
         unsafe {
-            gl.bind_texture(glow::TEXTURE_2D, to_native_gl(self.texture, glow::NativeTexture));
+            gl.bind_texture(
+                glow::TEXTURE_2D,
+                to_native_gl(self.texture, glow::NativeTexture),
+            );
         }
     }
 
@@ -705,7 +711,10 @@ impl GlStateBackup {
         #![allow(clippy::cast_sign_loss)]
         unsafe {
             gl.use_program(to_native_gl(self.program, glow::NativeProgram));
-            gl.bind_texture(glow::TEXTURE_2D, to_native_gl(self.texture, glow::NativeTexture));
+            gl.bind_texture(
+                glow::TEXTURE_2D,
+                to_native_gl(self.texture, glow::NativeTexture),
+            );
             #[cfg(feature = "bind_sampler_support")]
             if let Some(sampler) = self.sampler {
                 gl.bind_sampler(0, to_native_gl(sampler, glow::NativeSampler));
@@ -715,7 +724,10 @@ impl GlStateBackup {
             if let Some(vao) = self.vertex_array_object {
                 gl.bind_vertex_array(to_native_gl(vao, glow::NativeVertexArray));
             }
-            gl.bind_buffer(glow::ARRAY_BUFFER, to_native_gl(self.array_buffer, glow::NativeBuffer));
+            gl.bind_buffer(
+                glow::ARRAY_BUFFER,
+                to_native_gl(self.array_buffer, glow::NativeBuffer),
+            );
             gl.blend_equation_separate(
                 self.blend_equation_rgb as _,
                 self.blend_equation_alpha as _,

--- a/imgui-winit-glow-renderer-viewports/src/lib.rs
+++ b/imgui-winit-glow-renderer-viewports/src/lib.rs
@@ -497,7 +497,7 @@ impl Renderer {
                         input:
                             KeyboardInput {
                                 virtual_keycode: Some(key),
-                                state: ElementState::Pressed,
+                                state,
                                 ..
                             },
                         ..
@@ -510,7 +510,7 @@ impl Renderer {
                         // applications to use either general "ctrl" or a
                         // specific key. Same applies to other modifiers.
                         // https://github.com/ocornut/imgui/issues/5047
-                        handle_key_modifier(io, key, pressed);
+                        handle_key_modifier(imgui.io_mut(), key, pressed);
 
                         // Add main key event
                         if let Some(key) = to_imgui_key(key) {
@@ -911,7 +911,7 @@ struct PlatformBackend {
     event_queue: Rc<RefCell<VecDeque<ViewportEvent>>>,
 }
 
-fn handle_key_modifier(io: &mut Io, key: VirtualKeyCode, down: bool) {
+fn handle_key_modifier(io: &mut imgui::Io, key: VirtualKeyCode, down: bool) {
     if key == VirtualKeyCode::LShift || key == VirtualKeyCode::RShift {
         io.add_key_event(imgui::Key::ModShift, down);
     } else if key == VirtualKeyCode::LControl || key == VirtualKeyCode::RControl {

--- a/imgui-winit-glow-renderer-viewports/src/lib.rs
+++ b/imgui-winit-glow-renderer-viewports/src/lib.rs
@@ -493,8 +493,19 @@ impl Renderer {
                             },
                         ..
                     } => {
+                        let pressed = state == ElementState::Pressed;
+
+                        // We map both left and right ctrl to `ModCtrl`, etc.
+                        // imgui is told both "left control is pressed" and
+                        // "consider the control key is pressed". Allows
+                        // applications to use either general "ctrl" or a
+                        // specific key. Same applies to other modifiers.
+                        // https://github.com/ocornut/imgui/issues/5047
+                        handle_key_modifier(io, key, pressed);
+
+                        // Add main key event
                         if let Some(key) = to_imgui_key(key) {
-                            imgui.io_mut().add_key_event(key, true);
+                            imgui.io_mut().add_key_event(key, pressed);
                         }
                     }
                     winit::event::WindowEvent::ModifiersChanged(modifiers) => {
@@ -889,6 +900,18 @@ struct ViewportData {
 
 struct PlatformBackend {
     event_queue: Rc<RefCell<VecDeque<ViewportEvent>>>,
+}
+
+fn handle_key_modifier(io: &mut Io, key: VirtualKeyCode, down: bool) {
+    if key == VirtualKeyCode::LShift || key == VirtualKeyCode::RShift {
+        io.add_key_event(imgui::Key::ModShift, down);
+    } else if key == VirtualKeyCode::LControl || key == VirtualKeyCode::RControl {
+        io.add_key_event(imgui::Key::ModCtrl, down);
+    } else if key == VirtualKeyCode::LAlt || key == VirtualKeyCode::RAlt {
+        io.add_key_event(imgui::Key::ModAlt, down);
+    } else if key == VirtualKeyCode::LWin || key == VirtualKeyCode::RWin {
+        io.add_key_event(imgui::Key::ModSuper, down);
+    }
 }
 
 impl imgui::PlatformViewportBackend for PlatformBackend {

--- a/imgui-winit-glow-renderer-viewports/src/lib.rs
+++ b/imgui-winit-glow-renderer-viewports/src/lib.rs
@@ -305,10 +305,19 @@ impl GlStateBackup {
 
             context.bind_vertex_array(to_native_gl(self.vao, glow::NativeVertexArray));
 
-            context.bind_buffer(glow::ARRAY_BUFFER, to_native_gl(self.vbo, glow::NativeBuffer));
-            context.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, to_native_gl(self.ibo, glow::NativeBuffer));
+            context.bind_buffer(
+                glow::ARRAY_BUFFER,
+                to_native_gl(self.vbo, glow::NativeBuffer),
+            );
+            context.bind_buffer(
+                glow::ELEMENT_ARRAY_BUFFER,
+                to_native_gl(self.ibo, glow::NativeBuffer),
+            );
 
-            context.bind_texture(glow::TEXTURE_2D, to_native_gl(self.texture, glow::NativeTexture));
+            context.bind_texture(
+                glow::TEXTURE_2D,
+                to_native_gl(self.texture, glow::NativeTexture),
+            );
             context.active_texture(self.active_texture);
 
             context.use_program(to_native_gl(self.program, glow::NativeProgram));

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -291,6 +291,18 @@ fn to_imgui_key(keycode: VirtualKeyCode) -> Option<Key> {
     }
 }
 
+fn handle_key_modifier(io: &mut Io, key: VirtualKeyCode, down: bool) {
+    if key == VirtualKeyCode::LShift || key == VirtualKeyCode::RShift {
+        io.add_key_event(imgui::Key::ModShift, down);
+    } else if key == VirtualKeyCode::LControl || key == VirtualKeyCode::RControl {
+        io.add_key_event(imgui::Key::ModCtrl, down);
+    } else if key == VirtualKeyCode::LAlt || key == VirtualKeyCode::RAlt {
+        io.add_key_event(imgui::Key::ModAlt, down);
+    } else if key == VirtualKeyCode::LWin || key == VirtualKeyCode::RWin {
+        io.add_key_event(imgui::Key::ModSuper, down);
+    }
+}
+
 impl WinitPlatform {
     /// Initializes a winit platform instance and configures imgui.
     ///
@@ -461,8 +473,18 @@ impl WinitPlatform {
                     },
                 ..
             } => {
+                let pressed = state == ElementState::Pressed;
+
+                // We map both left and right ctrl to `ModCtrl`, etc.
+                // imgui is told both "left control is pressed" and
+                // "consider the control key is pressed". Allows
+                // applications to use either general "ctrl" or a
+                // specific key. Same applies to other modifiers.
+                // https://github.com/ocornut/imgui/issues/5047
+                handle_key_modifier(io, key, pressed);
+
+                // Add main key event
                 if let Some(key) = to_imgui_key(key) {
-                    let pressed = state == ElementState::Pressed;
                     io.add_key_event(key, pressed);
                 }
             }

--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -395,16 +395,6 @@ impl WinitPlatform {
                 window_id,
                 ref event,
             } if window_id == window.id() => {
-                // We need to track modifiers separately because some system like macOS, will
-                // not reliably send modifier states during certain events like ScreenCapture.
-                // Gotta let the people show off their pretty imgui widgets!
-                if let WindowEvent::ModifiersChanged(modifiers) = event {
-                    io.add_key_event(Key::ModShift, modifiers.shift());
-                    io.add_key_event(Key::ModCtrl, modifiers.ctrl());
-                    io.add_key_event(Key::ModAlt, modifiers.alt());
-                    io.add_key_event(Key::ModSuper, modifiers.logo());
-                }
-
                 self.handle_window_event(io, window, event);
             }
             // Track key release events outside our window. If we don't do this,
@@ -452,6 +442,15 @@ impl WinitPlatform {
                 let logical_size = window.inner_size().to_logical(scale_factor);
                 let logical_size = self.scale_size_from_winit(window, logical_size);
                 io.display_size = [logical_size.width as f32, logical_size.height as f32];
+            }
+            WindowEvent::ModifiersChanged(modifiers) => {
+                // We need to track modifiers separately because some system like macOS, will
+                // not reliably send modifier states during certain events like ScreenCapture.
+                // Gotta let the people show off their pretty imgui widgets!
+                io.add_key_event(Key::ModShift, modifiers.shift());
+                io.add_key_event(Key::ModCtrl, modifiers.ctrl());
+                io.add_key_event(Key::ModAlt, modifiers.alt());
+                io.add_key_event(Key::ModSuper, modifiers.logo());
             }
             WindowEvent::KeyboardInput {
                 input:


### PR DESCRIPTION
Previously, the `ModCtrl`/etc keys were not set reliably meaning the `io().key_ctrl` was never set, and possibly some other weird behaviour (like an abort if trying to call `is_key_down(Key::ModCtrl)`)

There's some further compounding weirdness in that winit seems to only emit the `ModifiersChanged` after the window re-gains focus (on Linux/X11)

Regardless, I think this change avoids these problems, and is consistent with `imgui-sdl2-support` (and https://github.com/ocornut/imgui/issues/5047 )

- [ ] This needs backported to `v0.10` as it's a bug in the last release
- [x] This will need applied to the viewports backend as it uses winit also (will merge that PR and rebase this one momentarily)