### PR TITLE
Removed glium cargo patch, updated glium to 0.34.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,3 @@ members = [
 
 package.rust-version = "1.70"
 resolver = "2"
-
-[patch.crates-io]
-glium = { git="https://github.com/glium/glium" }

--- a/imgui-examples/Cargo.toml
+++ b/imgui-examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dev-dependencies]
 copypasta = "0.8"
-glium = { version = "0.33.0", default-features = true }
+glium = { version = "0.34.0", default-features = true }
 image = "0.23"
 imgui = { path = "../imgui", features = ["tables-api"] }
 imgui-glium-renderer = { path = "../imgui-glium-renderer" }

--- a/imgui-glium-renderer/Cargo.toml
+++ b/imgui-glium-renderer/Cargo.toml
@@ -10,11 +10,11 @@ license = "MIT OR Apache-2.0"
 categories = ["gui", "rendering"]
 
 [dependencies]
-glium = { version = "0.33.0", default-features = false }
+glium = { version = "0.34.0", default-features = false }
 imgui = { version = "0.11.0", path = "../imgui" }
 
 [dev-dependencies]
-glium = { version = "0.33.0", default-features = false, features = ["glutin_backend"] }
+glium = { version = "0.34.0", default-features = false, features = ["glutin_backend"] }
 imgui-winit-support = {path = "../imgui-winit-support"}
 glutin = "0.31.1"
 glutin-winit = "0.4.2"


### PR DESCRIPTION
This should fix the problems introduced through #754.
The tests and examples should now compile fine.
Fixes #759.