### PR TITLE
Bump MSRV to 1.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: ["1.60"]
+        rust: ["1.64"]
 
     env:
       RUSTFLAGS: -D warnings
@@ -81,7 +81,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - "1.60"
+          - "1.64"
         os:
           - ubuntu-latest
           - macos-latest

--- a/README.markdown
+++ b/README.markdown
@@ -60,7 +60,7 @@ be applicable to usage with any backend/renderer.
 
 ## Minimum Support Rust Version (MSRV)
 
-The MSRV for `imgui-rs` and all of the backend crates is **1.60**. We update our MSRV periodically, and issue a minor bump for it.
+The MSRV for `imgui-rs` and all of the backend crates is **1.64**. We update our MSRV periodically, and issue a minor bump for it.
 
 ## Choosing a backend platform and a renderer
 


### PR DESCRIPTION
raw-window-handle now requires this. No hard-requirement from imgui-rs - projects with lock file pinning indirect dependencies will likely keep working in 1.60