### PR TITLE
Require correct version of `cc`

### DIFF
--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -31,7 +31,7 @@ mint = "0.5.6"
 cfg-if = "1"
 
 [build-dependencies]
-cc = "1.0"
+cc = "1.0.2"
 pkg-config = { version="0.3", optional=true }
 vcpkg = { version="0.2.15", optional=true }
 


### PR DESCRIPTION
`imgui-sys`'s build script uses `cc::Tool::is_like_gnu` and `cc::Tool::is_like_clang` which were added only in `cc 1.0.2`. This made the build fail when trying to compile using [cargo-minimal-versions](https://github.com/taiki-e/cargo-minimal-versions).