### PR TITLE
Remove noisy key event debug print

### DIFF
--- a/imgui-winit-support/src/lib.rs
+++ b/imgui-winit-support/src/lib.rs
@@ -408,20 +408,6 @@ impl WinitPlatform {
             } if window_id == window.id() => {
                 self.handle_window_event(io, window, event);
             }
-            // Track key release events outside our window. If we don't do this,
-            // we might never see the release event if some other window gets focus.
-            // Event::DeviceEvent {
-            //     event:
-            //         DeviceEvent::Key(RawKeyEvent {
-            //             physical_key,
-            //             state: ElementState::Released,
-            //         }),
-            //     ..
-            // } => {
-            //     if let Some(key) = to_imgui_key(key) {
-            //         io.add_key_event(key, false);
-            //     }
-            // }
             _ => (),
         }
     }
@@ -482,8 +468,6 @@ impl WinitPlatform {
                 // specific key. Same applies to other modifiers.
                 // https://github.com/ocornut/imgui/issues/5047
                 handle_key_modifier(io, &key, pressed);
-
-                println!("KEY EVENT: {event:?}");
 
                 // Add main key event
                 if let Some(key) = to_imgui_key(key, event.location) {


### PR DESCRIPTION
When #754 was merged it left a debug print in `imgui-winit-support` by accident, which produces a lot of noise. My guess is it was used to test that key events are received when the window focus changes. Either way it should be removed.