### PR TITLE
updating msrv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,6 @@ jobs:
     name: Run linter
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-
-    strategy:
-      matrix:
-        rust: ["1.70"]
-
     env:
       RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: -D warnings
@@ -33,7 +28,6 @@ jobs:
       - uses: hecrj/setup-rust-action@v1
         with:
           components: clippy
-          rust-version: ${{ matrix.rust }}
       - name: Cache cargo directories
         uses: actions/cache@v2
         with:
@@ -80,7 +74,6 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - stable
           - "1.70"
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,12 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "0 0 * * 1"
 
 jobs:
   rustfmt:
     name: Check rustfmt
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -19,10 +18,11 @@ jobs:
   clippy:
     name: Run linter
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
 
     strategy:
       matrix:
-        rust: ["1.64"]
+        rust: ["1.70"]
 
     env:
       RUSTFLAGS: -D warnings
@@ -81,7 +81,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - "1.64"
+          - "1.70"
         os:
           - ubuntu-latest
           - macos-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
     "imgui-examples",
     "xtask",
 ]
+
+package.rust-version = "1.70"
+resolver = "2"

--- a/imgui-examples/Cargo.toml
+++ b/imgui-examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui-examples"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 description = "imgui crate examples using Glium backend"
 homepage = "https://github.com/imgui-rs/imgui-rs"
 repository = "https://github.com/imgui-rs/imgui-rs"

--- a/imgui-glium-renderer/Cargo.toml
+++ b/imgui-glium-renderer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui-glium-renderer"
 version = "0.11.0"
-edition = "2018"
+edition = "2021"
 description = "Glium renderer for the imgui crate"
 homepage = "https://github.com/imgui-rs/imgui-rs"
 repository = "https://github.com/imgui-rs/imgui-rs"

--- a/imgui-glow-renderer/Cargo.toml
+++ b/imgui-glow-renderer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui-glow-renderer"
 version = "0.11.0"
-edition = "2018"
+edition = "2021"
 description = "glow renderer for the imgui crate"
 homepage = "https://github.com/imgui-rs/imgui-rs"
 repository = "https://github.com/imgui-rs/imgui-rs"

--- a/imgui-sdl2-support/Cargo.toml
+++ b/imgui-sdl2-support/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui-sdl2-support"
 version = "0.11.0"
-edition = "2018"
+edition = "2021"
 authors = ["The imgui-rs Developers"]
 description = "sdl2 support code for the imgui crate"
 homepage = "https://github.com/imgui-rs/imgui-rs"

--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui-sys"
 version = "0.11.0"
-edition = "2018"
+edition = "2021"
 description = "Raw FFI bindings to dear imgui"
 homepage = "https://github.com/imgui-rs/imgui-rs"
 repository = "https://github.com/imgui-rs/imgui-rs"

--- a/imgui-winit-support/Cargo.toml
+++ b/imgui-winit-support/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui-winit-support"
 version = "0.11.0"
-edition = "2018"
+edition = "2021"
 description = "winit support code for the imgui crate"
 homepage = "https://github.com/imgui-rs/imgui-rs"
 repository = "https://github.com/imgui-rs/imgui-rs"

--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui"
 version = "0.11.0"
-edition = "2018"
+edition = "2021"
 description = "High-level Rust bindings to dear imgui"
 homepage = "https://github.com/imgui-rs/imgui-rs"
 repository = "https://github.com/imgui-rs/imgui-rs"

--- a/imgui/src/render/draw_data.rs
+++ b/imgui/src/render/draw_data.rs
@@ -52,7 +52,6 @@ impl DrawData {
     /// Returns the number of draw lists included in the draw data.
     #[inline]
     pub fn draw_lists_count(&self) -> usize {
-        use std::convert::TryInto;
         self.cmd_lists_count.try_into().unwrap()
     }
     #[inline]


### PR DESCRIPTION
- this PR adds a formal MSRV to the repo (there's no reason we shouldn't use one)
- bumps that MSRV to 1.70
- moves rustfmt's check to run only on `main`
- reduces clippy to only run on stable rust, not on MSRV AND makes it only run on `main`
- reduces testing to ONLY the MSRV because of Rusts forwards compatibility concerns
- moves all crates to edition 2021
- moves us to formally use `resolver = 2` in the workspace setting
