### PR TITLE
fix: use correct alpha blending function

### DIFF
--- a/imgui-glium-renderer/src/lib.rs
+++ b/imgui-glium-renderer/src/lib.rs
@@ -9,8 +9,8 @@ use glium::uniforms::{
     MagnifySamplerFilter, MinifySamplerFilter, Sampler, SamplerBehavior, SamplerWrapFunction,
 };
 use glium::{
-    program, uniform, vertex, Blend, DrawError, DrawParameters, IndexBuffer, Program, Rect,
-    Surface, Texture2d, VertexBuffer,
+    program, uniform, vertex, Blend, BlendingFunction, DrawError, DrawParameters, IndexBuffer,
+    LinearBlendingFactor, Program, Rect, Surface, Texture2d, VertexBuffer,
 };
 use imgui::internal::RawWrapper;
 use imgui::{BackendFlags, DrawCmd, DrawCmdParams, DrawData, TextureId, Textures};
@@ -253,7 +253,13 @@ impl Renderer {
                                     tex: Sampler(texture.texture.as_ref(), texture.sampler)
                                 },
                                 &DrawParameters {
-                                    blend: Blend::alpha_blending(),
+                                    blend: Blend {
+                                        alpha: BlendingFunction::Addition {
+                                            source: LinearBlendingFactor::One,
+                                            destination: LinearBlendingFactor::OneMinusSourceAlpha,
+                                        },
+                                        ..Blend::alpha_blending()
+                                    },
                                     scissor: Some(Rect {
                                         left: f32::max(0.0, clip_rect[0]).floor() as u32,
                                         bottom: f32::max(0.0, fb_height - clip_rect[3]).floor()


### PR DESCRIPTION
Fixes #733

## About this PR

This PR changes the default alpha blending function just as described by @Lateasusual in #733.

I'm unsure of why this hasn't been done yet, but there appears to be a consensus on the mentioned issue that this is the way to go.