### PR TITLE
Fix broken reference in README.markdown

### DIFF
--- a/imgui/Cargo.toml
+++ b/imgui/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/imgui-rs/imgui-rs"
 documentation = "https://docs.rs/imgui"
 license = "MIT OR Apache-2.0"
 categories = ["gui", "api-bindings"]
-readme = "../README.markdown"
+readme = "../README.md"
 
 exclude = ["/resources"]
 
@@ -34,4 +34,3 @@ tables-api = []
 approx = "0.5.1"
 memoffset = "0.9"
 pretty_assertions = "1.4.1"
-

--- a/imgui/README.markdown
+++ b/imgui/README.markdown
@@ -1,1 +1,0 @@
-../README.markdown

--- a/imgui/README.md
+++ b/imgui/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
The main readme file was renamed from `README.markdown` to `README.md` so the symbolic link and `imgui/Cargo.toml` were outdated, just a small PR to fix it.