### PR TITLE
Change return type of `column_user_id` to `Id`

### DIFF
--- a/imgui/src/tables.rs
+++ b/imgui/src/tables.rs
@@ -848,8 +848,8 @@ impl<'a> Specs<'a> {
 pub struct TableColumnSortSpecs<'a>(&'a sys::ImGuiTableColumnSortSpecs);
 impl<'a> TableColumnSortSpecs<'a> {
     /// User id of the column (if specified by a TableSetupColumn() call)
-    pub fn column_user_id(&self) -> sys::ImGuiID {
-        self.0.ColumnUserID
+    pub fn column_user_id(&self) -> Id {
+        Id(self.0.ColumnUserID)
     }
 
     /// Index of the column


### PR DESCRIPTION
This matches the type of `TableColumnSetup.user_id`