### PR TITLE
Better example framework

### DIFF
--- a/imgui-examples/examples/collapsing_header.rs
+++ b/imgui-examples/examples/collapsing_header.rs
@@ -6,8 +6,7 @@ fn main() {
     let mut state = State {
         render_closable: true,
     };
-    let system = support::init(file!());
-    system.main_loop(move |run, ui| {
+    support::simple_init(file!(), move |run, ui| {
         let w = ui
             .window("Collapsing header")
             .opened(run)

--- a/imgui-examples/examples/color_button.rs
+++ b/imgui-examples/examples/color_button.rs
@@ -4,8 +4,7 @@ mod support;
 
 fn main() {
     let mut state = State::default();
-    let system = support::init(file!());
-    system.main_loop(move |run, ui| {
+    support::simple_init(file!(), move |run, ui| {
         example_selector(run, ui, &mut state);
         match state.example {
             1 => example_1(ui, &mut state),

--- a/imgui-examples/examples/creating_windows.rs
+++ b/imgui-examples/examples/creating_windows.rs
@@ -1,9 +1,7 @@
 mod support;
 
 fn main() {
-    let system = support::init(file!());
-
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         // If we don't explicitly create a window before creating some kind of widget, then Dear Imgui will automatically create one
         ui.text("This text will appear in a default window titled 'Debug'");
 

--- a/imgui-examples/examples/custom_textures.rs
+++ b/imgui-examples/examples/custom_textures.rs
@@ -217,7 +217,8 @@ impl Lenna {
 fn main() {
     let mut my_app = CustomTexturesApp::default();
 
-    let mut system = support::init(file!());
+    let mut system = support::simple_init(file!());
+
     my_app
         .register_textures(system.display.get_context(), system.renderer.textures())
         .expect("Failed to register textures");

--- a/imgui-examples/examples/custom_textures.rs
+++ b/imgui-examples/examples/custom_textures.rs
@@ -215,12 +215,19 @@ impl Lenna {
 }
 
 fn main() {
-    let mut my_app = CustomTexturesApp::default();
+    let my_app = std::rc::Rc::new(std::cell::RefCell::new(CustomTexturesApp::default()));
+    let app_clone = my_app.clone();
 
-    let mut system = support::simple_init(file!());
-
-    my_app
-        .register_textures(system.display.get_context(), system.renderer.textures())
-        .expect("Failed to register textures");
-    system.main_loop(move |_, ui| my_app.show_textures(ui));
+    support::init_with_startup(
+        file!(),
+        move |_ctx, renderer, display| {
+            app_clone
+                .borrow_mut()
+                .register_textures(display.get_context(), renderer.textures())
+                .expect("Failed to register textures");
+        },
+        move |_, ui| {
+            my_app.borrow_mut().show_textures(ui);
+        },
+    );
 }

--- a/imgui-examples/examples/disablement.rs
+++ b/imgui-examples/examples/disablement.rs
@@ -5,14 +5,11 @@ use imgui::*;
 mod support;
 
 fn main() {
-    let system = support::init(file!());
-
     let mut edit_mode = true;
     let mut safe_mode = true;
 
     let mut click_count = 0;
-
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         ui.window("Disabling widgets")
             .size([300.0, 200.0], Condition::FirstUseEver)
             .build(|| {

--- a/imgui-examples/examples/draw_list.rs
+++ b/imgui-examples/examples/draw_list.rs
@@ -17,8 +17,7 @@ fn draw_text_centered(
 }
 
 fn main() {
-    let system = support::init(file!());
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         // Get access to draw FG and BG draw lists.
         let bg_draw_list = ui.get_background_draw_list();
         let fg_draw_list = ui.get_foreground_draw_list();

--- a/imgui-examples/examples/empty.rs
+++ b/imgui-examples/examples/empty.rs
@@ -1,9 +1,7 @@
 mod support;
 
 fn main() {
-    let system = support::init(file!());
-
-    system.main_loop(move |_, _ui| {
+    support::simple_init(file!(), move |_, _ui| {
         // nothing! don't actually do any imgui funtimes
     });
 }

--- a/imgui-examples/examples/hello_world.rs
+++ b/imgui-examples/examples/hello_world.rs
@@ -3,12 +3,9 @@ use imgui::*;
 mod support;
 
 fn main() {
-    let system = support::init(file!());
-
     let mut value = 0;
     let choices = ["test test this is 1", "test test this is 2"];
-
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         ui.window("Hello world")
             .size([300.0, 110.0], Condition::FirstUseEver)
             .build(|| {

--- a/imgui-examples/examples/id_wrangling.rs
+++ b/imgui-examples/examples/id_wrangling.rs
@@ -1,8 +1,7 @@
 mod support;
 
 fn main() {
-    let system = support::init(file!());
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         let items = vec!["a", "b", "c", "d"];
 
         ui.window("Broken Example")

--- a/imgui-examples/examples/keyboard.rs
+++ b/imgui-examples/examples/keyboard.rs
@@ -3,7 +3,6 @@ use imgui::*;
 mod support;
 
 fn main() {
-    let system = support::init(file!());
     let mut press_counter = 0u32;
     let mut press_no_repeat_counter = 0u32;
     let mut release_counter = 0u32;
@@ -13,7 +12,7 @@ fn main() {
     let mut f1_release_count = 0u32;
     let mut text_buffer = String::new();
 
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         ui.window("Means of accessing key state")
             .size([500.0, 300.0], Condition::FirstUseEver)
             .build(|| {

--- a/imgui-examples/examples/long_list.rs
+++ b/imgui-examples/examples/long_list.rs
@@ -13,8 +13,7 @@ mod support;
 fn main() {
     let lots_of_words: Vec<String> = (0..10000).map(|x| format!("Line {}", x)).collect();
 
-    let system = support::init(file!());
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         // Show the C++ style API
         ui.window("Hello long world")
             .size([100.0, 500.0], Condition::FirstUseEver)

--- a/imgui-examples/examples/long_table.rs
+++ b/imgui-examples/examples/long_table.rs
@@ -3,9 +3,7 @@ use imgui::*;
 mod support;
 
 fn main() {
-    let system = support::init(file!());
-
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         ui.show_demo_window(&mut true);
 
         ui.window("Table with list clipper")

--- a/imgui-examples/examples/multiple_fonts.rs
+++ b/imgui-examples/examples/multiple_fonts.rs
@@ -3,7 +3,7 @@ use imgui::*;
 mod support;
 
 fn main() {
-    let mut system = support::init(file!());
+    let mut system = support::simple_init(file!());
     let dokdo = system.imgui.fonts().add_font(&[FontSource::TtfData {
         data: include_bytes!("../../resources/Dokdo-Regular.ttf"),
         size_pixels: system.font_size,

--- a/imgui-examples/examples/multiple_fonts.rs
+++ b/imgui-examples/examples/multiple_fonts.rs
@@ -2,33 +2,57 @@ use imgui::*;
 
 mod support;
 
+/// NOTE on this example:
+/// Most of this complexity is because of how we initialize our support
+/// (which primarily is a result of `winit`'s requirements for making a window).
+/// In reality, most of these two functions can be made directly after each other --
+/// to run the initialization code (which loads a font), all you need is imgui + a renderer.
 fn main() {
-    let mut system = support::simple_init(file!());
-    let dokdo = system.imgui.fonts().add_font(&[FontSource::TtfData {
-        data: include_bytes!("../../resources/Dokdo-Regular.ttf"),
-        size_pixels: system.font_size,
-        config: None,
-    }]);
-    let roboto = system.imgui.fonts().add_font(&[FontSource::TtfData {
-        data: include_bytes!("../../resources/Roboto-Regular.ttf"),
-        size_pixels: system.font_size,
-        config: None,
-    }]);
-    system
-        .renderer
-        .reload_font_texture(&mut system.imgui)
-        .expect("Failed to reload fonts");
-    system.main_loop(move |run, ui| {
-        ui.window("Hello world").opened(run).build(|| {
-            ui.text("Hello, I'm the default font!");
-            let _roboto = ui.push_font(roboto);
-            ui.text("Hello, I'm Roboto Regular!");
-            let _dokdo = ui.push_font(dokdo);
-            ui.text("Hello, I'm Dokdo Regular!");
-            _dokdo.pop();
-            ui.text("Hello, I'm Roboto Regular again!");
-            _roboto.pop();
-            ui.text("Hello, I'm the default font again!");
-        });
-    });
+    let dokdo = std::rc::Rc::new(std::cell::RefCell::new(None));
+    let roboto = std::rc::Rc::new(std::cell::RefCell::new(None));
+
+    let dokdo_init = dokdo.clone();
+    let roboto_init = roboto.clone();
+
+    support::init_with_startup(
+        file!(),
+        move |ctx, renderer, _| {
+            let mut dokdo_handle = dokdo_init.borrow_mut();
+            let mut roboto_handle = roboto_init.borrow_mut();
+
+            // this function runs right after the window is created.
+            // In your own code, this can be done whenever you have a renderer
+            // and a context.
+            *dokdo_handle = Some(ctx.fonts().add_font(&[FontSource::TtfData {
+                data: include_bytes!("../../resources/Dokdo-Regular.ttf"),
+                size_pixels: support::FONT_SIZE,
+                config: None,
+            }]));
+            *roboto_handle = Some(ctx.fonts().add_font(&[FontSource::TtfData {
+                data: include_bytes!("../../resources/Roboto-Regular.ttf"),
+                size_pixels: support::FONT_SIZE,
+                config: None,
+            }]));
+
+            renderer
+                .reload_font_texture(ctx)
+                .expect("Failed to reload fonts");
+        },
+        move |run, ui| {
+            let dokdo = dokdo.borrow().unwrap();
+            let roboto = roboto.borrow().unwrap();
+
+            ui.window("Hello world").opened(run).build(|| {
+                ui.text("Hello, I'm the default font!");
+                let _roboto = ui.push_font(roboto);
+                ui.text("Hello, I'm Roboto Regular!");
+                let _dokdo = ui.push_font(dokdo);
+                ui.text("Hello, I'm Dokdo Regular!");
+                _dokdo.pop();
+                ui.text("Hello, I'm Roboto Regular again!");
+                _roboto.pop();
+                ui.text("Hello, I'm the default font again!");
+            });
+        },
+    );
 }

--- a/imgui-examples/examples/progress_bar.rs
+++ b/imgui-examples/examples/progress_bar.rs
@@ -3,8 +3,7 @@ use imgui::*;
 mod support;
 
 fn main() {
-    let system = support::init(file!());
-    system.main_loop(move |run, ui| {
+    support::simple_init(file!(), move |run, ui| {
         let w = ui
             .window("Progress bar")
             .opened(run)

--- a/imgui-examples/examples/radio_button.rs
+++ b/imgui-examples/examples/radio_button.rs
@@ -4,8 +4,7 @@ mod support;
 
 fn main() {
     let mut state = State::default();
-    let system = support::init(file!());
-    system.main_loop(move |run, ui| {
+    support::simple_init(file!(), move |run, ui| {
         example_selector(run, ui, &mut state);
         match state.example {
             1 => example_1(ui, &mut state),

--- a/imgui-examples/examples/slider.rs
+++ b/imgui-examples/examples/slider.rs
@@ -4,8 +4,7 @@ mod support;
 
 fn main() {
     let mut state = State::default();
-    let system = support::init(file!());
-    system.main_loop(move |run, ui| {
+    support::simple_init(file!(), move |run, ui| {
         example_selector(run, ui, &mut state);
         match state.example {
             1 => example_1(ui, &mut state),

--- a/imgui-examples/examples/support/mod.rs
+++ b/imgui-examples/examples/support/mod.rs
@@ -12,17 +12,9 @@ use std::time::Instant;
 
 mod clipboard;
 
-pub struct System {
-    pub event_loop: EventLoop<()>,
-    pub window: Window,
-    pub display: glium::Display<WindowSurface>,
-    pub imgui: Context,
-    pub platform: WinitPlatform,
-    pub renderer: Renderer,
-    pub font_size: f32,
-}
+pub fn simple_init<F: FnMut(&mut bool, &mut Ui) + 'static>(title: &str, mut run_ui: F) {
+    let mut imgui = create_context();
 
-pub fn init(title: &str) -> System {
     let title = match Path::new(&title).file_name() {
         Some(file_name) => file_name.to_str().unwrap(),
         None => title,
@@ -35,9 +27,7 @@ pub fn init(title: &str) -> System {
     let (window, display) = glium::backend::glutin::SimpleWindowBuilder::new()
         .set_window_builder(builder)
         .build(&event_loop);
-
-    let mut imgui = Context::create();
-    imgui.set_ini_filename(None);
+    let mut renderer = Renderer::init(&mut imgui, &display).expect("Failed to initialize renderer");
 
     if let Some(backend) = clipboard::init() {
         imgui.set_clipboard_backend(backend);
@@ -60,13 +50,71 @@ pub fn init(title: &str) -> System {
         platform.attach_window(imgui.io_mut(), &window, dpi_mode);
     }
 
+    let mut last_frame = Instant::now();
+
+    event_loop
+        .run(move |event, window_target| match event {
+            Event::NewEvents(_) => {
+                let now = Instant::now();
+                imgui.io_mut().update_delta_time(now - last_frame);
+                last_frame = now;
+            }
+            Event::AboutToWait => {
+                platform
+                    .prepare_frame(imgui.io_mut(), &window)
+                    .expect("Failed to prepare frame");
+                window.request_redraw();
+            }
+            Event::WindowEvent {
+                event: WindowEvent::RedrawRequested,
+                ..
+            } => {
+                let ui = imgui.frame();
+
+                let mut run = true;
+                run_ui(&mut run, ui);
+                if !run {
+                    window_target.exit();
+                }
+
+                let mut target = display.draw();
+                target.clear_color_srgb(1.0, 1.0, 1.0, 1.0);
+                platform.prepare_render(ui, &window);
+                let draw_data = imgui.render();
+                renderer
+                    .render(&mut target, draw_data)
+                    .expect("Rendering failed");
+                target.finish().expect("Failed to swap buffers");
+            }
+            Event::WindowEvent {
+                event: WindowEvent::Resized(new_size),
+                ..
+            } => {
+                if new_size.width > 0 && new_size.height > 0 {
+                    display.resize((new_size.width, new_size.height));
+                }
+                platform.handle_event(imgui.io_mut(), &window, &event);
+            }
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => window_target.exit(),
+            event => {
+                platform.handle_event(imgui.io_mut(), &window, &event);
+            }
+        })
+        .expect("EventLoop error");
+}
+
+/// Creates the imgui context
+pub fn create_context() -> imgui::Context {
+    let mut imgui = Context::create();
     // Fixed font size. Note imgui_winit_support uses "logical
     // pixels", which are physical pixels scaled by the devices
     // scaling factor. Meaning, 13.0 pixels should look the same size
     // on two different screens, and thus we do not need to scale this
     // value (as the scaling is handled by winit)
     let font_size = 13.0;
-
     imgui.fonts().add_font(&[
         FontSource::TtfData {
             data: include_bytes!("../../../resources/Roboto-Regular.ttf"),
@@ -98,84 +146,16 @@ pub fn init(title: &str) -> System {
             }),
         },
     ]);
+    imgui.set_ini_filename(None);
 
-    let renderer = Renderer::init(&mut imgui, &display).expect("Failed to initialize renderer");
-
-    System {
-        event_loop,
-        window,
-        display,
-        imgui,
-        platform,
-        renderer,
-        font_size,
-    }
+    imgui
 }
 
-impl System {
-    pub fn main_loop<F: FnMut(&mut bool, &mut Ui) + 'static>(self, mut run_ui: F) {
-        let System {
-            event_loop,
-            window,
-            display,
-            mut imgui,
-            mut platform,
-            mut renderer,
-            ..
-        } = self;
-        let mut last_frame = Instant::now();
-
-        event_loop
-            .run(move |event, window_target| match event {
-                Event::NewEvents(_) => {
-                    let now = Instant::now();
-                    imgui.io_mut().update_delta_time(now - last_frame);
-                    last_frame = now;
-                }
-                Event::AboutToWait => {
-                    platform
-                        .prepare_frame(imgui.io_mut(), &window)
-                        .expect("Failed to prepare frame");
-                    window.request_redraw();
-                }
-                Event::WindowEvent {
-                    event: WindowEvent::RedrawRequested,
-                    ..
-                } => {
-                    let ui = imgui.frame();
-
-                    let mut run = true;
-                    run_ui(&mut run, ui);
-                    if !run {
-                        window_target.exit();
-                    }
-
-                    let mut target = display.draw();
-                    target.clear_color_srgb(1.0, 1.0, 1.0, 1.0);
-                    platform.prepare_render(ui, &window);
-                    let draw_data = imgui.render();
-                    renderer
-                        .render(&mut target, draw_data)
-                        .expect("Rendering failed");
-                    target.finish().expect("Failed to swap buffers");
-                }
-                Event::WindowEvent {
-                    event: WindowEvent::Resized(new_size),
-                    ..
-                } => {
-                    if new_size.width > 0 && new_size.height > 0 {
-                        display.resize((new_size.width, new_size.height));
-                    }
-                    platform.handle_event(imgui.io_mut(), &window, &event);
-                }
-                Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
-                    ..
-                } => window_target.exit(),
-                event => {
-                    platform.handle_event(imgui.io_mut(), &window, &event);
-                }
-            })
-            .expect("EventLoop error");
-    }
+/// Initialize the example with imgui and the renderer
+pub fn init_with<F: FnMut(&mut bool, &mut Ui) + 'static>(
+    title: &str,
+    mut imgui: imgui::Context,
+    mut renderer: Renderer,
+    mut run_ui: F,
+) {
 }

--- a/imgui-examples/examples/tables_api.rs
+++ b/imgui-examples/examples/tables_api.rs
@@ -3,8 +3,6 @@ use imgui::*;
 mod support;
 
 fn main() {
-    let system = support::init(file!());
-
     let mut humans = vec![
         HumanData {
             name: "Joonas",
@@ -28,7 +26,7 @@ fn main() {
         | TableFlags::RESIZABLE
         | TableFlags::NO_BORDERS_IN_BODY;
 
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         ui.window("Input text callbacks")
             .size([800.0, 400.0], Condition::FirstUseEver)
             .build(|| {

--- a/imgui-examples/examples/test_drawing_channels_split.rs
+++ b/imgui-examples/examples/test_drawing_channels_split.rs
@@ -4,8 +4,7 @@ const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
 const RED: [f32; 4] = [1.0, 0.0, 0.0, 1.0];
 
 fn main() {
-    let system = support::init(file!());
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         let draw_list = ui.get_window_draw_list();
         // Will draw channel 0 first, then channel 1, whatever the order of
         // the calls in the code.

--- a/imgui-examples/examples/test_window.rs
+++ b/imgui-examples/examples/test_window.rs
@@ -1,6 +1,5 @@
 mod support;
 
 fn main() {
-    let system = support::init(file!());
-    system.main_loop(move |run, ui| ui.show_demo_window(run));
+    support::simple_init(file!(), move |run, ui| ui.show_demo_window(run));
 }

--- a/imgui-examples/examples/test_window_impl.rs
+++ b/imgui-examples/examples/test_window_impl.rs
@@ -237,8 +237,9 @@ impl Default for CustomRenderingState {
 fn main() {
     let mut state = State::default();
 
-    let system = support::init(file!());
-    system.main_loop(move |run, ui| show_test_window(ui, &mut state, run));
+    support::simple_init(file!(), move |run, ui| {
+        show_test_window(ui, &mut state, run)
+    });
 }
 
 fn show_help_marker(ui: &Ui, desc: &str) {

--- a/imgui-examples/examples/text_callbacks.rs
+++ b/imgui-examples/examples/text_callbacks.rs
@@ -3,10 +3,8 @@ use imgui::*;
 mod support;
 
 fn main() {
-    let system = support::init(file!());
     let mut buffers = [String::default(), String::default(), String::default()];
-
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         ui.window("Input text callbacks")
             .size([500.0, 300.0], Condition::FirstUseEver)
             .build(|| {

--- a/imgui-examples/examples/text_input.rs
+++ b/imgui-examples/examples/text_input.rs
@@ -3,11 +3,10 @@ use imgui::*;
 mod support;
 
 fn main() {
-    let system = support::init(file!());
     let mut stable_str = String::new();
     let mut callback_str = String::new();
 
-    system.main_loop(move |_, ui| {
+    support::simple_init(file!(), move |_, ui| {
         if let Some(_window) = ui
             .window("Input text callbacks")
             .size([500.0, 300.0], Condition::FirstUseEver)

--- a/imgui-glium-renderer/Cargo.toml
+++ b/imgui-glium-renderer/Cargo.toml
@@ -16,7 +16,7 @@ imgui = { version = "0.12.0", path = "../imgui" }
 [dev-dependencies]
 glium = { version = "0.34.0", default-features = false, features = ["glutin_backend"] }
 imgui-winit-support = {path = "../imgui-winit-support"}
-glutin = "0.31.1"
+glutin = "0.31"
 glutin-winit = "0.4.2"
 winit = { version = "0.29.3", features = ["rwh_05"] }
 raw-window-handle = "0.5.0"


### PR DESCRIPTION
This is a better framework for making examples, eliminating a struct and moving towards pure callbacks.

A notable negative effect of this is that two examples which were more complicated (custom fonts and custom textures) now have a *much* uglier setup, involving refcells to pass data. I am very open to ways to simplify that, along with the core abstraction.

My plan is simple -- once we're done with this we'll be ready for this repository to upgrade to winit 0.30