### PR TITLE
Return the dockspace ID from `dockspace_over_main_viewport`

### DIFF
--- a/imgui/src/dock_space.rs
+++ b/imgui/src/dock_space.rs
@@ -3,14 +3,14 @@ use std::ptr::null;
 use crate::Ui;
 
 impl Ui {
-    pub fn dockspace_over_main_viewport(&self) {
+    pub fn dockspace_over_main_viewport(&self) -> imgui_sys::ImGuiID {
         unsafe {
             sys::igDockSpaceOverViewport(
                 0,
                 sys::igGetMainViewport(),
                 sys::ImGuiDockNodeFlags_PassthruCentralNode as i32,
                 null(),
-            );
+            )
         }
     }
 }


### PR DESCRIPTION
When creating a dockspace over a main viewport, you need the resulting id in order to use the `DockManager*` APIs (for instance to programmatically layout a bunch of windows).