### PR TITLE
Ability to fetch current frame.

### DIFF
--- a/imgui/src/context.rs
+++ b/imgui/src/context.rs
@@ -114,6 +114,12 @@ impl Context {
         clear_current_context();
         SuspendedContext(self)
     }
+    /// Sets current global imgui context, i.e. in a dynamically linked library.
+    pub fn set_current_context(&self) {
+        unsafe {
+            sys::igSetCurrentContext(self.raw);
+        }
+    }
     /// Returns the path to the ini file, or None if not set
     pub fn ini_filename(&self) -> Option<PathBuf> {
         let io = self.io();
@@ -536,6 +542,10 @@ impl Context {
     /// [`new_frame`]: Self::new_frame
     pub fn frame(&mut self) -> &mut Ui {
         self.new_frame()
+    }
+
+    pub fn current_frame(&mut self) -> &mut Ui {
+        &mut self.ui
     }
 
     /// Starts a new frame and returns an `Ui` instance for constructing a user interface.


### PR DESCRIPTION
Maybe i am missing something but i could not find a workaround for this without a method that looks something like this. 
Example use-case: While using bevy engine's ECS model and storing the imgui Context as a non-sendable resource in ECS's world i am completely unable to construct imgui's UI from different systems since only one scope can own mutable reference to the current frame's Ui. This method allows me to store imgui's context as a resource and retreive current frame on demand.

Also i found set_current_context useful for when i need to call imgui functions from a shared library (something to do with shared libraries having its own static memory for imgui context pointer). [Explanation here](https://github.com/ocornut/imgui/blob/master/imgui.cpp#L1130)