### PR TITLE
Replaced crate "clipboard" by "copypasta"

### DIFF
--- a/imgui-examples/Cargo.toml
+++ b/imgui-examples/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 publish = false
 
 [dev-dependencies]
-clipboard = "0.5"
+copypasta = "0.8"
 glium = { version = "0.32.1", default-features = true }
 image = "0.23"
 imgui = { path = "../imgui", features = ["tables-api"] }

--- a/imgui-examples/examples/support/clipboard.rs
+++ b/imgui-examples/examples/support/clipboard.rs
@@ -1,4 +1,4 @@
-use clipboard::{ClipboardContext, ClipboardProvider};
+use copypasta::{ClipboardContext, ClipboardProvider};
 use imgui::ClipboardBackend;
 
 pub struct ClipboardSupport(pub ClipboardContext);


### PR DESCRIPTION
The crate clipboard is not maintained anymore and has a dependency with multiple security issues.

This MR fixes https://github.com/imgui-rs/imgui-rs/issues/623.