### PR TITLE
Add functions `begin_popup_context_*`.

### DIFF
--- a/imgui/src/popups.rs
+++ b/imgui/src/popups.rs
@@ -252,7 +252,7 @@ impl Ui {
     ///
     /// This does not take a label, which means that multiple calls **in a row** will use the same label, which
     /// is based on the last node which had a label. Text and other non-interactive elements generally don't have
-    /// ids, so you'll need to use [begin_popup_context_with_label] for them.
+    /// ids, so you'll need to use [begin_popup_context_with_label](Self::begin_popup_context_with_label) for them.
     #[doc(alias = "BeginPopupContextItem")]
     pub fn begin_popup_context_item(&self) -> Option<PopupToken<'_>> {
         let render = unsafe {
@@ -272,7 +272,7 @@ impl Ui {
     /// Open and begin popup when clicked with the right mouse button on the given item with a dedicated label.
     ///
     /// If you want to use the label of the previous popup (outside of `Text` and other non-interactive cases, that
-    /// is the more normal case), use [begin_popup_context_item].
+    /// is the more normal case), use [begin_popup_context_item](Self::begin_popup_context_item).
     #[doc(alias = "BeginPopupContextItem")]
     pub fn begin_popup_context_with_label<Label: AsRef<str>>(
         &self,
@@ -296,7 +296,7 @@ impl Ui {
     ///
     /// This does not take a label, which means that multiple calls will use the same provided label.
     /// If you want an explicit label, such as having two different kinds of windows popups in your program,
-    /// use [begin_popup_context_window_with_label].
+    /// use [begin_popup_context_window_with_label](Self::begin_popup_context_window_with_label).
     #[doc(alias = "BeginPopupContextWindow")]
     pub fn begin_popup_context_window(&self) -> Option<PopupToken<'_>> {
         let render = unsafe {
@@ -340,7 +340,7 @@ impl Ui {
     ///
     /// This does not take a label, which means that multiple calls will use the same provided label.
     /// If you want an explicit label, such as having two different kinds of void popups in your program,
-    /// use [begin_popup_context_void_with_label].
+    /// use [begin_popup_context_void_with_label](Self::begin_popup_context_void_with_label).
     #[doc(alias = "BeginPopupContextWindow")]
     pub fn begin_popup_context_void(&self) -> Option<PopupToken<'_>> {
         let render = unsafe {

--- a/imgui/src/popups.rs
+++ b/imgui/src/popups.rs
@@ -249,7 +249,10 @@ impl Ui {
     }
 
     /// Open and begin popup when clicked with the right mouse button on last item.
-    /// If you want to use that on a non-interactive item such as text() use [`Self::begin_popup_context_item_id`].
+    ///
+    /// This does not take a label, which means that multiple calls **in a row** will use the same label, which
+    /// is based on the last node which had a label. Text and other non-interactive elements generally don't have
+    /// ids, so you'll need to use [begin_popup_context_with_label] for them.
     #[doc(alias = "BeginPopupContextItem")]
     pub fn begin_popup_context_item(&self) -> Option<PopupToken<'_>> {
         let render = unsafe {
@@ -266,10 +269,12 @@ impl Ui {
         }
     }
 
-    /// Open and begin popup when clicked with the right mouse button on the given item.
-    /// If you want to use the last item and it has an id you, you can use [`Self::begin_popup_context_item`].
+    /// Open and begin popup when clicked with the right mouse button on the given item with a dedicated label.
+    ///
+    /// If you want to use the label of the previous popup (outside of `Text` and other non-interactive cases, that
+    /// is the more normal case), use [begin_popup_context_item].
     #[doc(alias = "BeginPopupContextItem")]
-    pub fn begin_popup_context_item_id<Label: AsRef<str>>(
+    pub fn begin_popup_context_with_label<Label: AsRef<str>>(
         &self,
         str_id: Label,
     ) -> Option<PopupToken<'_>> {
@@ -288,8 +293,32 @@ impl Ui {
     }
 
     /// Open and begin popup when clicked on current window.
+    ///
+    /// This does not take a label, which means that multiple calls will use the same provided label.
+    /// If you want an explicit label, such as having two different kinds of windows popups in your program,
+    /// use [begin_popup_context_window_with_label].
     #[doc(alias = "BeginPopupContextWindow")]
-    pub fn begin_popup_context_window<Label: AsRef<str>>(
+    pub fn begin_popup_context_window(&self) -> Option<PopupToken<'_>> {
+        let render = unsafe {
+            sys::igBeginPopupContextWindow(
+                std::ptr::null(),
+                imgui_sys::ImGuiPopupFlags_MouseButtonRight as i32,
+            )
+        };
+
+        if render {
+            Some(PopupToken::new(self))
+        } else {
+            None
+        }
+    }
+
+    /// Open and begin popup when clicked on current window.
+    ///
+    /// This takes a label explicitly. This is useful when multiple code
+    /// locations may want to manipulate/open the same popup, given an explicit id.
+    #[doc(alias = "BeginPopupContextWindow")]
+    pub fn begin_popup_context_window_with_label<Label: AsRef<str>>(
         &self,
         str_id: Label,
     ) -> Option<PopupToken<'_>> {
@@ -308,8 +337,32 @@ impl Ui {
     }
 
     /// Open and begin popup when right clicked in void (where there are no windows).
+    ///
+    /// This does not take a label, which means that multiple calls will use the same provided label.
+    /// If you want an explicit label, such as having two different kinds of void popups in your program,
+    /// use [begin_popup_context_void_with_label].
+    #[doc(alias = "BeginPopupContextWindow")]
+    pub fn begin_popup_context_void(&self) -> Option<PopupToken<'_>> {
+        let render = unsafe {
+            sys::igBeginPopupContextVoid(
+                std::ptr::null(),
+                imgui_sys::ImGuiPopupFlags_MouseButtonRight as i32,
+            )
+        };
+
+        if render {
+            Some(PopupToken::new(self))
+        } else {
+            None
+        }
+    }
+
+    /// Open and begin popup when right clicked in void (where there are no windows).
+    ///
+    /// This takes a label explicitly. This is useful when multiple code
+    /// locations may want to manipulate/open the same popup, given an explicit id.
     #[doc(alias = "BeginPopupContextVoid")]
-    pub fn begin_popup_context_void<Label: AsRef<str>>(
+    pub fn begin_popup_context_void_with_label<Label: AsRef<str>>(
         &self,
         str_id: Label,
     ) -> Option<PopupToken<'_>> {

--- a/imgui/src/popups.rs
+++ b/imgui/src/popups.rs
@@ -247,6 +247,85 @@ impl Ui {
     pub fn close_current_popup(&self) {
         unsafe { sys::igCloseCurrentPopup() };
     }
+
+    /// Open+begin popup when clicked with the right mouse button on last item.
+    /// If you want to use that on a non-interactive item such as text() use [`Self::begin_popup_context_item_id`].
+    #[doc(alias = "BeginPopupContextItem")]
+    pub fn begin_popup_context_item(&self) -> Option<PopupToken<'_>> {
+        let render = unsafe {
+            sys::igBeginPopupContextItem(
+                std::ptr::null(),
+                imgui_sys::ImGuiPopupFlags_MouseButtonRight as i32,
+            )
+        };
+
+        if render {
+            Some(PopupToken::new(self))
+        } else {
+            None
+        }
+    }
+
+    /// Open+begin popup when clicked with the right mouse button on the given item.
+    /// If you want to use the last item and it has an id you, you can use [`Self::begin_popup_context_item`].
+    #[doc(alias = "BeginPopupContextItem")]
+    pub fn begin_popup_context_item_id<Label: AsRef<str>>(
+        &self,
+        str_id: Label,
+    ) -> Option<PopupToken<'_>> {
+        let render = unsafe {
+            sys::igBeginPopupContextItem(
+                self.scratch_txt(str_id),
+                imgui_sys::ImGuiPopupFlags_MouseButtonRight as i32,
+            )
+        };
+
+        if render {
+            Some(PopupToken::new(self))
+        } else {
+            None
+        }
+    }
+
+    /// Open+begin popup when clicked on current window.
+    #[doc(alias = "BeginPopupContextWindow")]
+    pub fn begin_popup_context_window<Label: AsRef<str>>(
+        &self,
+        str_id: Label,
+    ) -> Option<PopupToken<'_>> {
+        let render = unsafe {
+            sys::igBeginPopupContextWindow(
+                self.scratch_txt(str_id),
+                imgui_sys::ImGuiPopupFlags_MouseButtonRight as i32,
+            )
+        };
+
+        if render {
+            Some(PopupToken::new(self))
+        } else {
+            None
+        }
+    }
+
+    /// Open+begin popup when clicked in void (where there are no windows).
+    #[doc(alias = "BeginPopupContextVoid")]
+    pub fn begin_popup_context_void<Label: AsRef<str>>(
+        &self,
+        str_id: Label,
+    ) -> Option<PopupToken<'_>> {
+        let render = unsafe {
+            sys::igBeginPopupContextWindow(
+                self.scratch_txt(str_id),
+                imgui_sys::ImGuiPopupFlags_MouseButtonRight as i32,
+            )
+        };
+
+        if render {
+            Some(PopupToken::new(self))
+        } else {
+            None
+        }
+    }
 }
 
 create_token!(

--- a/imgui/src/popups.rs
+++ b/imgui/src/popups.rs
@@ -248,7 +248,7 @@ impl Ui {
         unsafe { sys::igCloseCurrentPopup() };
     }
 
-    /// Open+begin popup when clicked with the right mouse button on last item.
+    /// Open and begin popup when clicked with the right mouse button on last item.
     /// If you want to use that on a non-interactive item such as text() use [`Self::begin_popup_context_item_id`].
     #[doc(alias = "BeginPopupContextItem")]
     pub fn begin_popup_context_item(&self) -> Option<PopupToken<'_>> {
@@ -266,7 +266,7 @@ impl Ui {
         }
     }
 
-    /// Open+begin popup when clicked with the right mouse button on the given item.
+    /// Open and begin popup when clicked with the right mouse button on the given item.
     /// If you want to use the last item and it has an id you, you can use [`Self::begin_popup_context_item`].
     #[doc(alias = "BeginPopupContextItem")]
     pub fn begin_popup_context_item_id<Label: AsRef<str>>(
@@ -287,7 +287,7 @@ impl Ui {
         }
     }
 
-    /// Open+begin popup when clicked on current window.
+    /// Open and begin popup when clicked on current window.
     #[doc(alias = "BeginPopupContextWindow")]
     pub fn begin_popup_context_window<Label: AsRef<str>>(
         &self,
@@ -307,14 +307,14 @@ impl Ui {
         }
     }
 
-    /// Open+begin popup when clicked in void (where there are no windows).
+    /// Open and begin popup when right clicked in void (where there are no windows).
     #[doc(alias = "BeginPopupContextVoid")]
     pub fn begin_popup_context_void<Label: AsRef<str>>(
         &self,
         str_id: Label,
     ) -> Option<PopupToken<'_>> {
         let render = unsafe {
-            sys::igBeginPopupContextWindow(
+            sys::igBeginPopupContextVoid(
                 self.scratch_txt(str_id),
                 imgui_sys::ImGuiPopupFlags_MouseButtonRight as i32,
             )


### PR DESCRIPTION
Hi!

In ImGui there are these handy functions to do pop-up menus, usually by right-clicking the mouse. This PR adds basic wrappers around these.

The code is quite self-explanatory. The most notable thing missing is the ability to specify a flag other than `ImGuiPopupFlags_MouseButtonRight`. For me, I only open pop-ups when doing a `MouseButtonRight`, so this is good enough. But if you think it is wort it, we could ad an enum wrapper and a way to specify it, maybe a builder helper struct o a few `begin_popup_context_*_with_flags()` functions.

