### PR TITLE
Glow texture example vec capacity fix

### DIFF
--- a/imgui-glow-renderer/examples/glow_04_custom_textures.rs
+++ b/imgui-glow-renderer/examples/glow_04_custom_textures.rs
@@ -129,7 +129,7 @@ impl TexturesUi {
         const WIDTH: usize = 100;
         const HEIGHT: usize = 100;
 
-        let mut data = Vec::with_capacity(WIDTH * HEIGHT);
+        let mut data = Vec::with_capacity(WIDTH * HEIGHT * 3);
         for i in 0..WIDTH {
             for j in 0..HEIGHT {
                 // Insert RGB values


### PR DESCRIPTION
Small thing I noticed going through the example code. This vec should be initialized with capacity for 3 bytes per pixel instead of 1.