### PR TITLE
Update glow and sdl2 module dependencies

### DIFF
--- a/imgui-glow-renderer/Cargo.toml
+++ b/imgui-glow-renderer/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["gui", "rendering"]
 
 [dependencies]
 imgui = { version = "0.11.0", path = "../imgui" }
-glow = "0.12.0"
+glow = "0.12.3"
 memoffset = "0.9"
 
 [dev-dependencies]

--- a/imgui-sdl2-support/Cargo.toml
+++ b/imgui-sdl2-support/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["gui"]
 
 [dependencies]
 imgui = { version = "0.11.0", path = "../imgui" }
-sdl2 = "0.34.5"
+sdl2 = "~0.35.2"
 
 [dev-dependencies]
-glow = "0.12.0"
+glow = "~0.12.3"
 imgui-glow-renderer = { version = "0.11.0", path = "../imgui-glow-renderer" }
-sdl2 = { version = "0.34.5", features = ["bundled", "static-link"] }
+sdl2 = { version = "~0.35.2", features = ["bundled", "static-link"] }

--- a/imgui-sdl2-support/Cargo.toml
+++ b/imgui-sdl2-support/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["gui"]
 
 [dependencies]
 imgui = { version = "0.11.0", path = "../imgui" }
-sdl2 = "~0.35.2"
+sdl2 = "0.35.2"
 
 [dev-dependencies]
-glow = "~0.12.3"
+glow = "0.12.3"
 imgui-glow-renderer = { version = "0.11.0", path = "../imgui-glow-renderer" }
-sdl2 = { version = "~0.35.2", features = ["bundled", "static-link"] }
+sdl2 = { version = "0.35.2", features = ["bundled", "static-link"] }

--- a/imgui-winit-glow-renderer-viewports/Cargo.toml
+++ b/imgui-winit-glow-renderer-viewports/Cargo.toml
@@ -12,9 +12,9 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 imgui = { version = "0.11.0", path="../imgui", features=["docking"] }
 
-glow = "0.12.0"
-glutin = "0.30.3"
-raw-window-handle = "0.5.0"
+glow = "~0.12.3"
+glutin = "0.30.9"
+raw-window-handle = "0.5.2"
 winit = "0.27.5"
-thiserror = "1.0.38"
-glutin-winit = "0.2.1"
+thiserror = "1.0.44"
+glutin-winit = "0.2.2"

--- a/imgui-winit-glow-renderer-viewports/Cargo.toml
+++ b/imgui-winit-glow-renderer-viewports/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 imgui = { version = "0.11.0", path="../imgui", features=["docking"] }
 
-glow = "~0.12.3"
+glow = "0.12.3"
 glutin = "0.30.9"
 raw-window-handle = "0.5.2"
 winit = "0.27.5"


### PR DESCRIPTION
Update imgui-glow-rendered, imgui-sdl2-support and imgui-winit-glow-renderer-viewports dependencies