### PR TITLE
delete use of the `chlorine` crate

### DIFF
--- a/imgui-sys/Cargo.toml
+++ b/imgui-sys/Cargo.toml
@@ -26,7 +26,6 @@ exclude = [
 ]
 
 [dependencies]
-chlorine = "1.0.7"
 mint = "0.5.6"
 cfg-if = "1"
 

--- a/imgui-sys/src/bindings.rs
+++ b/imgui-sys/src/bindings.rs
@@ -97,64 +97,64 @@ pub struct ImFontBuilderIO {
 pub struct ImGuiContext {
     _unused: [u8; 0],
 }
-pub type ImGuiID = cty::c_uint;
-pub type ImS8 = cty::c_schar;
-pub type ImU8 = cty::c_uchar;
-pub type ImS16 = cty::c_short;
-pub type ImU16 = cty::c_ushort;
-pub type ImU32 = cty::c_uint;
-pub type ImS64 = cty::c_longlong;
-pub type ImGuiCol = cty::c_int;
-pub type ImGuiCond = cty::c_int;
-pub type ImGuiDataType = cty::c_int;
-pub type ImGuiMouseButton = cty::c_int;
-pub type ImGuiMouseCursor = cty::c_int;
-pub type ImGuiStyleVar = cty::c_int;
-pub type ImGuiTableBgTarget = cty::c_int;
-pub type ImDrawFlags = cty::c_int;
-pub type ImDrawListFlags = cty::c_int;
-pub type ImFontAtlasFlags = cty::c_int;
-pub type ImGuiBackendFlags = cty::c_int;
-pub type ImGuiButtonFlags = cty::c_int;
-pub type ImGuiChildFlags = cty::c_int;
-pub type ImGuiColorEditFlags = cty::c_int;
-pub type ImGuiConfigFlags = cty::c_int;
-pub type ImGuiComboFlags = cty::c_int;
-pub type ImGuiDragDropFlags = cty::c_int;
-pub type ImGuiFocusedFlags = cty::c_int;
-pub type ImGuiHoveredFlags = cty::c_int;
-pub type ImGuiInputFlags = cty::c_int;
-pub type ImGuiInputTextFlags = cty::c_int;
-pub type ImGuiItemFlags = cty::c_int;
-pub type ImGuiKeyChord = cty::c_int;
-pub type ImGuiPopupFlags = cty::c_int;
-pub type ImGuiMultiSelectFlags = cty::c_int;
-pub type ImGuiSelectableFlags = cty::c_int;
-pub type ImGuiSliderFlags = cty::c_int;
-pub type ImGuiTabBarFlags = cty::c_int;
-pub type ImGuiTabItemFlags = cty::c_int;
-pub type ImGuiTableFlags = cty::c_int;
-pub type ImGuiTableColumnFlags = cty::c_int;
-pub type ImGuiTableRowFlags = cty::c_int;
-pub type ImGuiTreeNodeFlags = cty::c_int;
-pub type ImGuiViewportFlags = cty::c_int;
-pub type ImGuiWindowFlags = cty::c_int;
-pub type ImTextureID = *mut cty::c_void;
-pub type ImDrawIdx = cty::c_ushort;
-pub type ImWchar32 = cty::c_uint;
-pub type ImWchar16 = cty::c_ushort;
+pub type ImGuiID = core::ffi::c_uint;
+pub type ImS8 = core::ffi::c_schar;
+pub type ImU8 = core::ffi::c_uchar;
+pub type ImS16 = core::ffi::c_short;
+pub type ImU16 = core::ffi::c_ushort;
+pub type ImU32 = core::ffi::c_uint;
+pub type ImS64 = core::ffi::c_longlong;
+pub type ImGuiCol = core::ffi::c_int;
+pub type ImGuiCond = core::ffi::c_int;
+pub type ImGuiDataType = core::ffi::c_int;
+pub type ImGuiMouseButton = core::ffi::c_int;
+pub type ImGuiMouseCursor = core::ffi::c_int;
+pub type ImGuiStyleVar = core::ffi::c_int;
+pub type ImGuiTableBgTarget = core::ffi::c_int;
+pub type ImDrawFlags = core::ffi::c_int;
+pub type ImDrawListFlags = core::ffi::c_int;
+pub type ImFontAtlasFlags = core::ffi::c_int;
+pub type ImGuiBackendFlags = core::ffi::c_int;
+pub type ImGuiButtonFlags = core::ffi::c_int;
+pub type ImGuiChildFlags = core::ffi::c_int;
+pub type ImGuiColorEditFlags = core::ffi::c_int;
+pub type ImGuiConfigFlags = core::ffi::c_int;
+pub type ImGuiComboFlags = core::ffi::c_int;
+pub type ImGuiDragDropFlags = core::ffi::c_int;
+pub type ImGuiFocusedFlags = core::ffi::c_int;
+pub type ImGuiHoveredFlags = core::ffi::c_int;
+pub type ImGuiInputFlags = core::ffi::c_int;
+pub type ImGuiInputTextFlags = core::ffi::c_int;
+pub type ImGuiItemFlags = core::ffi::c_int;
+pub type ImGuiKeyChord = core::ffi::c_int;
+pub type ImGuiPopupFlags = core::ffi::c_int;
+pub type ImGuiMultiSelectFlags = core::ffi::c_int;
+pub type ImGuiSelectableFlags = core::ffi::c_int;
+pub type ImGuiSliderFlags = core::ffi::c_int;
+pub type ImGuiTabBarFlags = core::ffi::c_int;
+pub type ImGuiTabItemFlags = core::ffi::c_int;
+pub type ImGuiTableFlags = core::ffi::c_int;
+pub type ImGuiTableColumnFlags = core::ffi::c_int;
+pub type ImGuiTableRowFlags = core::ffi::c_int;
+pub type ImGuiTreeNodeFlags = core::ffi::c_int;
+pub type ImGuiViewportFlags = core::ffi::c_int;
+pub type ImGuiWindowFlags = core::ffi::c_int;
+pub type ImTextureID = *mut core::ffi::c_void;
+pub type ImDrawIdx = core::ffi::c_ushort;
+pub type ImWchar32 = core::ffi::c_uint;
+pub type ImWchar16 = core::ffi::c_ushort;
 pub type ImWchar = ImWchar32;
 pub type ImGuiSelectionUserData = ImS64;
 pub type ImGuiInputTextCallback = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> cty::c_int,
+    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> core::ffi::c_int,
 >;
 pub type ImGuiSizeCallback =
     ::core::option::Option<unsafe extern "C" fn(data: *mut ImGuiSizeCallbackData)>;
 pub type ImGuiMemAllocFunc = ::core::option::Option<
-    unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+    unsafe extern "C" fn(sz: usize, user_data: *mut core::ffi::c_void) -> *mut core::ffi::c_void,
 >;
 pub type ImGuiMemFreeFunc = ::core::option::Option<
-    unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+    unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -198,7 +198,7 @@ pub const ImGuiWindowFlags_Tooltip: ImGuiWindowFlags_ = 33554432;
 pub const ImGuiWindowFlags_Popup: ImGuiWindowFlags_ = 67108864;
 pub const ImGuiWindowFlags_Modal: ImGuiWindowFlags_ = 134217728;
 pub const ImGuiWindowFlags_ChildMenu: ImGuiWindowFlags_ = 268435456;
-pub type ImGuiWindowFlags_ = cty::c_uint;
+pub type ImGuiWindowFlags_ = core::ffi::c_uint;
 pub const ImGuiChildFlags_None: ImGuiChildFlags_ = 0;
 pub const ImGuiChildFlags_Borders: ImGuiChildFlags_ = 1;
 pub const ImGuiChildFlags_AlwaysUseWindowPadding: ImGuiChildFlags_ = 2;
@@ -209,7 +209,7 @@ pub const ImGuiChildFlags_AutoResizeY: ImGuiChildFlags_ = 32;
 pub const ImGuiChildFlags_AlwaysAutoResize: ImGuiChildFlags_ = 64;
 pub const ImGuiChildFlags_FrameStyle: ImGuiChildFlags_ = 128;
 pub const ImGuiChildFlags_NavFlattened: ImGuiChildFlags_ = 256;
-pub type ImGuiChildFlags_ = cty::c_uint;
+pub type ImGuiChildFlags_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_None: ImGuiItemFlags_ = 0;
 pub const ImGuiItemFlags_NoTabStop: ImGuiItemFlags_ = 1;
 pub const ImGuiItemFlags_NoNav: ImGuiItemFlags_ = 2;
@@ -217,7 +217,7 @@ pub const ImGuiItemFlags_NoNavDefaultFocus: ImGuiItemFlags_ = 4;
 pub const ImGuiItemFlags_ButtonRepeat: ImGuiItemFlags_ = 8;
 pub const ImGuiItemFlags_AutoClosePopups: ImGuiItemFlags_ = 16;
 pub const ImGuiItemFlags_AllowDuplicateId: ImGuiItemFlags_ = 32;
-pub type ImGuiItemFlags_ = cty::c_uint;
+pub type ImGuiItemFlags_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_None: ImGuiInputTextFlags_ = 0;
 pub const ImGuiInputTextFlags_CharsDecimal: ImGuiInputTextFlags_ = 1;
 pub const ImGuiInputTextFlags_CharsHexadecimal: ImGuiInputTextFlags_ = 2;
@@ -242,7 +242,7 @@ pub const ImGuiInputTextFlags_CallbackAlways: ImGuiInputTextFlags_ = 524288;
 pub const ImGuiInputTextFlags_CallbackCharFilter: ImGuiInputTextFlags_ = 1048576;
 pub const ImGuiInputTextFlags_CallbackResize: ImGuiInputTextFlags_ = 2097152;
 pub const ImGuiInputTextFlags_CallbackEdit: ImGuiInputTextFlags_ = 4194304;
-pub type ImGuiInputTextFlags_ = cty::c_uint;
+pub type ImGuiInputTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_None: ImGuiTreeNodeFlags_ = 0;
 pub const ImGuiTreeNodeFlags_Selected: ImGuiTreeNodeFlags_ = 1;
 pub const ImGuiTreeNodeFlags_Framed: ImGuiTreeNodeFlags_ = 2;
@@ -261,7 +261,7 @@ pub const ImGuiTreeNodeFlags_SpanTextWidth: ImGuiTreeNodeFlags_ = 8192;
 pub const ImGuiTreeNodeFlags_SpanAllColumns: ImGuiTreeNodeFlags_ = 16384;
 pub const ImGuiTreeNodeFlags_NavLeftJumpsBackHere: ImGuiTreeNodeFlags_ = 32768;
 pub const ImGuiTreeNodeFlags_CollapsingHeader: ImGuiTreeNodeFlags_ = 26;
-pub type ImGuiTreeNodeFlags_ = cty::c_uint;
+pub type ImGuiTreeNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiPopupFlags_None: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonLeft: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonRight: ImGuiPopupFlags_ = 1;
@@ -274,7 +274,7 @@ pub const ImGuiPopupFlags_NoOpenOverItems: ImGuiPopupFlags_ = 256;
 pub const ImGuiPopupFlags_AnyPopupId: ImGuiPopupFlags_ = 1024;
 pub const ImGuiPopupFlags_AnyPopupLevel: ImGuiPopupFlags_ = 2048;
 pub const ImGuiPopupFlags_AnyPopup: ImGuiPopupFlags_ = 3072;
-pub type ImGuiPopupFlags_ = cty::c_uint;
+pub type ImGuiPopupFlags_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_None: ImGuiSelectableFlags_ = 0;
 pub const ImGuiSelectableFlags_NoAutoClosePopups: ImGuiSelectableFlags_ = 1;
 pub const ImGuiSelectableFlags_SpanAllColumns: ImGuiSelectableFlags_ = 2;
@@ -282,7 +282,7 @@ pub const ImGuiSelectableFlags_AllowDoubleClick: ImGuiSelectableFlags_ = 4;
 pub const ImGuiSelectableFlags_Disabled: ImGuiSelectableFlags_ = 8;
 pub const ImGuiSelectableFlags_AllowOverlap: ImGuiSelectableFlags_ = 16;
 pub const ImGuiSelectableFlags_Highlight: ImGuiSelectableFlags_ = 32;
-pub type ImGuiSelectableFlags_ = cty::c_uint;
+pub type ImGuiSelectableFlags_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_None: ImGuiComboFlags_ = 0;
 pub const ImGuiComboFlags_PopupAlignLeft: ImGuiComboFlags_ = 1;
 pub const ImGuiComboFlags_HeightSmall: ImGuiComboFlags_ = 2;
@@ -293,7 +293,7 @@ pub const ImGuiComboFlags_NoArrowButton: ImGuiComboFlags_ = 32;
 pub const ImGuiComboFlags_NoPreview: ImGuiComboFlags_ = 64;
 pub const ImGuiComboFlags_WidthFitPreview: ImGuiComboFlags_ = 128;
 pub const ImGuiComboFlags_HeightMask_: ImGuiComboFlags_ = 30;
-pub type ImGuiComboFlags_ = cty::c_uint;
+pub type ImGuiComboFlags_ = core::ffi::c_uint;
 pub const ImGuiTabBarFlags_None: ImGuiTabBarFlags_ = 0;
 pub const ImGuiTabBarFlags_Reorderable: ImGuiTabBarFlags_ = 1;
 pub const ImGuiTabBarFlags_AutoSelectNewTabs: ImGuiTabBarFlags_ = 2;
@@ -306,7 +306,7 @@ pub const ImGuiTabBarFlags_FittingPolicyResizeDown: ImGuiTabBarFlags_ = 128;
 pub const ImGuiTabBarFlags_FittingPolicyScroll: ImGuiTabBarFlags_ = 256;
 pub const ImGuiTabBarFlags_FittingPolicyMask_: ImGuiTabBarFlags_ = 384;
 pub const ImGuiTabBarFlags_FittingPolicyDefault_: ImGuiTabBarFlags_ = 128;
-pub type ImGuiTabBarFlags_ = cty::c_uint;
+pub type ImGuiTabBarFlags_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_None: ImGuiTabItemFlags_ = 0;
 pub const ImGuiTabItemFlags_UnsavedDocument: ImGuiTabItemFlags_ = 1;
 pub const ImGuiTabItemFlags_SetSelected: ImGuiTabItemFlags_ = 2;
@@ -317,14 +317,14 @@ pub const ImGuiTabItemFlags_NoReorder: ImGuiTabItemFlags_ = 32;
 pub const ImGuiTabItemFlags_Leading: ImGuiTabItemFlags_ = 64;
 pub const ImGuiTabItemFlags_Trailing: ImGuiTabItemFlags_ = 128;
 pub const ImGuiTabItemFlags_NoAssumedClosure: ImGuiTabItemFlags_ = 256;
-pub type ImGuiTabItemFlags_ = cty::c_uint;
+pub type ImGuiTabItemFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusedFlags_None: ImGuiFocusedFlags_ = 0;
 pub const ImGuiFocusedFlags_ChildWindows: ImGuiFocusedFlags_ = 1;
 pub const ImGuiFocusedFlags_RootWindow: ImGuiFocusedFlags_ = 2;
 pub const ImGuiFocusedFlags_AnyWindow: ImGuiFocusedFlags_ = 4;
 pub const ImGuiFocusedFlags_NoPopupHierarchy: ImGuiFocusedFlags_ = 8;
 pub const ImGuiFocusedFlags_RootAndChildWindows: ImGuiFocusedFlags_ = 3;
-pub type ImGuiFocusedFlags_ = cty::c_uint;
+pub type ImGuiFocusedFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_None: ImGuiHoveredFlags_ = 0;
 pub const ImGuiHoveredFlags_ChildWindows: ImGuiHoveredFlags_ = 1;
 pub const ImGuiHoveredFlags_RootWindow: ImGuiHoveredFlags_ = 2;
@@ -345,7 +345,7 @@ pub const ImGuiHoveredFlags_DelayNone: ImGuiHoveredFlags_ = 16384;
 pub const ImGuiHoveredFlags_DelayShort: ImGuiHoveredFlags_ = 32768;
 pub const ImGuiHoveredFlags_DelayNormal: ImGuiHoveredFlags_ = 65536;
 pub const ImGuiHoveredFlags_NoSharedDelay: ImGuiHoveredFlags_ = 131072;
-pub type ImGuiHoveredFlags_ = cty::c_uint;
+pub type ImGuiHoveredFlags_ = core::ffi::c_uint;
 pub const ImGuiDragDropFlags_None: ImGuiDragDropFlags_ = 0;
 pub const ImGuiDragDropFlags_SourceNoPreviewTooltip: ImGuiDragDropFlags_ = 1;
 pub const ImGuiDragDropFlags_SourceNoDisableHover: ImGuiDragDropFlags_ = 2;
@@ -359,7 +359,7 @@ pub const ImGuiDragDropFlags_AcceptBeforeDelivery: ImGuiDragDropFlags_ = 1024;
 pub const ImGuiDragDropFlags_AcceptNoDrawDefaultRect: ImGuiDragDropFlags_ = 2048;
 pub const ImGuiDragDropFlags_AcceptNoPreviewTooltip: ImGuiDragDropFlags_ = 4096;
 pub const ImGuiDragDropFlags_AcceptPeekOnly: ImGuiDragDropFlags_ = 3072;
-pub type ImGuiDragDropFlags_ = cty::c_uint;
+pub type ImGuiDragDropFlags_ = core::ffi::c_uint;
 pub const ImGuiDataType_S8: ImGuiDataType_ = 0;
 pub const ImGuiDataType_U8: ImGuiDataType_ = 1;
 pub const ImGuiDataType_S16: ImGuiDataType_ = 2;
@@ -372,18 +372,18 @@ pub const ImGuiDataType_Float: ImGuiDataType_ = 8;
 pub const ImGuiDataType_Double: ImGuiDataType_ = 9;
 pub const ImGuiDataType_Bool: ImGuiDataType_ = 10;
 pub const ImGuiDataType_COUNT: ImGuiDataType_ = 11;
-pub type ImGuiDataType_ = cty::c_uint;
+pub type ImGuiDataType_ = core::ffi::c_uint;
 pub const ImGuiDir_None: ImGuiDir = -1;
 pub const ImGuiDir_Left: ImGuiDir = 0;
 pub const ImGuiDir_Right: ImGuiDir = 1;
 pub const ImGuiDir_Up: ImGuiDir = 2;
 pub const ImGuiDir_Down: ImGuiDir = 3;
 pub const ImGuiDir_COUNT: ImGuiDir = 4;
-pub type ImGuiDir = cty::c_int;
+pub type ImGuiDir = core::ffi::c_int;
 pub const ImGuiSortDirection_None: ImGuiSortDirection = 0;
 pub const ImGuiSortDirection_Ascending: ImGuiSortDirection = 1;
 pub const ImGuiSortDirection_Descending: ImGuiSortDirection = 2;
-pub type ImGuiSortDirection = cty::c_uint;
+pub type ImGuiSortDirection = core::ffi::c_uint;
 pub const ImGuiKey_None: ImGuiKey = 0;
 pub const ImGuiKey_Tab: ImGuiKey = 512;
 pub const ImGuiKey_LeftArrow: ImGuiKey = 513;
@@ -551,7 +551,7 @@ pub const ImGuiKey_NamedKey_END: ImGuiKey = 666;
 pub const ImGuiKey_NamedKey_COUNT: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_SIZE: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_OFFSET: ImGuiKey = 512;
-pub type ImGuiKey = cty::c_uint;
+pub type ImGuiKey = core::ffi::c_uint;
 pub const ImGuiInputFlags_None: ImGuiInputFlags_ = 0;
 pub const ImGuiInputFlags_Repeat: ImGuiInputFlags_ = 1;
 pub const ImGuiInputFlags_RouteActive: ImGuiInputFlags_ = 1024;
@@ -563,7 +563,7 @@ pub const ImGuiInputFlags_RouteOverActive: ImGuiInputFlags_ = 32768;
 pub const ImGuiInputFlags_RouteUnlessBgFocused: ImGuiInputFlags_ = 65536;
 pub const ImGuiInputFlags_RouteFromRootWindow: ImGuiInputFlags_ = 131072;
 pub const ImGuiInputFlags_Tooltip: ImGuiInputFlags_ = 262144;
-pub type ImGuiInputFlags_ = cty::c_uint;
+pub type ImGuiInputFlags_ = core::ffi::c_uint;
 pub const ImGuiConfigFlags_None: ImGuiConfigFlags_ = 0;
 pub const ImGuiConfigFlags_NavEnableKeyboard: ImGuiConfigFlags_ = 1;
 pub const ImGuiConfigFlags_NavEnableGamepad: ImGuiConfigFlags_ = 2;
@@ -574,13 +574,13 @@ pub const ImGuiConfigFlags_NoMouseCursorChange: ImGuiConfigFlags_ = 32;
 pub const ImGuiConfigFlags_NoKeyboard: ImGuiConfigFlags_ = 64;
 pub const ImGuiConfigFlags_IsSRGB: ImGuiConfigFlags_ = 1048576;
 pub const ImGuiConfigFlags_IsTouchScreen: ImGuiConfigFlags_ = 2097152;
-pub type ImGuiConfigFlags_ = cty::c_uint;
+pub type ImGuiConfigFlags_ = core::ffi::c_uint;
 pub const ImGuiBackendFlags_None: ImGuiBackendFlags_ = 0;
 pub const ImGuiBackendFlags_HasGamepad: ImGuiBackendFlags_ = 1;
 pub const ImGuiBackendFlags_HasMouseCursors: ImGuiBackendFlags_ = 2;
 pub const ImGuiBackendFlags_HasSetMousePos: ImGuiBackendFlags_ = 4;
 pub const ImGuiBackendFlags_RendererHasVtxOffset: ImGuiBackendFlags_ = 8;
-pub type ImGuiBackendFlags_ = cty::c_uint;
+pub type ImGuiBackendFlags_ = core::ffi::c_uint;
 pub const ImGuiCol_Text: ImGuiCol_ = 0;
 pub const ImGuiCol_TextDisabled: ImGuiCol_ = 1;
 pub const ImGuiCol_WindowBg: ImGuiCol_ = 2;
@@ -638,7 +638,7 @@ pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 53;
 pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 54;
 pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 55;
 pub const ImGuiCol_COUNT: ImGuiCol_ = 56;
-pub type ImGuiCol_ = cty::c_uint;
+pub type ImGuiCol_ = core::ffi::c_uint;
 pub const ImGuiStyleVar_Alpha: ImGuiStyleVar_ = 0;
 pub const ImGuiStyleVar_DisabledAlpha: ImGuiStyleVar_ = 1;
 pub const ImGuiStyleVar_WindowPadding: ImGuiStyleVar_ = 2;
@@ -673,13 +673,13 @@ pub const ImGuiStyleVar_SeparatorTextBorderSize: ImGuiStyleVar_ = 30;
 pub const ImGuiStyleVar_SeparatorTextAlign: ImGuiStyleVar_ = 31;
 pub const ImGuiStyleVar_SeparatorTextPadding: ImGuiStyleVar_ = 32;
 pub const ImGuiStyleVar_COUNT: ImGuiStyleVar_ = 33;
-pub type ImGuiStyleVar_ = cty::c_uint;
+pub type ImGuiStyleVar_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_None: ImGuiButtonFlags_ = 0;
 pub const ImGuiButtonFlags_MouseButtonLeft: ImGuiButtonFlags_ = 1;
 pub const ImGuiButtonFlags_MouseButtonRight: ImGuiButtonFlags_ = 2;
 pub const ImGuiButtonFlags_MouseButtonMiddle: ImGuiButtonFlags_ = 4;
 pub const ImGuiButtonFlags_MouseButtonMask_: ImGuiButtonFlags_ = 7;
-pub type ImGuiButtonFlags_ = cty::c_uint;
+pub type ImGuiButtonFlags_ = core::ffi::c_uint;
 pub const ImGuiColorEditFlags_None: ImGuiColorEditFlags_ = 0;
 pub const ImGuiColorEditFlags_NoAlpha: ImGuiColorEditFlags_ = 2;
 pub const ImGuiColorEditFlags_NoPicker: ImGuiColorEditFlags_ = 4;
@@ -709,7 +709,7 @@ pub const ImGuiColorEditFlags_DisplayMask_: ImGuiColorEditFlags_ = 7340032;
 pub const ImGuiColorEditFlags_DataTypeMask_: ImGuiColorEditFlags_ = 25165824;
 pub const ImGuiColorEditFlags_PickerMask_: ImGuiColorEditFlags_ = 100663296;
 pub const ImGuiColorEditFlags_InputMask_: ImGuiColorEditFlags_ = 402653184;
-pub type ImGuiColorEditFlags_ = cty::c_uint;
+pub type ImGuiColorEditFlags_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_None: ImGuiSliderFlags_ = 0;
 pub const ImGuiSliderFlags_Logarithmic: ImGuiSliderFlags_ = 32;
 pub const ImGuiSliderFlags_NoRoundToFormat: ImGuiSliderFlags_ = 64;
@@ -719,12 +719,12 @@ pub const ImGuiSliderFlags_ClampOnInput: ImGuiSliderFlags_ = 512;
 pub const ImGuiSliderFlags_ClampZeroRange: ImGuiSliderFlags_ = 1024;
 pub const ImGuiSliderFlags_AlwaysClamp: ImGuiSliderFlags_ = 1536;
 pub const ImGuiSliderFlags_InvalidMask_: ImGuiSliderFlags_ = 1879048207;
-pub type ImGuiSliderFlags_ = cty::c_uint;
+pub type ImGuiSliderFlags_ = core::ffi::c_uint;
 pub const ImGuiMouseButton_Left: ImGuiMouseButton_ = 0;
 pub const ImGuiMouseButton_Right: ImGuiMouseButton_ = 1;
 pub const ImGuiMouseButton_Middle: ImGuiMouseButton_ = 2;
 pub const ImGuiMouseButton_COUNT: ImGuiMouseButton_ = 5;
-pub type ImGuiMouseButton_ = cty::c_uint;
+pub type ImGuiMouseButton_ = core::ffi::c_uint;
 pub const ImGuiMouseCursor_None: ImGuiMouseCursor_ = -1;
 pub const ImGuiMouseCursor_Arrow: ImGuiMouseCursor_ = 0;
 pub const ImGuiMouseCursor_TextInput: ImGuiMouseCursor_ = 1;
@@ -736,18 +736,18 @@ pub const ImGuiMouseCursor_ResizeNWSE: ImGuiMouseCursor_ = 6;
 pub const ImGuiMouseCursor_Hand: ImGuiMouseCursor_ = 7;
 pub const ImGuiMouseCursor_NotAllowed: ImGuiMouseCursor_ = 8;
 pub const ImGuiMouseCursor_COUNT: ImGuiMouseCursor_ = 9;
-pub type ImGuiMouseCursor_ = cty::c_int;
+pub type ImGuiMouseCursor_ = core::ffi::c_int;
 pub const ImGuiMouseSource_Mouse: ImGuiMouseSource = 0;
 pub const ImGuiMouseSource_TouchScreen: ImGuiMouseSource = 1;
 pub const ImGuiMouseSource_Pen: ImGuiMouseSource = 2;
 pub const ImGuiMouseSource_COUNT: ImGuiMouseSource = 3;
-pub type ImGuiMouseSource = cty::c_uint;
+pub type ImGuiMouseSource = core::ffi::c_uint;
 pub const ImGuiCond_None: ImGuiCond_ = 0;
 pub const ImGuiCond_Always: ImGuiCond_ = 1;
 pub const ImGuiCond_Once: ImGuiCond_ = 2;
 pub const ImGuiCond_FirstUseEver: ImGuiCond_ = 4;
 pub const ImGuiCond_Appearing: ImGuiCond_ = 8;
-pub type ImGuiCond_ = cty::c_uint;
+pub type ImGuiCond_ = core::ffi::c_uint;
 pub const ImGuiTableFlags_None: ImGuiTableFlags_ = 0;
 pub const ImGuiTableFlags_Resizable: ImGuiTableFlags_ = 1;
 pub const ImGuiTableFlags_Reorderable: ImGuiTableFlags_ = 2;
@@ -785,7 +785,7 @@ pub const ImGuiTableFlags_SortMulti: ImGuiTableFlags_ = 67108864;
 pub const ImGuiTableFlags_SortTristate: ImGuiTableFlags_ = 134217728;
 pub const ImGuiTableFlags_HighlightHoveredColumn: ImGuiTableFlags_ = 268435456;
 pub const ImGuiTableFlags_SizingMask_: ImGuiTableFlags_ = 57344;
-pub type ImGuiTableFlags_ = cty::c_uint;
+pub type ImGuiTableFlags_ = core::ffi::c_uint;
 pub const ImGuiTableColumnFlags_None: ImGuiTableColumnFlags_ = 0;
 pub const ImGuiTableColumnFlags_Disabled: ImGuiTableColumnFlags_ = 1;
 pub const ImGuiTableColumnFlags_DefaultHide: ImGuiTableColumnFlags_ = 2;
@@ -814,20 +814,20 @@ pub const ImGuiTableColumnFlags_WidthMask_: ImGuiTableColumnFlags_ = 24;
 pub const ImGuiTableColumnFlags_IndentMask_: ImGuiTableColumnFlags_ = 196608;
 pub const ImGuiTableColumnFlags_StatusMask_: ImGuiTableColumnFlags_ = 251658240;
 pub const ImGuiTableColumnFlags_NoDirectResize_: ImGuiTableColumnFlags_ = 1073741824;
-pub type ImGuiTableColumnFlags_ = cty::c_uint;
+pub type ImGuiTableColumnFlags_ = core::ffi::c_uint;
 pub const ImGuiTableRowFlags_None: ImGuiTableRowFlags_ = 0;
 pub const ImGuiTableRowFlags_Headers: ImGuiTableRowFlags_ = 1;
-pub type ImGuiTableRowFlags_ = cty::c_uint;
+pub type ImGuiTableRowFlags_ = core::ffi::c_uint;
 pub const ImGuiTableBgTarget_None: ImGuiTableBgTarget_ = 0;
 pub const ImGuiTableBgTarget_RowBg0: ImGuiTableBgTarget_ = 1;
 pub const ImGuiTableBgTarget_RowBg1: ImGuiTableBgTarget_ = 2;
 pub const ImGuiTableBgTarget_CellBg: ImGuiTableBgTarget_ = 3;
-pub type ImGuiTableBgTarget_ = cty::c_uint;
+pub type ImGuiTableBgTarget_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTableSortSpecs {
     pub Specs: *const ImGuiTableColumnSortSpecs,
-    pub SpecsCount: cty::c_int,
+    pub SpecsCount: core::ffi::c_int,
     pub SpecsDirty: bool,
 }
 impl Default for ImGuiTableSortSpecs {
@@ -933,8 +933,8 @@ pub struct ImGuiKeyData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImWchar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImWchar,
 }
 impl Default for ImVector_ImWchar {
@@ -954,9 +954,9 @@ pub struct ImGuiIO {
     pub DisplaySize: ImVec2,
     pub DeltaTime: f32,
     pub IniSavingRate: f32,
-    pub IniFilename: *const cty::c_char,
-    pub LogFilename: *const cty::c_char,
-    pub UserData: *mut cty::c_void,
+    pub IniFilename: *const core::ffi::c_char,
+    pub LogFilename: *const core::ffi::c_char,
+    pub UserData: *mut core::ffi::c_void,
     pub Fonts: *mut ImFontAtlas,
     pub FontGlobalScale: f32,
     pub FontAllowUserScaling: bool,
@@ -988,11 +988,11 @@ pub struct ImGuiIO {
     pub ConfigDebugBeginReturnValueLoop: bool,
     pub ConfigDebugIgnoreFocusLoss: bool,
     pub ConfigDebugIniSettings: bool,
-    pub BackendPlatformName: *const cty::c_char,
-    pub BackendRendererName: *const cty::c_char,
-    pub BackendPlatformUserData: *mut cty::c_void,
-    pub BackendRendererUserData: *mut cty::c_void,
-    pub BackendLanguageUserData: *mut cty::c_void,
+    pub BackendPlatformName: *const core::ffi::c_char,
+    pub BackendRendererName: *const core::ffi::c_char,
+    pub BackendPlatformUserData: *mut core::ffi::c_void,
+    pub BackendRendererUserData: *mut core::ffi::c_void,
+    pub BackendLanguageUserData: *mut core::ffi::c_void,
     pub WantCaptureMouse: bool,
     pub WantCaptureKeyboard: bool,
     pub WantTextInput: bool,
@@ -1001,10 +1001,10 @@ pub struct ImGuiIO {
     pub NavActive: bool,
     pub NavVisible: bool,
     pub Framerate: f32,
-    pub MetricsRenderVertices: cty::c_int,
-    pub MetricsRenderIndices: cty::c_int,
-    pub MetricsRenderWindows: cty::c_int,
-    pub MetricsActiveWindows: cty::c_int,
+    pub MetricsRenderVertices: core::ffi::c_int,
+    pub MetricsRenderIndices: core::ffi::c_int,
+    pub MetricsRenderWindows: core::ffi::c_int,
+    pub MetricsActiveWindows: core::ffi::c_int,
     pub MouseDelta: ImVec2,
     pub Ctx: *mut ImGuiContext,
     pub MousePos: ImVec2,
@@ -1057,16 +1057,16 @@ pub struct ImGuiInputTextCallbackData {
     pub Ctx: *mut ImGuiContext,
     pub EventFlag: ImGuiInputTextFlags,
     pub Flags: ImGuiInputTextFlags,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub EventChar: ImWchar,
     pub EventKey: ImGuiKey,
-    pub Buf: *mut cty::c_char,
-    pub BufTextLen: cty::c_int,
-    pub BufSize: cty::c_int,
+    pub Buf: *mut core::ffi::c_char,
+    pub BufTextLen: core::ffi::c_int,
+    pub BufSize: core::ffi::c_int,
     pub BufDirty: bool,
-    pub CursorPos: cty::c_int,
-    pub SelectionStart: cty::c_int,
-    pub SelectionEnd: cty::c_int,
+    pub CursorPos: core::ffi::c_int,
+    pub SelectionStart: core::ffi::c_int,
+    pub SelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextCallbackData {
     fn default() -> Self {
@@ -1080,7 +1080,7 @@ impl Default for ImGuiInputTextCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiSizeCallbackData {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub Pos: ImVec2,
     pub CurrentSize: ImVec2,
     pub DesiredSize: ImVec2,
@@ -1097,12 +1097,12 @@ impl Default for ImGuiSizeCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPayload {
-    pub Data: *mut cty::c_void,
-    pub DataSize: cty::c_int,
+    pub Data: *mut core::ffi::c_void,
+    pub DataSize: core::ffi::c_int,
     pub SourceId: ImGuiID,
     pub SourceParentId: ImGuiID,
-    pub DataFrameCount: cty::c_int,
-    pub DataType: [cty::c_char; 33usize],
+    pub DataFrameCount: core::ffi::c_int,
+    pub DataType: [core::ffi::c_char; 33usize],
     pub Preview: bool,
     pub Delivery: bool,
 }
@@ -1118,13 +1118,13 @@ impl Default for ImGuiPayload {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiOnceUponAFrame {
-    pub RefFrame: cty::c_int,
+    pub RefFrame: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextRange {
-    pub b: *const cty::c_char,
-    pub e: *const cty::c_char,
+    pub b: *const core::ffi::c_char,
+    pub e: *const core::ffi::c_char,
 }
 impl Default for ImGuiTextRange {
     fn default() -> Self {
@@ -1138,8 +1138,8 @@ impl Default for ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTextRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTextRange,
 }
 impl Default for ImVector_ImGuiTextRange {
@@ -1154,9 +1154,9 @@ impl Default for ImVector_ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextFilter {
-    pub InputBuf: [cty::c_char; 256usize],
+    pub InputBuf: [core::ffi::c_char; 256usize],
     pub Filters: ImVector_ImGuiTextRange,
-    pub CountGrep: cty::c_int,
+    pub CountGrep: core::ffi::c_int,
 }
 impl Default for ImGuiTextFilter {
     fn default() -> Self {
@@ -1170,9 +1170,9 @@ impl Default for ImGuiTextFilter {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_char,
 }
 impl Default for ImVector_char {
     fn default() -> Self {
@@ -1206,9 +1206,9 @@ pub struct ImGuiStoragePair {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStoragePair__bindgen_ty_1 {
-    pub val_i: cty::c_int,
+    pub val_i: core::ffi::c_int,
     pub val_f: f32,
-    pub val_p: *mut cty::c_void,
+    pub val_p: *mut core::ffi::c_void,
 }
 impl Default for ImGuiStoragePair__bindgen_ty_1 {
     fn default() -> Self {
@@ -1245,8 +1245,8 @@ impl ::core::fmt::Debug for ImGuiStoragePair {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStoragePair {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStoragePair,
 }
 impl Default for ImVector_ImGuiStoragePair {
@@ -1276,13 +1276,13 @@ impl Default for ImGuiStorage {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiListClipper {
     pub Ctx: *mut ImGuiContext,
-    pub DisplayStart: cty::c_int,
-    pub DisplayEnd: cty::c_int,
-    pub ItemsCount: cty::c_int,
+    pub DisplayStart: core::ffi::c_int,
+    pub DisplayEnd: core::ffi::c_int,
+    pub ItemsCount: core::ffi::c_int,
     pub ItemsHeight: f32,
     pub StartPosY: f32,
     pub StartSeekOffsetY: f64,
-    pub TempData: *mut cty::c_void,
+    pub TempData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiListClipper {
     fn default() -> Self {
@@ -1315,12 +1315,12 @@ pub const ImGuiMultiSelectFlags_ScopeRect: ImGuiMultiSelectFlags_ = 4096;
 pub const ImGuiMultiSelectFlags_SelectOnClick: ImGuiMultiSelectFlags_ = 8192;
 pub const ImGuiMultiSelectFlags_SelectOnClickRelease: ImGuiMultiSelectFlags_ = 16384;
 pub const ImGuiMultiSelectFlags_NavWrapX: ImGuiMultiSelectFlags_ = 65536;
-pub type ImGuiMultiSelectFlags_ = cty::c_uint;
+pub type ImGuiMultiSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSelectionRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSelectionRequest,
 }
 impl Default for ImVector_ImGuiSelectionRequest {
@@ -1340,7 +1340,7 @@ pub struct ImGuiMultiSelectIO {
     pub NavIdItem: ImGuiSelectionUserData,
     pub NavIdSelected: bool,
     pub RangeSrcReset: bool,
-    pub ItemsCount: cty::c_int,
+    pub ItemsCount: core::ffi::c_int,
 }
 impl Default for ImGuiMultiSelectIO {
     fn default() -> Self {
@@ -1354,7 +1354,7 @@ impl Default for ImGuiMultiSelectIO {
 pub const ImGuiSelectionRequestType_None: ImGuiSelectionRequestType = 0;
 pub const ImGuiSelectionRequestType_SetAll: ImGuiSelectionRequestType = 1;
 pub const ImGuiSelectionRequestType_SetRange: ImGuiSelectionRequestType = 2;
-pub type ImGuiSelectionRequestType = cty::c_uint;
+pub type ImGuiSelectionRequestType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionRequest {
@@ -1376,13 +1376,16 @@ impl Default for ImGuiSelectionRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionBasicStorage {
-    pub Size: cty::c_int,
+    pub Size: core::ffi::c_int,
     pub PreserveOrder: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterIndexToStorageId: ::core::option::Option<
-        unsafe extern "C" fn(self_: *mut ImGuiSelectionBasicStorage, idx: cty::c_int) -> ImGuiID,
+        unsafe extern "C" fn(
+            self_: *mut ImGuiSelectionBasicStorage,
+            idx: core::ffi::c_int,
+        ) -> ImGuiID,
     >,
-    pub _SelectionOrder: cty::c_int,
+    pub _SelectionOrder: core::ffi::c_int,
     pub _Storage: ImGuiStorage,
 }
 impl Default for ImGuiSelectionBasicStorage {
@@ -1397,11 +1400,11 @@ impl Default for ImGuiSelectionBasicStorage {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionExternalStorage {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterSetItemSelected: ::core::option::Option<
         unsafe extern "C" fn(
             self_: *mut ImGuiSelectionExternalStorage,
-            idx: cty::c_int,
+            idx: core::ffi::c_int,
             selected: bool,
         ),
     >,
@@ -1423,11 +1426,11 @@ pub type ImDrawCallback = ::core::option::Option<
 pub struct ImDrawCmd {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
-    pub IdxOffset: cty::c_uint,
-    pub ElemCount: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
+    pub IdxOffset: core::ffi::c_uint,
+    pub ElemCount: core::ffi::c_uint,
     pub UserCallback: ImDrawCallback,
-    pub UserCallbackData: *mut cty::c_void,
+    pub UserCallbackData: *mut core::ffi::c_void,
 }
 impl Default for ImDrawCmd {
     fn default() -> Self {
@@ -1450,7 +1453,7 @@ pub struct ImDrawVert {
 pub struct ImDrawCmdHeader {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
 }
 impl Default for ImDrawCmdHeader {
     fn default() -> Self {
@@ -1464,8 +1467,8 @@ impl Default for ImDrawCmdHeader {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawCmd {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawCmd,
 }
 impl Default for ImVector_ImDrawCmd {
@@ -1480,8 +1483,8 @@ impl Default for ImVector_ImDrawCmd {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawIdx {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawIdx,
 }
 impl Default for ImVector_ImDrawIdx {
@@ -1511,8 +1514,8 @@ impl Default for ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawChannel {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawChannel,
 }
 impl Default for ImVector_ImDrawChannel {
@@ -1527,8 +1530,8 @@ impl Default for ImVector_ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImDrawListSplitter {
-    pub _Current: cty::c_int,
-    pub _Count: cty::c_int,
+    pub _Current: core::ffi::c_int,
+    pub _Count: core::ffi::c_int,
     pub _Channels: ImVector_ImDrawChannel,
 }
 impl Default for ImDrawListSplitter {
@@ -1554,18 +1557,18 @@ pub const ImDrawFlags_RoundCornersRight: ImDrawFlags_ = 160;
 pub const ImDrawFlags_RoundCornersAll: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersDefault_: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersMask_: ImDrawFlags_ = 496;
-pub type ImDrawFlags_ = cty::c_uint;
+pub type ImDrawFlags_ = core::ffi::c_uint;
 pub const ImDrawListFlags_None: ImDrawListFlags_ = 0;
 pub const ImDrawListFlags_AntiAliasedLines: ImDrawListFlags_ = 1;
 pub const ImDrawListFlags_AntiAliasedLinesUseTex: ImDrawListFlags_ = 2;
 pub const ImDrawListFlags_AntiAliasedFill: ImDrawListFlags_ = 4;
 pub const ImDrawListFlags_AllowVtxOffset: ImDrawListFlags_ = 8;
-pub type ImDrawListFlags_ = cty::c_uint;
+pub type ImDrawListFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawVert {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawVert,
 }
 impl Default for ImVector_ImDrawVert {
@@ -1580,8 +1583,8 @@ impl Default for ImVector_ImDrawVert {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec2 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec2,
 }
 impl Default for ImVector_ImVec2 {
@@ -1596,8 +1599,8 @@ impl Default for ImVector_ImVec2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec4 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec4,
 }
 impl Default for ImVector_ImVec4 {
@@ -1612,8 +1615,8 @@ impl Default for ImVector_ImVec4 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImTextureID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImTextureID,
 }
 impl Default for ImVector_ImTextureID {
@@ -1632,7 +1635,7 @@ pub struct ImDrawList {
     pub IdxBuffer: ImVector_ImDrawIdx,
     pub VtxBuffer: ImVector_ImDrawVert,
     pub Flags: ImDrawListFlags,
-    pub _VtxCurrentIdx: cty::c_uint,
+    pub _VtxCurrentIdx: core::ffi::c_uint,
     pub _Data: *mut ImDrawListSharedData,
     pub _VtxWritePtr: *mut ImDrawVert,
     pub _IdxWritePtr: *mut ImDrawIdx,
@@ -1642,7 +1645,7 @@ pub struct ImDrawList {
     pub _ClipRectStack: ImVector_ImVec4,
     pub _TextureIdStack: ImVector_ImTextureID,
     pub _FringeScale: f32,
-    pub _OwnerName: *const cty::c_char,
+    pub _OwnerName: *const core::ffi::c_char,
 }
 impl Default for ImDrawList {
     fn default() -> Self {
@@ -1656,8 +1659,8 @@ impl Default for ImDrawList {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawListPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImDrawList,
 }
 impl Default for ImVector_ImDrawListPtr {
@@ -1673,9 +1676,9 @@ impl Default for ImVector_ImDrawListPtr {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImDrawData {
     pub Valid: bool,
-    pub CmdListsCount: cty::c_int,
-    pub TotalIdxCount: cty::c_int,
-    pub TotalVtxCount: cty::c_int,
+    pub CmdListsCount: core::ffi::c_int,
+    pub TotalIdxCount: core::ffi::c_int,
+    pub TotalVtxCount: core::ffi::c_int,
     pub CmdLists: ImVector_ImDrawListPtr,
     pub DisplayPos: ImVec2,
     pub DisplaySize: ImVec2,
@@ -1694,13 +1697,13 @@ impl Default for ImDrawData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontConfig {
-    pub FontData: *mut cty::c_void,
-    pub FontDataSize: cty::c_int,
+    pub FontData: *mut core::ffi::c_void,
+    pub FontDataSize: core::ffi::c_int,
     pub FontDataOwnedByAtlas: bool,
-    pub FontNo: cty::c_int,
+    pub FontNo: core::ffi::c_int,
     pub SizePixels: f32,
-    pub OversampleH: cty::c_int,
-    pub OversampleV: cty::c_int,
+    pub OversampleH: core::ffi::c_int,
+    pub OversampleV: core::ffi::c_int,
     pub PixelSnapH: bool,
     pub GlyphExtraSpacing: ImVec2,
     pub GlyphOffset: ImVec2,
@@ -1708,11 +1711,11 @@ pub struct ImFontConfig {
     pub GlyphMinAdvanceX: f32,
     pub GlyphMaxAdvanceX: f32,
     pub MergeMode: bool,
-    pub FontBuilderFlags: cty::c_uint,
+    pub FontBuilderFlags: core::ffi::c_uint,
     pub RasterizerMultiply: f32,
     pub RasterizerDensity: f32,
     pub EllipsisChar: ImWchar,
-    pub Name: [cty::c_char; 40usize],
+    pub Name: [core::ffi::c_char; 40usize],
     pub DstFont: *mut ImFont,
 }
 impl Default for ImFontConfig {
@@ -1741,33 +1744,33 @@ pub struct ImFontGlyph {
 }
 impl ImFontGlyph {
     #[inline]
-    pub fn Colored(&self) -> cty::c_uint {
+    pub fn Colored(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Colored(&mut self, val: cty::c_uint) {
+    pub fn set_Colored(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Visible(&self) -> cty::c_uint {
+    pub fn Visible(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Visible(&mut self, val: cty::c_uint) {
+    pub fn set_Visible(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(1usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Codepoint(&self) -> cty::c_uint {
+    pub fn Codepoint(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
     }
     #[inline]
-    pub fn set_Codepoint(&mut self, val: cty::c_uint) {
+    pub fn set_Codepoint(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(2usize, 30u8, val as u64)
@@ -1775,9 +1778,9 @@ impl ImFontGlyph {
     }
     #[inline]
     pub fn new_bitfield_1(
-        Colored: cty::c_uint,
-        Visible: cty::c_uint,
-        Codepoint: cty::c_uint,
+        Colored: core::ffi::c_uint,
+        Visible: core::ffi::c_uint,
+        Codepoint: core::ffi::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1798,8 +1801,8 @@ impl ImFontGlyph {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImU32 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImU32,
 }
 impl Default for ImVector_ImU32 {
@@ -1828,11 +1831,11 @@ impl Default for ImFontGlyphRangesBuilder {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontAtlasCustomRect {
-    pub Width: cty::c_ushort,
-    pub Height: cty::c_ushort,
-    pub X: cty::c_ushort,
-    pub Y: cty::c_ushort,
-    pub GlyphID: cty::c_uint,
+    pub Width: core::ffi::c_ushort,
+    pub Height: core::ffi::c_ushort,
+    pub X: core::ffi::c_ushort,
+    pub Y: core::ffi::c_ushort,
+    pub GlyphID: core::ffi::c_uint,
     pub GlyphAdvanceX: f32,
     pub GlyphOffset: ImVec2,
     pub Font: *mut ImFont,
@@ -1850,12 +1853,12 @@ pub const ImFontAtlasFlags_None: ImFontAtlasFlags_ = 0;
 pub const ImFontAtlasFlags_NoPowerOfTwoHeight: ImFontAtlasFlags_ = 1;
 pub const ImFontAtlasFlags_NoMouseCursors: ImFontAtlasFlags_ = 2;
 pub const ImFontAtlasFlags_NoBakedLines: ImFontAtlasFlags_ = 4;
-pub type ImFontAtlasFlags_ = cty::c_uint;
+pub type ImFontAtlasFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImFont,
 }
 impl Default for ImVector_ImFontPtr {
@@ -1870,8 +1873,8 @@ impl Default for ImVector_ImFontPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontAtlasCustomRect {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontAtlasCustomRect,
 }
 impl Default for ImVector_ImFontAtlasCustomRect {
@@ -1886,8 +1889,8 @@ impl Default for ImVector_ImFontAtlasCustomRect {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontConfig {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontConfig,
 }
 impl Default for ImVector_ImFontConfig {
@@ -1904,16 +1907,16 @@ impl Default for ImVector_ImFontConfig {
 pub struct ImFontAtlas {
     pub Flags: ImFontAtlasFlags,
     pub TexID: ImTextureID,
-    pub TexDesiredWidth: cty::c_int,
-    pub TexGlyphPadding: cty::c_int,
+    pub TexDesiredWidth: core::ffi::c_int,
+    pub TexGlyphPadding: core::ffi::c_int,
     pub Locked: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub TexReady: bool,
     pub TexPixelsUseColors: bool,
-    pub TexPixelsAlpha8: *mut cty::c_uchar,
-    pub TexPixelsRGBA32: *mut cty::c_uint,
-    pub TexWidth: cty::c_int,
-    pub TexHeight: cty::c_int,
+    pub TexPixelsAlpha8: *mut core::ffi::c_uchar,
+    pub TexPixelsRGBA32: *mut core::ffi::c_uint,
+    pub TexWidth: core::ffi::c_int,
+    pub TexHeight: core::ffi::c_int,
     pub TexUvScale: ImVec2,
     pub TexUvWhitePixel: ImVec2,
     pub Fonts: ImVector_ImFontPtr,
@@ -1921,9 +1924,9 @@ pub struct ImFontAtlas {
     pub ConfigData: ImVector_ImFontConfig,
     pub TexUvLines: [ImVec4; 64usize],
     pub FontBuilderIO: *const ImFontBuilderIO,
-    pub FontBuilderFlags: cty::c_uint,
-    pub PackIdMouseCursors: cty::c_int,
-    pub PackIdLines: cty::c_int,
+    pub FontBuilderFlags: core::ffi::c_uint,
+    pub PackIdMouseCursors: core::ffi::c_int,
+    pub PackIdLines: core::ffi::c_int,
 }
 impl Default for ImFontAtlas {
     fn default() -> Self {
@@ -1937,8 +1940,8 @@ impl Default for ImFontAtlas {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_float {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut f32,
 }
 impl Default for ImVector_float {
@@ -1953,8 +1956,8 @@ impl Default for ImVector_float {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontGlyph {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontGlyph,
 }
 impl Default for ImVector_ImFontGlyph {
@@ -1977,17 +1980,17 @@ pub struct ImFont {
     pub FallbackGlyph: *const ImFontGlyph,
     pub ContainerAtlas: *mut ImFontAtlas,
     pub ConfigData: *const ImFontConfig,
-    pub ConfigDataCount: cty::c_short,
+    pub ConfigDataCount: core::ffi::c_short,
     pub FallbackChar: ImWchar,
     pub EllipsisChar: ImWchar,
-    pub EllipsisCharCount: cty::c_short,
+    pub EllipsisCharCount: core::ffi::c_short,
     pub EllipsisWidth: f32,
     pub EllipsisCharStep: f32,
     pub DirtyLookupTables: bool,
     pub Scale: f32,
     pub Ascent: f32,
     pub Descent: f32,
-    pub MetricsTotalSurface: cty::c_int,
+    pub MetricsTotalSurface: core::ffi::c_int,
     pub Used4kPagesMap: [ImU8; 34usize],
 }
 impl Default for ImFont {
@@ -2003,7 +2006,7 @@ pub const ImGuiViewportFlags_None: ImGuiViewportFlags_ = 0;
 pub const ImGuiViewportFlags_IsPlatformWindow: ImGuiViewportFlags_ = 1;
 pub const ImGuiViewportFlags_IsPlatformMonitor: ImGuiViewportFlags_ = 2;
 pub const ImGuiViewportFlags_OwnedByApp: ImGuiViewportFlags_ = 4;
-pub type ImGuiViewportFlags_ = cty::c_uint;
+pub type ImGuiViewportFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiViewport {
@@ -2013,8 +2016,8 @@ pub struct ImGuiViewport {
     pub Size: ImVec2,
     pub WorkPos: ImVec2,
     pub WorkSize: ImVec2,
-    pub PlatformHandle: *mut cty::c_void,
-    pub PlatformHandleRaw: *mut cty::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
+    pub PlatformHandleRaw: *mut core::ffi::c_void,
 }
 impl Default for ImGuiViewport {
     fn default() -> Self {
@@ -2028,16 +2031,17 @@ impl Default for ImGuiViewport {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPlatformIO {
-    pub Platform_GetClipboardTextFn:
-        ::core::option::Option<unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const cty::c_char>,
+    pub Platform_GetClipboardTextFn: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const core::ffi::c_char,
+    >,
     pub Platform_SetClipboardTextFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const cty::c_char),
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const core::ffi::c_char),
     >,
-    pub Platform_ClipboardUserData: *mut cty::c_void,
+    pub Platform_ClipboardUserData: *mut core::ffi::c_void,
     pub Platform_OpenInShellFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const cty::c_char) -> bool,
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const core::ffi::c_char) -> bool,
     >,
-    pub Platform_OpenInShellUserData: *mut cty::c_void,
+    pub Platform_OpenInShellUserData: *mut core::ffi::c_void,
     pub Platform_SetImeDataFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
@@ -2045,7 +2049,7 @@ pub struct ImGuiPlatformIO {
             data: *mut ImGuiPlatformImeData,
         ),
     >,
-    pub Platform_ImeUserData: *mut cty::c_void,
+    pub Platform_ImeUserData: *mut core::ffi::c_void,
     pub Platform_LocaleDecimalPoint: ImWchar,
 }
 impl Default for ImGuiPlatformIO {
@@ -2134,16 +2138,16 @@ extern "C" {
     pub fn igShowStyleEditor(ref_: *mut ImGuiStyle);
 }
 extern "C" {
-    pub fn igShowStyleSelector(label: *const cty::c_char) -> bool;
+    pub fn igShowStyleSelector(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igShowFontSelector(label: *const cty::c_char);
+    pub fn igShowFontSelector(label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igShowUserGuide();
 }
 extern "C" {
-    pub fn igGetVersion() -> *const cty::c_char;
+    pub fn igGetVersion() -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igStyleColorsDark(dst: *mut ImGuiStyle);
@@ -2155,14 +2159,18 @@ extern "C" {
     pub fn igStyleColorsClassic(dst: *mut ImGuiStyle);
 }
 extern "C" {
-    pub fn igBegin(name: *const cty::c_char, p_open: *mut bool, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBegin(
+        name: *const core::ffi::c_char,
+        p_open: *mut bool,
+        flags: ImGuiWindowFlags,
+    ) -> bool;
 }
 extern "C" {
     pub fn igEnd();
 }
 extern "C" {
     pub fn igBeginChild_Str(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         child_flags: ImGuiChildFlags,
         window_flags: ImGuiWindowFlags,
@@ -2217,7 +2225,7 @@ extern "C" {
         size_min: ImVec2,
         size_max: ImVec2,
         custom_callback: ImGuiSizeCallback,
-        custom_callback_data: *mut cty::c_void,
+        custom_callback_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -2251,16 +2259,20 @@ extern "C" {
     pub fn igSetWindowFontScale(scale: f32);
 }
 extern "C" {
-    pub fn igSetWindowPos_Str(name: *const cty::c_char, pos: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowPos_Str(name: *const core::ffi::c_char, pos: ImVec2, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igSetWindowSize_Str(name: *const cty::c_char, size: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowSize_Str(name: *const core::ffi::c_char, size: ImVec2, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igSetWindowCollapsed_Str(name: *const cty::c_char, collapsed: bool, cond: ImGuiCond);
+    pub fn igSetWindowCollapsed_Str(
+        name: *const core::ffi::c_char,
+        collapsed: bool,
+        cond: ImGuiCond,
+    );
 }
 extern "C" {
-    pub fn igSetWindowFocus_Str(name: *const cty::c_char);
+    pub fn igSetWindowFocus_Str(name: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igGetScrollX() -> f32;
@@ -2305,7 +2317,7 @@ extern "C" {
     pub fn igPushStyleColor_Vec4(idx: ImGuiCol, col: ImVec4);
 }
 extern "C" {
-    pub fn igPopStyleColor(count: cty::c_int);
+    pub fn igPopStyleColor(count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushStyleVar_Float(idx: ImGuiStyleVar, val: f32);
@@ -2320,7 +2332,7 @@ extern "C" {
     pub fn igPushStyleVarY(idx: ImGuiStyleVar, val_y: f32);
 }
 extern "C" {
-    pub fn igPopStyleVar(count: cty::c_int);
+    pub fn igPopStyleVar(count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushItemFlag(option: ImGuiItemFlags, enabled: bool);
@@ -2440,113 +2452,116 @@ extern "C" {
     pub fn igGetFrameHeightWithSpacing() -> f32;
 }
 extern "C" {
-    pub fn igPushID_Str(str_id: *const cty::c_char);
+    pub fn igPushID_Str(str_id: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igPushID_StrStr(str_id_begin: *const cty::c_char, str_id_end: *const cty::c_char);
+    pub fn igPushID_StrStr(
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
+    );
 }
 extern "C" {
-    pub fn igPushID_Ptr(ptr_id: *const cty::c_void);
+    pub fn igPushID_Ptr(ptr_id: *const core::ffi::c_void);
 }
 extern "C" {
-    pub fn igPushID_Int(int_id: cty::c_int);
+    pub fn igPushID_Int(int_id: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPopID();
 }
 extern "C" {
-    pub fn igGetID_Str(str_id: *const cty::c_char) -> ImGuiID;
+    pub fn igGetID_Str(str_id: *const core::ffi::c_char) -> ImGuiID;
 }
 extern "C" {
     pub fn igGetID_StrStr(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetID_Ptr(ptr_id: *const cty::c_void) -> ImGuiID;
+    pub fn igGetID_Ptr(ptr_id: *const core::ffi::c_void) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetID_Int(int_id: cty::c_int) -> ImGuiID;
+    pub fn igGetID_Int(int_id: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
-    pub fn igTextUnformatted(text: *const cty::c_char, text_end: *const cty::c_char);
+    pub fn igTextUnformatted(text: *const core::ffi::c_char, text_end: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igText(fmt: *const cty::c_char, ...);
+    pub fn igText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextColored(col: ImVec4, fmt: *const cty::c_char, ...);
+    pub fn igTextColored(col: ImVec4, fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextDisabled(fmt: *const cty::c_char, ...);
+    pub fn igTextDisabled(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextWrapped(fmt: *const cty::c_char, ...);
+    pub fn igTextWrapped(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igLabelText(label: *const cty::c_char, fmt: *const cty::c_char, ...);
+    pub fn igLabelText(label: *const core::ffi::c_char, fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igBulletText(fmt: *const cty::c_char, ...);
+    pub fn igBulletText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igSeparatorText(label: *const cty::c_char);
+    pub fn igSeparatorText(label: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igButton(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igButton(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 extern "C" {
-    pub fn igSmallButton(label: *const cty::c_char) -> bool;
+    pub fn igSmallButton(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
     pub fn igInvisibleButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         flags: ImGuiButtonFlags,
     ) -> bool;
 }
 extern "C" {
-    pub fn igArrowButton(str_id: *const cty::c_char, dir: ImGuiDir) -> bool;
+    pub fn igArrowButton(str_id: *const core::ffi::c_char, dir: ImGuiDir) -> bool;
 }
 extern "C" {
-    pub fn igCheckbox(label: *const cty::c_char, v: *mut bool) -> bool;
+    pub fn igCheckbox(label: *const core::ffi::c_char, v: *mut bool) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_IntPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_int,
-        flags_value: cty::c_int,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_int,
+        flags_value: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_UintPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_uint,
-        flags_value: cty::c_uint,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_uint,
+        flags_value: core::ffi::c_uint,
     ) -> bool;
 }
 extern "C" {
-    pub fn igRadioButton_Bool(label: *const cty::c_char, active: bool) -> bool;
+    pub fn igRadioButton_Bool(label: *const core::ffi::c_char, active: bool) -> bool;
 }
 extern "C" {
     pub fn igRadioButton_IntPtr(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_button: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_button: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
-    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const cty::c_char);
+    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igBullet();
 }
 extern "C" {
-    pub fn igTextLink(label: *const cty::c_char) -> bool;
+    pub fn igTextLink(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igTextLinkOpenURL(label: *const cty::c_char, url: *const cty::c_char);
+    pub fn igTextLinkOpenURL(label: *const core::ffi::c_char, url: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igImage(
@@ -2560,7 +2575,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igImageButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         user_texture_id: ImTextureID,
         image_size: ImVec2,
         uv0: ImVec2,
@@ -2571,8 +2586,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginCombo(
-        label: *const cty::c_char,
-        preview_value: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        preview_value: *const core::ffi::c_char,
         flags: ImGuiComboFlags,
     ) -> bool;
 }
@@ -2581,475 +2596,475 @@ extern "C" {
 }
 extern "C" {
     pub fn igCombo_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCombo_Str(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items_separated_by_zeros: *const cty::c_char,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items_separated_by_zeros: *const core::ffi::c_char,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCombo_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloatRange2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_current_min: *mut f32,
         v_current_max: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragIntRange2(
-        label: *const cty::c_char,
-        v_current_min: *mut cty::c_int,
-        v_current_max: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v_current_min: *mut core::ffi::c_int,
+        v_current_max: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderAngle(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_rad: *mut f32,
         v_degrees_min: f32,
         v_degrees_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderInt(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputText(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputTextMultiline(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         size: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputTextWithHint(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         step: f32,
         step_fast: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        step: cty::c_int,
-        step_fast: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        step: core::ffi::c_int,
+        step_fast: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputDouble(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f64,
         step: f64,
         step_fast: f64,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorEdit3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorEdit4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorPicker3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorPicker4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
         ref_col: *const f32,
@@ -3057,7 +3072,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igColorButton(
-        desc_id: *const cty::c_char,
+        desc_id: *const core::ffi::c_char,
         col: ImVec4,
         flags: ImGuiColorEditFlags,
         size: ImVec2,
@@ -3067,38 +3082,46 @@ extern "C" {
     pub fn igSetColorEditOptions(flags: ImGuiColorEditFlags);
 }
 extern "C" {
-    pub fn igTreeNode_Str(label: *const cty::c_char) -> bool;
+    pub fn igTreeNode_Str(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igTreeNode_StrStr(str_id: *const cty::c_char, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_StrStr(
+        str_id: *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 extern "C" {
-    pub fn igTreeNode_Ptr(ptr_id: *const cty::c_void, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_Ptr(
+        ptr_id: *const core::ffi::c_void,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 extern "C" {
-    pub fn igTreeNodeEx_Str(label: *const cty::c_char, flags: ImGuiTreeNodeFlags) -> bool;
+    pub fn igTreeNodeEx_Str(label: *const core::ffi::c_char, flags: ImGuiTreeNodeFlags) -> bool;
 }
 extern "C" {
     pub fn igTreeNodeEx_StrStr(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 extern "C" {
     pub fn igTreeNodeEx_Ptr(
-        ptr_id: *const cty::c_void,
+        ptr_id: *const core::ffi::c_void,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 extern "C" {
-    pub fn igTreePush_Str(str_id: *const cty::c_char);
+    pub fn igTreePush_Str(str_id: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igTreePush_Ptr(ptr_id: *const cty::c_void);
+    pub fn igTreePush_Ptr(ptr_id: *const core::ffi::c_void);
 }
 extern "C" {
     pub fn igTreePop();
@@ -3108,13 +3131,13 @@ extern "C" {
 }
 extern "C" {
     pub fn igCollapsingHeader_TreeNodeFlags(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igCollapsingHeader_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_visible: *mut bool,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
@@ -3127,7 +3150,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igSelectable_Bool(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         selected: bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -3135,7 +3158,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igSelectable_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_selected: *mut bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -3144,8 +3167,8 @@ extern "C" {
 extern "C" {
     pub fn igBeginMultiSelect(
         flags: ImGuiMultiSelectFlags,
-        selection_size: cty::c_int,
-        items_count: cty::c_int,
+        selection_size: core::ffi::c_int,
+        items_count: core::ffi::c_int,
     ) -> *mut ImGuiMultiSelectIO;
 }
 extern "C" {
@@ -3158,58 +3181,58 @@ extern "C" {
     pub fn igIsItemToggledSelection() -> bool;
 }
 extern "C" {
-    pub fn igBeginListBox(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igBeginListBox(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 extern "C" {
     pub fn igEndListBox();
 }
 extern "C" {
     pub fn igListBox_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igListBox_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igPlotLines_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn igPlotLines_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -3217,43 +3240,47 @@ extern "C" {
 }
 extern "C" {
     pub fn igPlotHistogram_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn igPlotHistogram_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
     );
 }
 extern "C" {
-    pub fn igValue_Bool(prefix: *const cty::c_char, b: bool);
+    pub fn igValue_Bool(prefix: *const core::ffi::c_char, b: bool);
 }
 extern "C" {
-    pub fn igValue_Int(prefix: *const cty::c_char, v: cty::c_int);
+    pub fn igValue_Int(prefix: *const core::ffi::c_char, v: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igValue_Uint(prefix: *const cty::c_char, v: cty::c_uint);
+    pub fn igValue_Uint(prefix: *const core::ffi::c_char, v: core::ffi::c_uint);
 }
 extern "C" {
-    pub fn igValue_Float(prefix: *const cty::c_char, v: f32, float_format: *const cty::c_char);
+    pub fn igValue_Float(
+        prefix: *const core::ffi::c_char,
+        v: f32,
+        float_format: *const core::ffi::c_char,
+    );
 }
 extern "C" {
     pub fn igBeginMenuBar() -> bool;
@@ -3268,23 +3295,23 @@ extern "C" {
     pub fn igEndMainMenuBar();
 }
 extern "C" {
-    pub fn igBeginMenu(label: *const cty::c_char, enabled: bool) -> bool;
+    pub fn igBeginMenu(label: *const core::ffi::c_char, enabled: bool) -> bool;
 }
 extern "C" {
     pub fn igEndMenu();
 }
 extern "C" {
     pub fn igMenuItem_Bool(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
 }
 extern "C" {
     pub fn igMenuItem_BoolPtr(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         p_selected: *mut bool,
         enabled: bool,
     ) -> bool;
@@ -3296,20 +3323,20 @@ extern "C" {
     pub fn igEndTooltip();
 }
 extern "C" {
-    pub fn igSetTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetTooltip(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
     pub fn igBeginItemTooltip() -> bool;
 }
 extern "C" {
-    pub fn igSetItemTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetItemTooltip(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igBeginPopup(str_id: *const cty::c_char, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBeginPopup(str_id: *const core::ffi::c_char, flags: ImGuiWindowFlags) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupModal(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiWindowFlags,
     ) -> bool;
@@ -3318,42 +3345,42 @@ extern "C" {
     pub fn igEndPopup();
 }
 extern "C" {
-    pub fn igOpenPopup_Str(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopup_Str(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
     pub fn igOpenPopup_ID(id: ImGuiID, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
-    pub fn igOpenPopupOnItemClick(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopupOnItemClick(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
     pub fn igCloseCurrentPopup();
 }
 extern "C" {
     pub fn igBeginPopupContextItem(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupContextWindow(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupContextVoid(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
-    pub fn igIsPopupOpen(str_id: *const cty::c_char, flags: ImGuiPopupFlags) -> bool;
+    pub fn igIsPopupOpen(str_id: *const core::ffi::c_char, flags: ImGuiPopupFlags) -> bool;
 }
 extern "C" {
     pub fn igBeginTable(
-        str_id: *const cty::c_char,
-        columns: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        columns: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -3369,21 +3396,21 @@ extern "C" {
     pub fn igTableNextColumn() -> bool;
 }
 extern "C" {
-    pub fn igTableSetColumnIndex(column_n: cty::c_int) -> bool;
+    pub fn igTableSetColumnIndex(column_n: core::ffi::c_int) -> bool;
 }
 extern "C" {
     pub fn igTableSetupColumn(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTableColumnFlags,
         init_width_or_weight: f32,
         user_id: ImGuiID,
     );
 }
 extern "C" {
-    pub fn igTableSetupScrollFreeze(cols: cty::c_int, rows: cty::c_int);
+    pub fn igTableSetupScrollFreeze(cols: core::ffi::c_int, rows: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igTableHeader(label: *const cty::c_char);
+    pub fn igTableHeader(label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igTableHeadersRow();
@@ -3395,62 +3422,62 @@ extern "C" {
     pub fn igTableGetSortSpecs() -> *mut ImGuiTableSortSpecs;
 }
 extern "C" {
-    pub fn igTableGetColumnCount() -> cty::c_int;
+    pub fn igTableGetColumnCount() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetColumnIndex() -> cty::c_int;
+    pub fn igTableGetColumnIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetRowIndex() -> cty::c_int;
+    pub fn igTableGetRowIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetColumnName(column_n: cty::c_int) -> *const cty::c_char;
+    pub fn igTableGetColumnName(column_n: core::ffi::c_int) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igTableGetColumnFlags(column_n: cty::c_int) -> ImGuiTableColumnFlags;
+    pub fn igTableGetColumnFlags(column_n: core::ffi::c_int) -> ImGuiTableColumnFlags;
 }
 extern "C" {
-    pub fn igTableSetColumnEnabled(column_n: cty::c_int, v: bool);
+    pub fn igTableSetColumnEnabled(column_n: core::ffi::c_int, v: bool);
 }
 extern "C" {
-    pub fn igTableGetHoveredColumn() -> cty::c_int;
+    pub fn igTableGetHoveredColumn() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: cty::c_int);
+    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igColumns(count: cty::c_int, id: *const cty::c_char, borders: bool);
+    pub fn igColumns(count: core::ffi::c_int, id: *const core::ffi::c_char, borders: bool);
 }
 extern "C" {
     pub fn igNextColumn();
 }
 extern "C" {
-    pub fn igGetColumnIndex() -> cty::c_int;
+    pub fn igGetColumnIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igGetColumnWidth(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnWidth(column_index: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igSetColumnWidth(column_index: cty::c_int, width: f32);
+    pub fn igSetColumnWidth(column_index: core::ffi::c_int, width: f32);
 }
 extern "C" {
-    pub fn igGetColumnOffset(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnOffset(column_index: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igSetColumnOffset(column_index: cty::c_int, offset_x: f32);
+    pub fn igSetColumnOffset(column_index: core::ffi::c_int, offset_x: f32);
 }
 extern "C" {
-    pub fn igGetColumnsCount() -> cty::c_int;
+    pub fn igGetColumnsCount() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igBeginTabBar(str_id: *const cty::c_char, flags: ImGuiTabBarFlags) -> bool;
+    pub fn igBeginTabBar(str_id: *const core::ffi::c_char, flags: ImGuiTabBarFlags) -> bool;
 }
 extern "C" {
     pub fn igEndTabBar();
 }
 extern "C" {
     pub fn igBeginTabItem(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
     ) -> bool;
@@ -3459,19 +3486,19 @@ extern "C" {
     pub fn igEndTabItem();
 }
 extern "C" {
-    pub fn igTabItemButton(label: *const cty::c_char, flags: ImGuiTabItemFlags) -> bool;
+    pub fn igTabItemButton(label: *const core::ffi::c_char, flags: ImGuiTabItemFlags) -> bool;
 }
 extern "C" {
-    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const cty::c_char);
+    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLogToTTY(auto_open_depth: cty::c_int);
+    pub fn igLogToTTY(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igLogToFile(auto_open_depth: cty::c_int, filename: *const cty::c_char);
+    pub fn igLogToFile(auto_open_depth: core::ffi::c_int, filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLogToClipboard(auto_open_depth: cty::c_int);
+    pub fn igLogToClipboard(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
     pub fn igLogFinish();
@@ -3484,8 +3511,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igSetDragDropPayload(
-        type_: *const cty::c_char,
-        data: *const cty::c_void,
+        type_: *const core::ffi::c_char,
+        data: *const core::ffi::c_void,
         sz: usize,
         cond: ImGuiCond,
     ) -> bool;
@@ -3498,7 +3525,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igAcceptDragDropPayload(
-        type_: *const cty::c_char,
+        type_: *const core::ffi::c_char,
         flags: ImGuiDragDropFlags,
     ) -> *const ImGuiPayload;
 }
@@ -3528,7 +3555,7 @@ extern "C" {
     pub fn igSetItemDefaultFocus();
 }
 extern "C" {
-    pub fn igSetKeyboardFocusHere(offset: cty::c_int);
+    pub fn igSetKeyboardFocusHere(offset: core::ffi::c_int);
 }
 extern "C" {
     pub fn igSetNextItemAllowOverlap();
@@ -3603,13 +3630,13 @@ extern "C" {
     pub fn igGetTime() -> f64;
 }
 extern "C" {
-    pub fn igGetFrameCount() -> cty::c_int;
+    pub fn igGetFrameCount() -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igGetDrawListSharedData() -> *mut ImDrawListSharedData;
 }
 extern "C" {
-    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const cty::c_char;
+    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetStateStorage(storage: *mut ImGuiStorage);
@@ -3620,8 +3647,8 @@ extern "C" {
 extern "C" {
     pub fn igCalcTextSize(
         pOut: *mut ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_double_hash: bool,
         wrap_width: f32,
     );
@@ -3665,10 +3692,10 @@ extern "C" {
     pub fn igIsKeyChordPressed(key_chord: ImGuiKeyChord) -> bool;
 }
 extern "C" {
-    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> cty::c_int;
+    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igGetKeyName(key: ImGuiKey) -> *const cty::c_char;
+    pub fn igGetKeyName(key: ImGuiKey) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetNextFrameWantCaptureKeyboard(want_capture_keyboard: bool);
@@ -3695,7 +3722,7 @@ extern "C" {
     pub fn igIsMouseDoubleClicked(button: ImGuiMouseButton) -> bool;
 }
 extern "C" {
-    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> cty::c_int;
+    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igIsMouseHoveringRect(r_min: ImVec2, r_max: ImVec2, clip: bool) -> bool;
@@ -3731,25 +3758,25 @@ extern "C" {
     pub fn igSetNextFrameWantCaptureMouse(want_capture_mouse: bool);
 }
 extern "C" {
-    pub fn igGetClipboardText() -> *const cty::c_char;
+    pub fn igGetClipboardText() -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igSetClipboardText(text: *const cty::c_char);
+    pub fn igSetClipboardText(text: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLoadIniSettingsFromDisk(ini_filename: *const cty::c_char);
+    pub fn igLoadIniSettingsFromDisk(ini_filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLoadIniSettingsFromMemory(ini_data: *const cty::c_char, ini_size: usize);
+    pub fn igLoadIniSettingsFromMemory(ini_data: *const core::ffi::c_char, ini_size: usize);
 }
 extern "C" {
-    pub fn igSaveIniSettingsToDisk(ini_filename: *const cty::c_char);
+    pub fn igSaveIniSettingsToDisk(ini_filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const cty::c_char;
+    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igDebugTextEncoding(text: *const cty::c_char);
+    pub fn igDebugTextEncoding(text: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugFlashStyleColor(idx: ImGuiCol);
@@ -3759,7 +3786,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igDebugCheckVersionAndDataLayout(
-        version_str: *const cty::c_char,
+        version_str: *const core::ffi::c_char,
         sz_io: usize,
         sz_style: usize,
         sz_vec2: usize,
@@ -3769,27 +3796,27 @@ extern "C" {
     ) -> bool;
 }
 extern "C" {
-    pub fn igDebugLog(fmt: *const cty::c_char, ...);
+    pub fn igDebugLog(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
     pub fn igSetAllocatorFunctions(
         alloc_func: ImGuiMemAllocFunc,
         free_func: ImGuiMemFreeFunc,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
     pub fn igGetAllocatorFunctions(
         p_alloc_func: *mut ImGuiMemAllocFunc,
         p_free_func: *mut ImGuiMemFreeFunc,
-        p_user_data: *mut *mut cty::c_void,
+        p_user_data: *mut *mut core::ffi::c_void,
     );
 }
 extern "C" {
-    pub fn igMemAlloc(size: usize) -> *mut cty::c_void;
+    pub fn igMemAlloc(size: usize) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn igMemFree(ptr: *mut cty::c_void);
+    pub fn igMemFree(ptr: *mut core::ffi::c_void);
 }
 extern "C" {
     pub fn ImGuiTableSortSpecs_ImGuiTableSortSpecs() -> *mut ImGuiTableSortSpecs;
@@ -3822,7 +3849,7 @@ extern "C" {
     pub fn ImGuiIO_AddMousePosEvent(self_: *mut ImGuiIO, x: f32, y: f32);
 }
 extern "C" {
-    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: cty::c_int, down: bool);
+    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: core::ffi::c_int, down: bool);
 }
 extern "C" {
     pub fn ImGuiIO_AddMouseWheelEvent(self_: *mut ImGuiIO, wheel_x: f32, wheel_y: f32);
@@ -3834,21 +3861,21 @@ extern "C" {
     pub fn ImGuiIO_AddFocusEvent(self_: *mut ImGuiIO, focused: bool);
 }
 extern "C" {
-    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: cty::c_uint);
+    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: core::ffi::c_uint);
 }
 extern "C" {
     pub fn ImGuiIO_AddInputCharacterUTF16(self_: *mut ImGuiIO, c: ImWchar16);
 }
 extern "C" {
-    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const cty::c_char);
+    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn ImGuiIO_SetKeyEventNativeData(
         self_: *mut ImGuiIO,
         key: ImGuiKey,
-        native_keycode: cty::c_int,
-        native_scancode: cty::c_int,
-        native_legacy_index: cty::c_int,
+        native_keycode: core::ffi::c_int,
+        native_scancode: core::ffi::c_int,
+        native_legacy_index: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -3878,16 +3905,16 @@ extern "C" {
 extern "C" {
     pub fn ImGuiInputTextCallbackData_DeleteChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        bytes_count: cty::c_int,
+        pos: core::ffi::c_int,
+        bytes_count: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImGuiInputTextCallbackData_InsertChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        pos: core::ffi::c_int,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -3909,7 +3936,10 @@ extern "C" {
     pub fn ImGuiPayload_Clear(self_: *mut ImGuiPayload);
 }
 extern "C" {
-    pub fn ImGuiPayload_IsDataType(self_: *mut ImGuiPayload, type_: *const cty::c_char) -> bool;
+    pub fn ImGuiPayload_IsDataType(
+        self_: *mut ImGuiPayload,
+        type_: *const core::ffi::c_char,
+    ) -> bool;
 }
 extern "C" {
     pub fn ImGuiPayload_IsPreview(self_: *mut ImGuiPayload) -> bool;
@@ -3925,7 +3955,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiTextFilter_ImGuiTextFilter(
-        default_filter: *const cty::c_char,
+        default_filter: *const core::ffi::c_char,
     ) -> *mut ImGuiTextFilter;
 }
 extern "C" {
@@ -3934,15 +3964,15 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_Draw(
         self_: *mut ImGuiTextFilter,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         width: f32,
     ) -> bool;
 }
 extern "C" {
     pub fn ImGuiTextFilter_PassFilter(
         self_: *mut ImGuiTextFilter,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     ) -> bool;
 }
 extern "C" {
@@ -3962,8 +3992,8 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiTextRange_ImGuiTextRange_Str(
-        _b: *const cty::c_char,
-        _e: *const cty::c_char,
+        _b: *const core::ffi::c_char,
+        _e: *const core::ffi::c_char,
     ) -> *mut ImGuiTextRange;
 }
 extern "C" {
@@ -3972,7 +4002,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextRange_split(
         self_: *mut ImGuiTextRange,
-        separator: cty::c_char,
+        separator: core::ffi::c_char,
         out: *mut ImVector_ImGuiTextRange,
     );
 }
@@ -3983,13 +4013,13 @@ extern "C" {
     pub fn ImGuiTextBuffer_destroy(self_: *mut ImGuiTextBuffer);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> cty::c_int;
+    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiTextBuffer_empty(self_: *mut ImGuiTextBuffer) -> bool;
@@ -3998,22 +4028,22 @@ extern "C" {
     pub fn ImGuiTextBuffer_clear(self_: *mut ImGuiTextBuffer);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: cty::c_int);
+    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiTextBuffer_append(
         self_: *mut ImGuiTextBuffer,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Int(
         _key: ImGuiID,
-        _val: cty::c_int,
+        _val: core::ffi::c_int,
     ) -> *mut ImGuiStoragePair;
 }
 extern "C" {
@@ -4028,7 +4058,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Ptr(
         _key: ImGuiID,
-        _val: *mut cty::c_void,
+        _val: *mut core::ffi::c_void,
     ) -> *mut ImGuiStoragePair;
 }
 extern "C" {
@@ -4038,11 +4068,11 @@ extern "C" {
     pub fn ImGuiStorage_GetInt(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: cty::c_int);
+    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiStorage_GetBool(self_: *mut ImGuiStorage, key: ImGuiID, default_val: bool) -> bool;
@@ -4057,17 +4087,24 @@ extern "C" {
     pub fn ImGuiStorage_SetFloat(self_: *mut ImGuiStorage, key: ImGuiID, val: f32);
 }
 extern "C" {
-    pub fn ImGuiStorage_GetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID) -> *mut cty::c_void;
+    pub fn ImGuiStorage_GetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+    ) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn ImGuiStorage_SetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID, val: *mut cty::c_void);
+    pub fn ImGuiStorage_SetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+        val: *mut core::ffi::c_void,
+    );
 }
 extern "C" {
     pub fn ImGuiStorage_GetIntRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> *mut cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> *mut core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiStorage_GetBoolRef(
@@ -4087,14 +4124,14 @@ extern "C" {
     pub fn ImGuiStorage_GetVoidPtrRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: *mut cty::c_void,
-    ) -> *mut *mut cty::c_void;
+        default_val: *mut core::ffi::c_void,
+    ) -> *mut *mut core::ffi::c_void;
 }
 extern "C" {
     pub fn ImGuiStorage_BuildSortByKey(self_: *mut ImGuiStorage);
 }
 extern "C" {
-    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: cty::c_int);
+    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiListClipper_ImGuiListClipper() -> *mut ImGuiListClipper;
@@ -4105,7 +4142,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_Begin(
         self_: *mut ImGuiListClipper,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         items_height: f32,
     );
 }
@@ -4118,18 +4155,21 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemByIndex(
         self_: *mut ImGuiListClipper,
-        item_index: cty::c_int,
+        item_index: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemsByIndex(
         self_: *mut ImGuiListClipper,
-        item_begin: cty::c_int,
-        item_end: cty::c_int,
+        item_begin: core::ffi::c_int,
+        item_end: core::ffi::c_int,
     );
 }
 extern "C" {
-    pub fn ImGuiListClipper_SeekCursorForItem(self_: *mut ImGuiListClipper, item_index: cty::c_int);
+    pub fn ImGuiListClipper_SeekCursorForItem(
+        self_: *mut ImGuiListClipper,
+        item_index: core::ffi::c_int,
+    );
 }
 extern "C" {
     pub fn ImColor_ImColor_Nil() -> *mut ImColor;
@@ -4145,10 +4185,10 @@ extern "C" {
 }
 extern "C" {
     pub fn ImColor_ImColor_Int(
-        r: cty::c_int,
-        g: cty::c_int,
-        b: cty::c_int,
-        a: cty::c_int,
+        r: core::ffi::c_int,
+        g: core::ffi::c_int,
+        b: core::ffi::c_int,
+        a: core::ffi::c_int,
     ) -> *mut ImColor;
 }
 extern "C" {
@@ -4197,14 +4237,14 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetNextSelectedItem(
         self_: *mut ImGuiSelectionBasicStorage,
-        opaque_it: *mut *mut cty::c_void,
+        opaque_it: *mut *mut core::ffi::c_void,
         out_id: *mut ImGuiID,
     ) -> bool;
 }
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetStorageIdFromIndex(
         self_: *mut ImGuiSelectionBasicStorage,
-        idx: cty::c_int,
+        idx: core::ffi::c_int,
     ) -> ImGuiID;
 }
 extern "C" {
@@ -4245,7 +4285,7 @@ extern "C" {
     pub fn ImDrawListSplitter_Split(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        count: cty::c_int,
+        count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4255,7 +4295,7 @@ extern "C" {
     pub fn ImDrawListSplitter_SetCurrentChannel(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        channel_idx: cty::c_int,
+        channel_idx: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4377,7 +4417,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4387,7 +4427,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4396,7 +4436,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4406,7 +4446,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4416,7 +4456,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4427,7 +4467,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4435,8 +4475,8 @@ extern "C" {
         self_: *mut ImDrawList,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -4446,8 +4486,8 @@ extern "C" {
         font_size: f32,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip_rect: *const ImVec4,
     );
@@ -4461,7 +4501,7 @@ extern "C" {
         p4: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4472,14 +4512,14 @@ extern "C" {
         p3: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImDrawList_AddPolyline(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
         flags: ImDrawFlags,
         thickness: f32,
@@ -4489,7 +4529,7 @@ extern "C" {
     pub fn ImDrawList_AddConvexPolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -4497,7 +4537,7 @@ extern "C" {
     pub fn ImDrawList_AddConcavePolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -4570,7 +4610,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4578,8 +4618,8 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_of_12: cty::c_int,
-        a_max_of_12: cty::c_int,
+        a_min_of_12: core::ffi::c_int,
+        a_max_of_12: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4590,7 +4630,7 @@ extern "C" {
         rot: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4599,7 +4639,7 @@ extern "C" {
         p2: ImVec2,
         p3: ImVec2,
         p4: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4607,7 +4647,7 @@ extern "C" {
         self_: *mut ImDrawList,
         p2: ImVec2,
         p3: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4623,7 +4663,7 @@ extern "C" {
     pub fn ImDrawList_AddCallback(
         self_: *mut ImDrawList,
         callback: ImDrawCallback,
-        callback_data: *mut cty::c_void,
+        callback_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -4633,26 +4673,26 @@ extern "C" {
     pub fn ImDrawList_CloneOutput(self_: *mut ImDrawList) -> *mut ImDrawList;
 }
 extern "C" {
-    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: cty::c_int);
+    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImDrawList_ChannelsMerge(self_: *mut ImDrawList);
 }
 extern "C" {
-    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: cty::c_int);
+    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImDrawList_PrimReserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImDrawList_PrimUnreserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4719,16 +4759,16 @@ extern "C" {
     pub fn ImDrawList__CalcCircleAutoSegmentCount(
         self_: *mut ImDrawList,
         radius: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImDrawList__PathArcToFastEx(
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_sample: cty::c_int,
-        a_max_sample: cty::c_int,
-        a_step: cty::c_int,
+        a_min_sample: core::ffi::c_int,
+        a_max_sample: core::ffi::c_int,
+        a_step: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4738,7 +4778,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4786,8 +4826,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontGlyphRangesBuilder_AddText(
         self_: *mut ImFontGlyphRangesBuilder,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -4832,7 +4872,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromFileTTF(
         self_: *mut ImFontAtlas,
-        filename: *const cty::c_char,
+        filename: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -4841,8 +4881,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryTTF(
         self_: *mut ImFontAtlas,
-        font_data: *mut cty::c_void,
-        font_data_size: cty::c_int,
+        font_data: *mut core::ffi::c_void,
+        font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -4851,8 +4891,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedTTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data: *const cty::c_void,
-        compressed_font_data_size: cty::c_int,
+        compressed_font_data: *const core::ffi::c_void,
+        compressed_font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -4861,7 +4901,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data_base85: *const cty::c_char,
+        compressed_font_data_base85: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -4885,19 +4925,19 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsAlpha8(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsRGBA32(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4938,25 +4978,25 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectRegular(
         self_: *mut ImFontAtlas,
-        width: cty::c_int,
-        height: cty::c_int,
-    ) -> cty::c_int;
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectFontGlyph(
         self_: *mut ImFontAtlas,
         font: *mut ImFont,
         id: ImWchar,
-        width: cty::c_int,
-        height: cty::c_int,
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
         advance_x: f32,
         offset: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImFontAtlas_GetCustomRectByIndex(
         self_: *mut ImFontAtlas,
-        index: cty::c_int,
+        index: core::ffi::c_int,
     ) -> *mut ImFontAtlasCustomRect;
 }
 extern "C" {
@@ -4996,7 +5036,7 @@ extern "C" {
     pub fn ImFont_IsLoaded(self_: *mut ImFont) -> bool;
 }
 extern "C" {
-    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const cty::c_char;
+    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImFont_CalcTextSizeA(
@@ -5005,19 +5045,19 @@ extern "C" {
         size: f32,
         max_width: f32,
         wrap_width: f32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
-        remaining: *mut *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        remaining: *mut *const core::ffi::c_char,
     );
 }
 extern "C" {
     pub fn ImFont_CalcWordWrapPositionA(
         self_: *mut ImFont,
         scale: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImFont_RenderChar(
@@ -5037,8 +5077,8 @@ extern "C" {
         pos: ImVec2,
         col: ImU32,
         clip_rect: ImVec4,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip: bool,
     );
@@ -5050,7 +5090,7 @@ extern "C" {
     pub fn ImFont_ClearOutputData(self_: *mut ImFont);
 }
 extern "C" {
-    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: cty::c_int);
+    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImFont_AddGlyph(
@@ -5077,8 +5117,8 @@ extern "C" {
 extern "C" {
     pub fn ImFont_IsGlyphRangeUnused(
         self_: *mut ImFont,
-        c_begin: cty::c_uint,
-        c_last: cty::c_uint,
+        c_begin: core::ffi::c_uint,
+        c_last: core::ffi::c_uint,
     ) -> bool;
 }
 extern "C" {
@@ -5106,8 +5146,12 @@ extern "C" {
     pub fn ImGuiPlatformImeData_destroy(self_: *mut ImGuiPlatformImeData);
 }
 extern "C" {
-    pub fn igLogText(fmt: *const cty::c_char, ...);
+    pub fn igLogText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_appendf(buffer: *mut ImGuiTextBuffer, fmt: *const cty::c_char, ...);
+    pub fn ImGuiTextBuffer_appendf(
+        buffer: *mut ImGuiTextBuffer,
+        fmt: *const core::ffi::c_char,
+        ...
+    );
 }

--- a/imgui-sys/src/docking_bindings.rs
+++ b/imgui-sys/src/docking_bindings.rs
@@ -82,14 +82,14 @@ where
         }
     }
 }
-pub type __int64_t = cty::c_longlong;
+pub type __int64_t = core::ffi::c_longlong;
 pub type __darwin_off_t = __int64_t;
 pub type fpos_t = __darwin_off_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct __sbuf {
-    pub _base: *mut cty::c_uchar,
-    pub _size: cty::c_int,
+    pub _base: *mut core::ffi::c_uchar,
+    pub _size: core::ffi::c_int,
 }
 impl Default for __sbuf {
     fn default() -> Self {
@@ -108,39 +108,45 @@ pub struct __sFILEX {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct __sFILE {
-    pub _p: *mut cty::c_uchar,
-    pub _r: cty::c_int,
-    pub _w: cty::c_int,
-    pub _flags: cty::c_short,
-    pub _file: cty::c_short,
+    pub _p: *mut core::ffi::c_uchar,
+    pub _r: core::ffi::c_int,
+    pub _w: core::ffi::c_int,
+    pub _flags: core::ffi::c_short,
+    pub _file: core::ffi::c_short,
     pub _bf: __sbuf,
-    pub _lbfsize: cty::c_int,
-    pub _cookie: *mut cty::c_void,
-    pub _close: ::core::option::Option<unsafe extern "C" fn(arg1: *mut cty::c_void) -> cty::c_int>,
+    pub _lbfsize: core::ffi::c_int,
+    pub _cookie: *mut core::ffi::c_void,
+    pub _close: ::core::option::Option<
+        unsafe extern "C" fn(arg1: *mut core::ffi::c_void) -> core::ffi::c_int,
+    >,
     pub _read: ::core::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cty::c_void,
-            arg2: *mut cty::c_char,
-            arg3: cty::c_int,
-        ) -> cty::c_int,
+            arg1: *mut core::ffi::c_void,
+            arg2: *mut core::ffi::c_char,
+            arg3: core::ffi::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub _seek: ::core::option::Option<
-        unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: fpos_t, arg3: cty::c_int) -> fpos_t,
+        unsafe extern "C" fn(
+            arg1: *mut core::ffi::c_void,
+            arg2: fpos_t,
+            arg3: core::ffi::c_int,
+        ) -> fpos_t,
     >,
     pub _write: ::core::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cty::c_void,
-            arg2: *const cty::c_char,
-            arg3: cty::c_int,
-        ) -> cty::c_int,
+            arg1: *mut core::ffi::c_void,
+            arg2: *const core::ffi::c_char,
+            arg3: core::ffi::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub _ub: __sbuf,
     pub _extra: *mut __sFILEX,
-    pub _ur: cty::c_int,
-    pub _ubuf: [cty::c_uchar; 3usize],
-    pub _nbuf: [cty::c_uchar; 1usize],
+    pub _ur: core::ffi::c_int,
+    pub _ubuf: [core::ffi::c_uchar; 3usize],
+    pub _nbuf: [core::ffi::c_uchar; 1usize],
     pub _lb: __sbuf,
-    pub _blksize: cty::c_int,
+    pub _blksize: core::ffi::c_int,
     pub _offset: fpos_t,
 }
 impl Default for __sFILE {
@@ -171,9 +177,9 @@ pub struct STB_TexteditState {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_const_charPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut *const cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut *const core::ffi::c_char,
 }
 impl Default for ImVector_const_charPtr {
     fn default() -> Self {
@@ -184,67 +190,67 @@ impl Default for ImVector_const_charPtr {
         }
     }
 }
-pub type ImGuiID = cty::c_uint;
-pub type ImS8 = cty::c_schar;
-pub type ImU8 = cty::c_uchar;
-pub type ImS16 = cty::c_short;
-pub type ImU16 = cty::c_ushort;
-pub type ImS32 = cty::c_int;
-pub type ImU32 = cty::c_uint;
-pub type ImS64 = cty::c_longlong;
-pub type ImU64 = cty::c_ulonglong;
-pub type ImGuiCol = cty::c_int;
-pub type ImGuiCond = cty::c_int;
-pub type ImGuiDataType = cty::c_int;
-pub type ImGuiMouseButton = cty::c_int;
-pub type ImGuiMouseCursor = cty::c_int;
-pub type ImGuiStyleVar = cty::c_int;
-pub type ImGuiTableBgTarget = cty::c_int;
-pub type ImDrawFlags = cty::c_int;
-pub type ImDrawListFlags = cty::c_int;
-pub type ImFontAtlasFlags = cty::c_int;
-pub type ImGuiBackendFlags = cty::c_int;
-pub type ImGuiButtonFlags = cty::c_int;
-pub type ImGuiChildFlags = cty::c_int;
-pub type ImGuiColorEditFlags = cty::c_int;
-pub type ImGuiConfigFlags = cty::c_int;
-pub type ImGuiComboFlags = cty::c_int;
-pub type ImGuiDockNodeFlags = cty::c_int;
-pub type ImGuiDragDropFlags = cty::c_int;
-pub type ImGuiFocusedFlags = cty::c_int;
-pub type ImGuiHoveredFlags = cty::c_int;
-pub type ImGuiInputFlags = cty::c_int;
-pub type ImGuiInputTextFlags = cty::c_int;
-pub type ImGuiItemFlags = cty::c_int;
-pub type ImGuiKeyChord = cty::c_int;
-pub type ImGuiPopupFlags = cty::c_int;
-pub type ImGuiMultiSelectFlags = cty::c_int;
-pub type ImGuiSelectableFlags = cty::c_int;
-pub type ImGuiSliderFlags = cty::c_int;
-pub type ImGuiTabBarFlags = cty::c_int;
-pub type ImGuiTabItemFlags = cty::c_int;
-pub type ImGuiTableFlags = cty::c_int;
-pub type ImGuiTableColumnFlags = cty::c_int;
-pub type ImGuiTableRowFlags = cty::c_int;
-pub type ImGuiTreeNodeFlags = cty::c_int;
-pub type ImGuiViewportFlags = cty::c_int;
-pub type ImGuiWindowFlags = cty::c_int;
-pub type ImTextureID = *mut cty::c_void;
-pub type ImDrawIdx = cty::c_ushort;
-pub type ImWchar32 = cty::c_uint;
-pub type ImWchar16 = cty::c_ushort;
+pub type ImGuiID = core::ffi::c_uint;
+pub type ImS8 = core::ffi::c_schar;
+pub type ImU8 = core::ffi::c_uchar;
+pub type ImS16 = core::ffi::c_short;
+pub type ImU16 = core::ffi::c_ushort;
+pub type ImS32 = core::ffi::c_int;
+pub type ImU32 = core::ffi::c_uint;
+pub type ImS64 = core::ffi::c_longlong;
+pub type ImU64 = core::ffi::c_ulonglong;
+pub type ImGuiCol = core::ffi::c_int;
+pub type ImGuiCond = core::ffi::c_int;
+pub type ImGuiDataType = core::ffi::c_int;
+pub type ImGuiMouseButton = core::ffi::c_int;
+pub type ImGuiMouseCursor = core::ffi::c_int;
+pub type ImGuiStyleVar = core::ffi::c_int;
+pub type ImGuiTableBgTarget = core::ffi::c_int;
+pub type ImDrawFlags = core::ffi::c_int;
+pub type ImDrawListFlags = core::ffi::c_int;
+pub type ImFontAtlasFlags = core::ffi::c_int;
+pub type ImGuiBackendFlags = core::ffi::c_int;
+pub type ImGuiButtonFlags = core::ffi::c_int;
+pub type ImGuiChildFlags = core::ffi::c_int;
+pub type ImGuiColorEditFlags = core::ffi::c_int;
+pub type ImGuiConfigFlags = core::ffi::c_int;
+pub type ImGuiComboFlags = core::ffi::c_int;
+pub type ImGuiDockNodeFlags = core::ffi::c_int;
+pub type ImGuiDragDropFlags = core::ffi::c_int;
+pub type ImGuiFocusedFlags = core::ffi::c_int;
+pub type ImGuiHoveredFlags = core::ffi::c_int;
+pub type ImGuiInputFlags = core::ffi::c_int;
+pub type ImGuiInputTextFlags = core::ffi::c_int;
+pub type ImGuiItemFlags = core::ffi::c_int;
+pub type ImGuiKeyChord = core::ffi::c_int;
+pub type ImGuiPopupFlags = core::ffi::c_int;
+pub type ImGuiMultiSelectFlags = core::ffi::c_int;
+pub type ImGuiSelectableFlags = core::ffi::c_int;
+pub type ImGuiSliderFlags = core::ffi::c_int;
+pub type ImGuiTabBarFlags = core::ffi::c_int;
+pub type ImGuiTabItemFlags = core::ffi::c_int;
+pub type ImGuiTableFlags = core::ffi::c_int;
+pub type ImGuiTableColumnFlags = core::ffi::c_int;
+pub type ImGuiTableRowFlags = core::ffi::c_int;
+pub type ImGuiTreeNodeFlags = core::ffi::c_int;
+pub type ImGuiViewportFlags = core::ffi::c_int;
+pub type ImGuiWindowFlags = core::ffi::c_int;
+pub type ImTextureID = *mut core::ffi::c_void;
+pub type ImDrawIdx = core::ffi::c_ushort;
+pub type ImWchar32 = core::ffi::c_uint;
+pub type ImWchar16 = core::ffi::c_ushort;
 pub type ImWchar = ImWchar32;
 pub type ImGuiSelectionUserData = ImS64;
 pub type ImGuiInputTextCallback = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> cty::c_int,
+    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> core::ffi::c_int,
 >;
 pub type ImGuiSizeCallback =
     ::core::option::Option<unsafe extern "C" fn(data: *mut ImGuiSizeCallbackData)>;
 pub type ImGuiMemAllocFunc = ::core::option::Option<
-    unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+    unsafe extern "C" fn(sz: usize, user_data: *mut core::ffi::c_void) -> *mut core::ffi::c_void,
 >;
 pub type ImGuiMemFreeFunc = ::core::option::Option<
-    unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+    unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -290,7 +296,7 @@ pub const ImGuiWindowFlags_Popup: ImGuiWindowFlags_ = 67108864;
 pub const ImGuiWindowFlags_Modal: ImGuiWindowFlags_ = 134217728;
 pub const ImGuiWindowFlags_ChildMenu: ImGuiWindowFlags_ = 268435456;
 pub const ImGuiWindowFlags_DockNodeHost: ImGuiWindowFlags_ = 536870912;
-pub type ImGuiWindowFlags_ = cty::c_uint;
+pub type ImGuiWindowFlags_ = core::ffi::c_uint;
 pub const ImGuiChildFlags_None: ImGuiChildFlags_ = 0;
 pub const ImGuiChildFlags_Borders: ImGuiChildFlags_ = 1;
 pub const ImGuiChildFlags_AlwaysUseWindowPadding: ImGuiChildFlags_ = 2;
@@ -301,7 +307,7 @@ pub const ImGuiChildFlags_AutoResizeY: ImGuiChildFlags_ = 32;
 pub const ImGuiChildFlags_AlwaysAutoResize: ImGuiChildFlags_ = 64;
 pub const ImGuiChildFlags_FrameStyle: ImGuiChildFlags_ = 128;
 pub const ImGuiChildFlags_NavFlattened: ImGuiChildFlags_ = 256;
-pub type ImGuiChildFlags_ = cty::c_uint;
+pub type ImGuiChildFlags_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_None: ImGuiItemFlags_ = 0;
 pub const ImGuiItemFlags_NoTabStop: ImGuiItemFlags_ = 1;
 pub const ImGuiItemFlags_NoNav: ImGuiItemFlags_ = 2;
@@ -309,7 +315,7 @@ pub const ImGuiItemFlags_NoNavDefaultFocus: ImGuiItemFlags_ = 4;
 pub const ImGuiItemFlags_ButtonRepeat: ImGuiItemFlags_ = 8;
 pub const ImGuiItemFlags_AutoClosePopups: ImGuiItemFlags_ = 16;
 pub const ImGuiItemFlags_AllowDuplicateId: ImGuiItemFlags_ = 32;
-pub type ImGuiItemFlags_ = cty::c_uint;
+pub type ImGuiItemFlags_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_None: ImGuiInputTextFlags_ = 0;
 pub const ImGuiInputTextFlags_CharsDecimal: ImGuiInputTextFlags_ = 1;
 pub const ImGuiInputTextFlags_CharsHexadecimal: ImGuiInputTextFlags_ = 2;
@@ -334,7 +340,7 @@ pub const ImGuiInputTextFlags_CallbackAlways: ImGuiInputTextFlags_ = 524288;
 pub const ImGuiInputTextFlags_CallbackCharFilter: ImGuiInputTextFlags_ = 1048576;
 pub const ImGuiInputTextFlags_CallbackResize: ImGuiInputTextFlags_ = 2097152;
 pub const ImGuiInputTextFlags_CallbackEdit: ImGuiInputTextFlags_ = 4194304;
-pub type ImGuiInputTextFlags_ = cty::c_uint;
+pub type ImGuiInputTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_None: ImGuiTreeNodeFlags_ = 0;
 pub const ImGuiTreeNodeFlags_Selected: ImGuiTreeNodeFlags_ = 1;
 pub const ImGuiTreeNodeFlags_Framed: ImGuiTreeNodeFlags_ = 2;
@@ -353,7 +359,7 @@ pub const ImGuiTreeNodeFlags_SpanTextWidth: ImGuiTreeNodeFlags_ = 8192;
 pub const ImGuiTreeNodeFlags_SpanAllColumns: ImGuiTreeNodeFlags_ = 16384;
 pub const ImGuiTreeNodeFlags_NavLeftJumpsBackHere: ImGuiTreeNodeFlags_ = 32768;
 pub const ImGuiTreeNodeFlags_CollapsingHeader: ImGuiTreeNodeFlags_ = 26;
-pub type ImGuiTreeNodeFlags_ = cty::c_uint;
+pub type ImGuiTreeNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiPopupFlags_None: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonLeft: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonRight: ImGuiPopupFlags_ = 1;
@@ -366,7 +372,7 @@ pub const ImGuiPopupFlags_NoOpenOverItems: ImGuiPopupFlags_ = 256;
 pub const ImGuiPopupFlags_AnyPopupId: ImGuiPopupFlags_ = 1024;
 pub const ImGuiPopupFlags_AnyPopupLevel: ImGuiPopupFlags_ = 2048;
 pub const ImGuiPopupFlags_AnyPopup: ImGuiPopupFlags_ = 3072;
-pub type ImGuiPopupFlags_ = cty::c_uint;
+pub type ImGuiPopupFlags_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_None: ImGuiSelectableFlags_ = 0;
 pub const ImGuiSelectableFlags_NoAutoClosePopups: ImGuiSelectableFlags_ = 1;
 pub const ImGuiSelectableFlags_SpanAllColumns: ImGuiSelectableFlags_ = 2;
@@ -374,7 +380,7 @@ pub const ImGuiSelectableFlags_AllowDoubleClick: ImGuiSelectableFlags_ = 4;
 pub const ImGuiSelectableFlags_Disabled: ImGuiSelectableFlags_ = 8;
 pub const ImGuiSelectableFlags_AllowOverlap: ImGuiSelectableFlags_ = 16;
 pub const ImGuiSelectableFlags_Highlight: ImGuiSelectableFlags_ = 32;
-pub type ImGuiSelectableFlags_ = cty::c_uint;
+pub type ImGuiSelectableFlags_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_None: ImGuiComboFlags_ = 0;
 pub const ImGuiComboFlags_PopupAlignLeft: ImGuiComboFlags_ = 1;
 pub const ImGuiComboFlags_HeightSmall: ImGuiComboFlags_ = 2;
@@ -385,7 +391,7 @@ pub const ImGuiComboFlags_NoArrowButton: ImGuiComboFlags_ = 32;
 pub const ImGuiComboFlags_NoPreview: ImGuiComboFlags_ = 64;
 pub const ImGuiComboFlags_WidthFitPreview: ImGuiComboFlags_ = 128;
 pub const ImGuiComboFlags_HeightMask_: ImGuiComboFlags_ = 30;
-pub type ImGuiComboFlags_ = cty::c_uint;
+pub type ImGuiComboFlags_ = core::ffi::c_uint;
 pub const ImGuiTabBarFlags_None: ImGuiTabBarFlags_ = 0;
 pub const ImGuiTabBarFlags_Reorderable: ImGuiTabBarFlags_ = 1;
 pub const ImGuiTabBarFlags_AutoSelectNewTabs: ImGuiTabBarFlags_ = 2;
@@ -398,7 +404,7 @@ pub const ImGuiTabBarFlags_FittingPolicyResizeDown: ImGuiTabBarFlags_ = 128;
 pub const ImGuiTabBarFlags_FittingPolicyScroll: ImGuiTabBarFlags_ = 256;
 pub const ImGuiTabBarFlags_FittingPolicyMask_: ImGuiTabBarFlags_ = 384;
 pub const ImGuiTabBarFlags_FittingPolicyDefault_: ImGuiTabBarFlags_ = 128;
-pub type ImGuiTabBarFlags_ = cty::c_uint;
+pub type ImGuiTabBarFlags_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_None: ImGuiTabItemFlags_ = 0;
 pub const ImGuiTabItemFlags_UnsavedDocument: ImGuiTabItemFlags_ = 1;
 pub const ImGuiTabItemFlags_SetSelected: ImGuiTabItemFlags_ = 2;
@@ -409,7 +415,7 @@ pub const ImGuiTabItemFlags_NoReorder: ImGuiTabItemFlags_ = 32;
 pub const ImGuiTabItemFlags_Leading: ImGuiTabItemFlags_ = 64;
 pub const ImGuiTabItemFlags_Trailing: ImGuiTabItemFlags_ = 128;
 pub const ImGuiTabItemFlags_NoAssumedClosure: ImGuiTabItemFlags_ = 256;
-pub type ImGuiTabItemFlags_ = cty::c_uint;
+pub type ImGuiTabItemFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusedFlags_None: ImGuiFocusedFlags_ = 0;
 pub const ImGuiFocusedFlags_ChildWindows: ImGuiFocusedFlags_ = 1;
 pub const ImGuiFocusedFlags_RootWindow: ImGuiFocusedFlags_ = 2;
@@ -417,7 +423,7 @@ pub const ImGuiFocusedFlags_AnyWindow: ImGuiFocusedFlags_ = 4;
 pub const ImGuiFocusedFlags_NoPopupHierarchy: ImGuiFocusedFlags_ = 8;
 pub const ImGuiFocusedFlags_DockHierarchy: ImGuiFocusedFlags_ = 16;
 pub const ImGuiFocusedFlags_RootAndChildWindows: ImGuiFocusedFlags_ = 3;
-pub type ImGuiFocusedFlags_ = cty::c_uint;
+pub type ImGuiFocusedFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_None: ImGuiHoveredFlags_ = 0;
 pub const ImGuiHoveredFlags_ChildWindows: ImGuiHoveredFlags_ = 1;
 pub const ImGuiHoveredFlags_RootWindow: ImGuiHoveredFlags_ = 2;
@@ -439,7 +445,7 @@ pub const ImGuiHoveredFlags_DelayNone: ImGuiHoveredFlags_ = 16384;
 pub const ImGuiHoveredFlags_DelayShort: ImGuiHoveredFlags_ = 32768;
 pub const ImGuiHoveredFlags_DelayNormal: ImGuiHoveredFlags_ = 65536;
 pub const ImGuiHoveredFlags_NoSharedDelay: ImGuiHoveredFlags_ = 131072;
-pub type ImGuiHoveredFlags_ = cty::c_uint;
+pub type ImGuiHoveredFlags_ = core::ffi::c_uint;
 pub const ImGuiDockNodeFlags_None: ImGuiDockNodeFlags_ = 0;
 pub const ImGuiDockNodeFlags_KeepAliveOnly: ImGuiDockNodeFlags_ = 1;
 pub const ImGuiDockNodeFlags_NoDockingOverCentralNode: ImGuiDockNodeFlags_ = 4;
@@ -448,7 +454,7 @@ pub const ImGuiDockNodeFlags_NoDockingSplit: ImGuiDockNodeFlags_ = 16;
 pub const ImGuiDockNodeFlags_NoResize: ImGuiDockNodeFlags_ = 32;
 pub const ImGuiDockNodeFlags_AutoHideTabBar: ImGuiDockNodeFlags_ = 64;
 pub const ImGuiDockNodeFlags_NoUndocking: ImGuiDockNodeFlags_ = 128;
-pub type ImGuiDockNodeFlags_ = cty::c_uint;
+pub type ImGuiDockNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiDragDropFlags_None: ImGuiDragDropFlags_ = 0;
 pub const ImGuiDragDropFlags_SourceNoPreviewTooltip: ImGuiDragDropFlags_ = 1;
 pub const ImGuiDragDropFlags_SourceNoDisableHover: ImGuiDragDropFlags_ = 2;
@@ -462,7 +468,7 @@ pub const ImGuiDragDropFlags_AcceptBeforeDelivery: ImGuiDragDropFlags_ = 1024;
 pub const ImGuiDragDropFlags_AcceptNoDrawDefaultRect: ImGuiDragDropFlags_ = 2048;
 pub const ImGuiDragDropFlags_AcceptNoPreviewTooltip: ImGuiDragDropFlags_ = 4096;
 pub const ImGuiDragDropFlags_AcceptPeekOnly: ImGuiDragDropFlags_ = 3072;
-pub type ImGuiDragDropFlags_ = cty::c_uint;
+pub type ImGuiDragDropFlags_ = core::ffi::c_uint;
 pub const ImGuiDataType_S8: ImGuiDataType_ = 0;
 pub const ImGuiDataType_U8: ImGuiDataType_ = 1;
 pub const ImGuiDataType_S16: ImGuiDataType_ = 2;
@@ -475,18 +481,18 @@ pub const ImGuiDataType_Float: ImGuiDataType_ = 8;
 pub const ImGuiDataType_Double: ImGuiDataType_ = 9;
 pub const ImGuiDataType_Bool: ImGuiDataType_ = 10;
 pub const ImGuiDataType_COUNT: ImGuiDataType_ = 11;
-pub type ImGuiDataType_ = cty::c_uint;
+pub type ImGuiDataType_ = core::ffi::c_uint;
 pub const ImGuiDir_None: ImGuiDir = -1;
 pub const ImGuiDir_Left: ImGuiDir = 0;
 pub const ImGuiDir_Right: ImGuiDir = 1;
 pub const ImGuiDir_Up: ImGuiDir = 2;
 pub const ImGuiDir_Down: ImGuiDir = 3;
 pub const ImGuiDir_COUNT: ImGuiDir = 4;
-pub type ImGuiDir = cty::c_int;
+pub type ImGuiDir = core::ffi::c_int;
 pub const ImGuiSortDirection_None: ImGuiSortDirection = 0;
 pub const ImGuiSortDirection_Ascending: ImGuiSortDirection = 1;
 pub const ImGuiSortDirection_Descending: ImGuiSortDirection = 2;
-pub type ImGuiSortDirection = cty::c_uint;
+pub type ImGuiSortDirection = core::ffi::c_uint;
 pub const ImGuiKey_None: ImGuiKey = 0;
 pub const ImGuiKey_Tab: ImGuiKey = 512;
 pub const ImGuiKey_LeftArrow: ImGuiKey = 513;
@@ -654,7 +660,7 @@ pub const ImGuiKey_NamedKey_END: ImGuiKey = 666;
 pub const ImGuiKey_NamedKey_COUNT: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_SIZE: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_OFFSET: ImGuiKey = 512;
-pub type ImGuiKey = cty::c_uint;
+pub type ImGuiKey = core::ffi::c_uint;
 pub const ImGuiInputFlags_None: ImGuiInputFlags_ = 0;
 pub const ImGuiInputFlags_Repeat: ImGuiInputFlags_ = 1;
 pub const ImGuiInputFlags_RouteActive: ImGuiInputFlags_ = 1024;
@@ -666,7 +672,7 @@ pub const ImGuiInputFlags_RouteOverActive: ImGuiInputFlags_ = 32768;
 pub const ImGuiInputFlags_RouteUnlessBgFocused: ImGuiInputFlags_ = 65536;
 pub const ImGuiInputFlags_RouteFromRootWindow: ImGuiInputFlags_ = 131072;
 pub const ImGuiInputFlags_Tooltip: ImGuiInputFlags_ = 262144;
-pub type ImGuiInputFlags_ = cty::c_uint;
+pub type ImGuiInputFlags_ = core::ffi::c_uint;
 pub const ImGuiConfigFlags_None: ImGuiConfigFlags_ = 0;
 pub const ImGuiConfigFlags_NavEnableKeyboard: ImGuiConfigFlags_ = 1;
 pub const ImGuiConfigFlags_NavEnableGamepad: ImGuiConfigFlags_ = 2;
@@ -681,7 +687,7 @@ pub const ImGuiConfigFlags_DpiEnableScaleViewports: ImGuiConfigFlags_ = 16384;
 pub const ImGuiConfigFlags_DpiEnableScaleFonts: ImGuiConfigFlags_ = 32768;
 pub const ImGuiConfigFlags_IsSRGB: ImGuiConfigFlags_ = 1048576;
 pub const ImGuiConfigFlags_IsTouchScreen: ImGuiConfigFlags_ = 2097152;
-pub type ImGuiConfigFlags_ = cty::c_uint;
+pub type ImGuiConfigFlags_ = core::ffi::c_uint;
 pub const ImGuiBackendFlags_None: ImGuiBackendFlags_ = 0;
 pub const ImGuiBackendFlags_HasGamepad: ImGuiBackendFlags_ = 1;
 pub const ImGuiBackendFlags_HasMouseCursors: ImGuiBackendFlags_ = 2;
@@ -690,7 +696,7 @@ pub const ImGuiBackendFlags_RendererHasVtxOffset: ImGuiBackendFlags_ = 8;
 pub const ImGuiBackendFlags_PlatformHasViewports: ImGuiBackendFlags_ = 1024;
 pub const ImGuiBackendFlags_HasMouseHoveredViewport: ImGuiBackendFlags_ = 2048;
 pub const ImGuiBackendFlags_RendererHasViewports: ImGuiBackendFlags_ = 4096;
-pub type ImGuiBackendFlags_ = cty::c_uint;
+pub type ImGuiBackendFlags_ = core::ffi::c_uint;
 pub const ImGuiCol_Text: ImGuiCol_ = 0;
 pub const ImGuiCol_TextDisabled: ImGuiCol_ = 1;
 pub const ImGuiCol_WindowBg: ImGuiCol_ = 2;
@@ -750,7 +756,7 @@ pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 55;
 pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 56;
 pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 57;
 pub const ImGuiCol_COUNT: ImGuiCol_ = 58;
-pub type ImGuiCol_ = cty::c_uint;
+pub type ImGuiCol_ = core::ffi::c_uint;
 pub const ImGuiStyleVar_Alpha: ImGuiStyleVar_ = 0;
 pub const ImGuiStyleVar_DisabledAlpha: ImGuiStyleVar_ = 1;
 pub const ImGuiStyleVar_WindowPadding: ImGuiStyleVar_ = 2;
@@ -786,13 +792,13 @@ pub const ImGuiStyleVar_SeparatorTextAlign: ImGuiStyleVar_ = 31;
 pub const ImGuiStyleVar_SeparatorTextPadding: ImGuiStyleVar_ = 32;
 pub const ImGuiStyleVar_DockingSeparatorSize: ImGuiStyleVar_ = 33;
 pub const ImGuiStyleVar_COUNT: ImGuiStyleVar_ = 34;
-pub type ImGuiStyleVar_ = cty::c_uint;
+pub type ImGuiStyleVar_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_None: ImGuiButtonFlags_ = 0;
 pub const ImGuiButtonFlags_MouseButtonLeft: ImGuiButtonFlags_ = 1;
 pub const ImGuiButtonFlags_MouseButtonRight: ImGuiButtonFlags_ = 2;
 pub const ImGuiButtonFlags_MouseButtonMiddle: ImGuiButtonFlags_ = 4;
 pub const ImGuiButtonFlags_MouseButtonMask_: ImGuiButtonFlags_ = 7;
-pub type ImGuiButtonFlags_ = cty::c_uint;
+pub type ImGuiButtonFlags_ = core::ffi::c_uint;
 pub const ImGuiColorEditFlags_None: ImGuiColorEditFlags_ = 0;
 pub const ImGuiColorEditFlags_NoAlpha: ImGuiColorEditFlags_ = 2;
 pub const ImGuiColorEditFlags_NoPicker: ImGuiColorEditFlags_ = 4;
@@ -822,7 +828,7 @@ pub const ImGuiColorEditFlags_DisplayMask_: ImGuiColorEditFlags_ = 7340032;
 pub const ImGuiColorEditFlags_DataTypeMask_: ImGuiColorEditFlags_ = 25165824;
 pub const ImGuiColorEditFlags_PickerMask_: ImGuiColorEditFlags_ = 100663296;
 pub const ImGuiColorEditFlags_InputMask_: ImGuiColorEditFlags_ = 402653184;
-pub type ImGuiColorEditFlags_ = cty::c_uint;
+pub type ImGuiColorEditFlags_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_None: ImGuiSliderFlags_ = 0;
 pub const ImGuiSliderFlags_Logarithmic: ImGuiSliderFlags_ = 32;
 pub const ImGuiSliderFlags_NoRoundToFormat: ImGuiSliderFlags_ = 64;
@@ -832,12 +838,12 @@ pub const ImGuiSliderFlags_ClampOnInput: ImGuiSliderFlags_ = 512;
 pub const ImGuiSliderFlags_ClampZeroRange: ImGuiSliderFlags_ = 1024;
 pub const ImGuiSliderFlags_AlwaysClamp: ImGuiSliderFlags_ = 1536;
 pub const ImGuiSliderFlags_InvalidMask_: ImGuiSliderFlags_ = 1879048207;
-pub type ImGuiSliderFlags_ = cty::c_uint;
+pub type ImGuiSliderFlags_ = core::ffi::c_uint;
 pub const ImGuiMouseButton_Left: ImGuiMouseButton_ = 0;
 pub const ImGuiMouseButton_Right: ImGuiMouseButton_ = 1;
 pub const ImGuiMouseButton_Middle: ImGuiMouseButton_ = 2;
 pub const ImGuiMouseButton_COUNT: ImGuiMouseButton_ = 5;
-pub type ImGuiMouseButton_ = cty::c_uint;
+pub type ImGuiMouseButton_ = core::ffi::c_uint;
 pub const ImGuiMouseCursor_None: ImGuiMouseCursor_ = -1;
 pub const ImGuiMouseCursor_Arrow: ImGuiMouseCursor_ = 0;
 pub const ImGuiMouseCursor_TextInput: ImGuiMouseCursor_ = 1;
@@ -849,18 +855,18 @@ pub const ImGuiMouseCursor_ResizeNWSE: ImGuiMouseCursor_ = 6;
 pub const ImGuiMouseCursor_Hand: ImGuiMouseCursor_ = 7;
 pub const ImGuiMouseCursor_NotAllowed: ImGuiMouseCursor_ = 8;
 pub const ImGuiMouseCursor_COUNT: ImGuiMouseCursor_ = 9;
-pub type ImGuiMouseCursor_ = cty::c_int;
+pub type ImGuiMouseCursor_ = core::ffi::c_int;
 pub const ImGuiMouseSource_Mouse: ImGuiMouseSource = 0;
 pub const ImGuiMouseSource_TouchScreen: ImGuiMouseSource = 1;
 pub const ImGuiMouseSource_Pen: ImGuiMouseSource = 2;
 pub const ImGuiMouseSource_COUNT: ImGuiMouseSource = 3;
-pub type ImGuiMouseSource = cty::c_uint;
+pub type ImGuiMouseSource = core::ffi::c_uint;
 pub const ImGuiCond_None: ImGuiCond_ = 0;
 pub const ImGuiCond_Always: ImGuiCond_ = 1;
 pub const ImGuiCond_Once: ImGuiCond_ = 2;
 pub const ImGuiCond_FirstUseEver: ImGuiCond_ = 4;
 pub const ImGuiCond_Appearing: ImGuiCond_ = 8;
-pub type ImGuiCond_ = cty::c_uint;
+pub type ImGuiCond_ = core::ffi::c_uint;
 pub const ImGuiTableFlags_None: ImGuiTableFlags_ = 0;
 pub const ImGuiTableFlags_Resizable: ImGuiTableFlags_ = 1;
 pub const ImGuiTableFlags_Reorderable: ImGuiTableFlags_ = 2;
@@ -898,7 +904,7 @@ pub const ImGuiTableFlags_SortMulti: ImGuiTableFlags_ = 67108864;
 pub const ImGuiTableFlags_SortTristate: ImGuiTableFlags_ = 134217728;
 pub const ImGuiTableFlags_HighlightHoveredColumn: ImGuiTableFlags_ = 268435456;
 pub const ImGuiTableFlags_SizingMask_: ImGuiTableFlags_ = 57344;
-pub type ImGuiTableFlags_ = cty::c_uint;
+pub type ImGuiTableFlags_ = core::ffi::c_uint;
 pub const ImGuiTableColumnFlags_None: ImGuiTableColumnFlags_ = 0;
 pub const ImGuiTableColumnFlags_Disabled: ImGuiTableColumnFlags_ = 1;
 pub const ImGuiTableColumnFlags_DefaultHide: ImGuiTableColumnFlags_ = 2;
@@ -927,20 +933,20 @@ pub const ImGuiTableColumnFlags_WidthMask_: ImGuiTableColumnFlags_ = 24;
 pub const ImGuiTableColumnFlags_IndentMask_: ImGuiTableColumnFlags_ = 196608;
 pub const ImGuiTableColumnFlags_StatusMask_: ImGuiTableColumnFlags_ = 251658240;
 pub const ImGuiTableColumnFlags_NoDirectResize_: ImGuiTableColumnFlags_ = 1073741824;
-pub type ImGuiTableColumnFlags_ = cty::c_uint;
+pub type ImGuiTableColumnFlags_ = core::ffi::c_uint;
 pub const ImGuiTableRowFlags_None: ImGuiTableRowFlags_ = 0;
 pub const ImGuiTableRowFlags_Headers: ImGuiTableRowFlags_ = 1;
-pub type ImGuiTableRowFlags_ = cty::c_uint;
+pub type ImGuiTableRowFlags_ = core::ffi::c_uint;
 pub const ImGuiTableBgTarget_None: ImGuiTableBgTarget_ = 0;
 pub const ImGuiTableBgTarget_RowBg0: ImGuiTableBgTarget_ = 1;
 pub const ImGuiTableBgTarget_RowBg1: ImGuiTableBgTarget_ = 2;
 pub const ImGuiTableBgTarget_CellBg: ImGuiTableBgTarget_ = 3;
-pub type ImGuiTableBgTarget_ = cty::c_uint;
+pub type ImGuiTableBgTarget_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTableSortSpecs {
     pub Specs: *const ImGuiTableColumnSortSpecs,
-    pub SpecsCount: cty::c_int,
+    pub SpecsCount: core::ffi::c_int,
     pub SpecsDirty: bool,
 }
 impl Default for ImGuiTableSortSpecs {
@@ -1047,8 +1053,8 @@ pub struct ImGuiKeyData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImWchar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImWchar,
 }
 impl Default for ImVector_ImWchar {
@@ -1068,9 +1074,9 @@ pub struct ImGuiIO {
     pub DisplaySize: ImVec2,
     pub DeltaTime: f32,
     pub IniSavingRate: f32,
-    pub IniFilename: *const cty::c_char,
-    pub LogFilename: *const cty::c_char,
-    pub UserData: *mut cty::c_void,
+    pub IniFilename: *const core::ffi::c_char,
+    pub LogFilename: *const core::ffi::c_char,
+    pub UserData: *mut core::ffi::c_void,
     pub Fonts: *mut ImFontAtlas,
     pub FontGlobalScale: f32,
     pub FontAllowUserScaling: bool,
@@ -1110,11 +1116,11 @@ pub struct ImGuiIO {
     pub ConfigDebugBeginReturnValueLoop: bool,
     pub ConfigDebugIgnoreFocusLoss: bool,
     pub ConfigDebugIniSettings: bool,
-    pub BackendPlatformName: *const cty::c_char,
-    pub BackendRendererName: *const cty::c_char,
-    pub BackendPlatformUserData: *mut cty::c_void,
-    pub BackendRendererUserData: *mut cty::c_void,
-    pub BackendLanguageUserData: *mut cty::c_void,
+    pub BackendPlatformName: *const core::ffi::c_char,
+    pub BackendRendererName: *const core::ffi::c_char,
+    pub BackendPlatformUserData: *mut core::ffi::c_void,
+    pub BackendRendererUserData: *mut core::ffi::c_void,
+    pub BackendLanguageUserData: *mut core::ffi::c_void,
     pub WantCaptureMouse: bool,
     pub WantCaptureKeyboard: bool,
     pub WantTextInput: bool,
@@ -1123,10 +1129,10 @@ pub struct ImGuiIO {
     pub NavActive: bool,
     pub NavVisible: bool,
     pub Framerate: f32,
-    pub MetricsRenderVertices: cty::c_int,
-    pub MetricsRenderIndices: cty::c_int,
-    pub MetricsRenderWindows: cty::c_int,
-    pub MetricsActiveWindows: cty::c_int,
+    pub MetricsRenderVertices: core::ffi::c_int,
+    pub MetricsRenderIndices: core::ffi::c_int,
+    pub MetricsRenderWindows: core::ffi::c_int,
+    pub MetricsActiveWindows: core::ffi::c_int,
     pub MouseDelta: ImVec2,
     pub Ctx: *mut ImGuiContext,
     pub MousePos: ImVec2,
@@ -1181,16 +1187,16 @@ pub struct ImGuiInputTextCallbackData {
     pub Ctx: *mut ImGuiContext,
     pub EventFlag: ImGuiInputTextFlags,
     pub Flags: ImGuiInputTextFlags,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub EventChar: ImWchar,
     pub EventKey: ImGuiKey,
-    pub Buf: *mut cty::c_char,
-    pub BufTextLen: cty::c_int,
-    pub BufSize: cty::c_int,
+    pub Buf: *mut core::ffi::c_char,
+    pub BufTextLen: core::ffi::c_int,
+    pub BufSize: core::ffi::c_int,
     pub BufDirty: bool,
-    pub CursorPos: cty::c_int,
-    pub SelectionStart: cty::c_int,
-    pub SelectionEnd: cty::c_int,
+    pub CursorPos: core::ffi::c_int,
+    pub SelectionStart: core::ffi::c_int,
+    pub SelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextCallbackData {
     fn default() -> Self {
@@ -1204,7 +1210,7 @@ impl Default for ImGuiInputTextCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiSizeCallbackData {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub Pos: ImVec2,
     pub CurrentSize: ImVec2,
     pub DesiredSize: ImVec2,
@@ -1234,12 +1240,12 @@ pub struct ImGuiWindowClass {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPayload {
-    pub Data: *mut cty::c_void,
-    pub DataSize: cty::c_int,
+    pub Data: *mut core::ffi::c_void,
+    pub DataSize: core::ffi::c_int,
     pub SourceId: ImGuiID,
     pub SourceParentId: ImGuiID,
-    pub DataFrameCount: cty::c_int,
-    pub DataType: [cty::c_char; 33usize],
+    pub DataFrameCount: core::ffi::c_int,
+    pub DataType: [core::ffi::c_char; 33usize],
     pub Preview: bool,
     pub Delivery: bool,
 }
@@ -1255,13 +1261,13 @@ impl Default for ImGuiPayload {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiOnceUponAFrame {
-    pub RefFrame: cty::c_int,
+    pub RefFrame: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextRange {
-    pub b: *const cty::c_char,
-    pub e: *const cty::c_char,
+    pub b: *const core::ffi::c_char,
+    pub e: *const core::ffi::c_char,
 }
 impl Default for ImGuiTextRange {
     fn default() -> Self {
@@ -1275,8 +1281,8 @@ impl Default for ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTextRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTextRange,
 }
 impl Default for ImVector_ImGuiTextRange {
@@ -1291,9 +1297,9 @@ impl Default for ImVector_ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextFilter {
-    pub InputBuf: [cty::c_char; 256usize],
+    pub InputBuf: [core::ffi::c_char; 256usize],
     pub Filters: ImVector_ImGuiTextRange,
-    pub CountGrep: cty::c_int,
+    pub CountGrep: core::ffi::c_int,
 }
 impl Default for ImGuiTextFilter {
     fn default() -> Self {
@@ -1307,9 +1313,9 @@ impl Default for ImGuiTextFilter {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_char,
 }
 impl Default for ImVector_char {
     fn default() -> Self {
@@ -1343,9 +1349,9 @@ pub struct ImGuiStoragePair {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStoragePair__bindgen_ty_1 {
-    pub val_i: cty::c_int,
+    pub val_i: core::ffi::c_int,
     pub val_f: f32,
-    pub val_p: *mut cty::c_void,
+    pub val_p: *mut core::ffi::c_void,
 }
 impl Default for ImGuiStoragePair__bindgen_ty_1 {
     fn default() -> Self {
@@ -1382,8 +1388,8 @@ impl ::core::fmt::Debug for ImGuiStoragePair {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStoragePair {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStoragePair,
 }
 impl Default for ImVector_ImGuiStoragePair {
@@ -1413,13 +1419,13 @@ impl Default for ImGuiStorage {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiListClipper {
     pub Ctx: *mut ImGuiContext,
-    pub DisplayStart: cty::c_int,
-    pub DisplayEnd: cty::c_int,
-    pub ItemsCount: cty::c_int,
+    pub DisplayStart: core::ffi::c_int,
+    pub DisplayEnd: core::ffi::c_int,
+    pub ItemsCount: core::ffi::c_int,
     pub ItemsHeight: f32,
     pub StartPosY: f32,
     pub StartSeekOffsetY: f64,
-    pub TempData: *mut cty::c_void,
+    pub TempData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiListClipper {
     fn default() -> Self {
@@ -1452,12 +1458,12 @@ pub const ImGuiMultiSelectFlags_ScopeRect: ImGuiMultiSelectFlags_ = 4096;
 pub const ImGuiMultiSelectFlags_SelectOnClick: ImGuiMultiSelectFlags_ = 8192;
 pub const ImGuiMultiSelectFlags_SelectOnClickRelease: ImGuiMultiSelectFlags_ = 16384;
 pub const ImGuiMultiSelectFlags_NavWrapX: ImGuiMultiSelectFlags_ = 65536;
-pub type ImGuiMultiSelectFlags_ = cty::c_uint;
+pub type ImGuiMultiSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSelectionRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSelectionRequest,
 }
 impl Default for ImVector_ImGuiSelectionRequest {
@@ -1477,7 +1483,7 @@ pub struct ImGuiMultiSelectIO {
     pub NavIdItem: ImGuiSelectionUserData,
     pub NavIdSelected: bool,
     pub RangeSrcReset: bool,
-    pub ItemsCount: cty::c_int,
+    pub ItemsCount: core::ffi::c_int,
 }
 impl Default for ImGuiMultiSelectIO {
     fn default() -> Self {
@@ -1491,7 +1497,7 @@ impl Default for ImGuiMultiSelectIO {
 pub const ImGuiSelectionRequestType_None: ImGuiSelectionRequestType = 0;
 pub const ImGuiSelectionRequestType_SetAll: ImGuiSelectionRequestType = 1;
 pub const ImGuiSelectionRequestType_SetRange: ImGuiSelectionRequestType = 2;
-pub type ImGuiSelectionRequestType = cty::c_uint;
+pub type ImGuiSelectionRequestType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionRequest {
@@ -1513,13 +1519,16 @@ impl Default for ImGuiSelectionRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionBasicStorage {
-    pub Size: cty::c_int,
+    pub Size: core::ffi::c_int,
     pub PreserveOrder: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterIndexToStorageId: ::core::option::Option<
-        unsafe extern "C" fn(self_: *mut ImGuiSelectionBasicStorage, idx: cty::c_int) -> ImGuiID,
+        unsafe extern "C" fn(
+            self_: *mut ImGuiSelectionBasicStorage,
+            idx: core::ffi::c_int,
+        ) -> ImGuiID,
     >,
-    pub _SelectionOrder: cty::c_int,
+    pub _SelectionOrder: core::ffi::c_int,
     pub _Storage: ImGuiStorage,
 }
 impl Default for ImGuiSelectionBasicStorage {
@@ -1534,11 +1543,11 @@ impl Default for ImGuiSelectionBasicStorage {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionExternalStorage {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterSetItemSelected: ::core::option::Option<
         unsafe extern "C" fn(
             self_: *mut ImGuiSelectionExternalStorage,
-            idx: cty::c_int,
+            idx: core::ffi::c_int,
             selected: bool,
         ),
     >,
@@ -1560,11 +1569,11 @@ pub type ImDrawCallback = ::core::option::Option<
 pub struct ImDrawCmd {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
-    pub IdxOffset: cty::c_uint,
-    pub ElemCount: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
+    pub IdxOffset: core::ffi::c_uint,
+    pub ElemCount: core::ffi::c_uint,
     pub UserCallback: ImDrawCallback,
-    pub UserCallbackData: *mut cty::c_void,
+    pub UserCallbackData: *mut core::ffi::c_void,
 }
 impl Default for ImDrawCmd {
     fn default() -> Self {
@@ -1587,7 +1596,7 @@ pub struct ImDrawVert {
 pub struct ImDrawCmdHeader {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
 }
 impl Default for ImDrawCmdHeader {
     fn default() -> Self {
@@ -1601,8 +1610,8 @@ impl Default for ImDrawCmdHeader {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawCmd {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawCmd,
 }
 impl Default for ImVector_ImDrawCmd {
@@ -1617,8 +1626,8 @@ impl Default for ImVector_ImDrawCmd {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawIdx {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawIdx,
 }
 impl Default for ImVector_ImDrawIdx {
@@ -1648,8 +1657,8 @@ impl Default for ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawChannel {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawChannel,
 }
 impl Default for ImVector_ImDrawChannel {
@@ -1664,8 +1673,8 @@ impl Default for ImVector_ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImDrawListSplitter {
-    pub _Current: cty::c_int,
-    pub _Count: cty::c_int,
+    pub _Current: core::ffi::c_int,
+    pub _Count: core::ffi::c_int,
     pub _Channels: ImVector_ImDrawChannel,
 }
 impl Default for ImDrawListSplitter {
@@ -1691,18 +1700,18 @@ pub const ImDrawFlags_RoundCornersRight: ImDrawFlags_ = 160;
 pub const ImDrawFlags_RoundCornersAll: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersDefault_: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersMask_: ImDrawFlags_ = 496;
-pub type ImDrawFlags_ = cty::c_uint;
+pub type ImDrawFlags_ = core::ffi::c_uint;
 pub const ImDrawListFlags_None: ImDrawListFlags_ = 0;
 pub const ImDrawListFlags_AntiAliasedLines: ImDrawListFlags_ = 1;
 pub const ImDrawListFlags_AntiAliasedLinesUseTex: ImDrawListFlags_ = 2;
 pub const ImDrawListFlags_AntiAliasedFill: ImDrawListFlags_ = 4;
 pub const ImDrawListFlags_AllowVtxOffset: ImDrawListFlags_ = 8;
-pub type ImDrawListFlags_ = cty::c_uint;
+pub type ImDrawListFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawVert {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawVert,
 }
 impl Default for ImVector_ImDrawVert {
@@ -1717,8 +1726,8 @@ impl Default for ImVector_ImDrawVert {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec2 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec2,
 }
 impl Default for ImVector_ImVec2 {
@@ -1733,8 +1742,8 @@ impl Default for ImVector_ImVec2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec4 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec4,
 }
 impl Default for ImVector_ImVec4 {
@@ -1749,8 +1758,8 @@ impl Default for ImVector_ImVec4 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImTextureID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImTextureID,
 }
 impl Default for ImVector_ImTextureID {
@@ -1769,7 +1778,7 @@ pub struct ImDrawList {
     pub IdxBuffer: ImVector_ImDrawIdx,
     pub VtxBuffer: ImVector_ImDrawVert,
     pub Flags: ImDrawListFlags,
-    pub _VtxCurrentIdx: cty::c_uint,
+    pub _VtxCurrentIdx: core::ffi::c_uint,
     pub _Data: *mut ImDrawListSharedData,
     pub _VtxWritePtr: *mut ImDrawVert,
     pub _IdxWritePtr: *mut ImDrawIdx,
@@ -1779,7 +1788,7 @@ pub struct ImDrawList {
     pub _ClipRectStack: ImVector_ImVec4,
     pub _TextureIdStack: ImVector_ImTextureID,
     pub _FringeScale: f32,
-    pub _OwnerName: *const cty::c_char,
+    pub _OwnerName: *const core::ffi::c_char,
 }
 impl Default for ImDrawList {
     fn default() -> Self {
@@ -1793,8 +1802,8 @@ impl Default for ImDrawList {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawListPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImDrawList,
 }
 impl Default for ImVector_ImDrawListPtr {
@@ -1810,9 +1819,9 @@ impl Default for ImVector_ImDrawListPtr {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImDrawData {
     pub Valid: bool,
-    pub CmdListsCount: cty::c_int,
-    pub TotalIdxCount: cty::c_int,
-    pub TotalVtxCount: cty::c_int,
+    pub CmdListsCount: core::ffi::c_int,
+    pub TotalIdxCount: core::ffi::c_int,
+    pub TotalVtxCount: core::ffi::c_int,
     pub CmdLists: ImVector_ImDrawListPtr,
     pub DisplayPos: ImVec2,
     pub DisplaySize: ImVec2,
@@ -1831,13 +1840,13 @@ impl Default for ImDrawData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontConfig {
-    pub FontData: *mut cty::c_void,
-    pub FontDataSize: cty::c_int,
+    pub FontData: *mut core::ffi::c_void,
+    pub FontDataSize: core::ffi::c_int,
     pub FontDataOwnedByAtlas: bool,
-    pub FontNo: cty::c_int,
+    pub FontNo: core::ffi::c_int,
     pub SizePixels: f32,
-    pub OversampleH: cty::c_int,
-    pub OversampleV: cty::c_int,
+    pub OversampleH: core::ffi::c_int,
+    pub OversampleV: core::ffi::c_int,
     pub PixelSnapH: bool,
     pub GlyphExtraSpacing: ImVec2,
     pub GlyphOffset: ImVec2,
@@ -1845,11 +1854,11 @@ pub struct ImFontConfig {
     pub GlyphMinAdvanceX: f32,
     pub GlyphMaxAdvanceX: f32,
     pub MergeMode: bool,
-    pub FontBuilderFlags: cty::c_uint,
+    pub FontBuilderFlags: core::ffi::c_uint,
     pub RasterizerMultiply: f32,
     pub RasterizerDensity: f32,
     pub EllipsisChar: ImWchar,
-    pub Name: [cty::c_char; 40usize],
+    pub Name: [core::ffi::c_char; 40usize],
     pub DstFont: *mut ImFont,
 }
 impl Default for ImFontConfig {
@@ -1878,33 +1887,33 @@ pub struct ImFontGlyph {
 }
 impl ImFontGlyph {
     #[inline]
-    pub fn Colored(&self) -> cty::c_uint {
+    pub fn Colored(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Colored(&mut self, val: cty::c_uint) {
+    pub fn set_Colored(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Visible(&self) -> cty::c_uint {
+    pub fn Visible(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Visible(&mut self, val: cty::c_uint) {
+    pub fn set_Visible(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(1usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Codepoint(&self) -> cty::c_uint {
+    pub fn Codepoint(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
     }
     #[inline]
-    pub fn set_Codepoint(&mut self, val: cty::c_uint) {
+    pub fn set_Codepoint(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(2usize, 30u8, val as u64)
@@ -1912,9 +1921,9 @@ impl ImFontGlyph {
     }
     #[inline]
     pub fn new_bitfield_1(
-        Colored: cty::c_uint,
-        Visible: cty::c_uint,
-        Codepoint: cty::c_uint,
+        Colored: core::ffi::c_uint,
+        Visible: core::ffi::c_uint,
+        Codepoint: core::ffi::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1935,8 +1944,8 @@ impl ImFontGlyph {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImU32 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImU32,
 }
 impl Default for ImVector_ImU32 {
@@ -1965,11 +1974,11 @@ impl Default for ImFontGlyphRangesBuilder {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontAtlasCustomRect {
-    pub Width: cty::c_ushort,
-    pub Height: cty::c_ushort,
-    pub X: cty::c_ushort,
-    pub Y: cty::c_ushort,
-    pub GlyphID: cty::c_uint,
+    pub Width: core::ffi::c_ushort,
+    pub Height: core::ffi::c_ushort,
+    pub X: core::ffi::c_ushort,
+    pub Y: core::ffi::c_ushort,
+    pub GlyphID: core::ffi::c_uint,
     pub GlyphAdvanceX: f32,
     pub GlyphOffset: ImVec2,
     pub Font: *mut ImFont,
@@ -1987,12 +1996,12 @@ pub const ImFontAtlasFlags_None: ImFontAtlasFlags_ = 0;
 pub const ImFontAtlasFlags_NoPowerOfTwoHeight: ImFontAtlasFlags_ = 1;
 pub const ImFontAtlasFlags_NoMouseCursors: ImFontAtlasFlags_ = 2;
 pub const ImFontAtlasFlags_NoBakedLines: ImFontAtlasFlags_ = 4;
-pub type ImFontAtlasFlags_ = cty::c_uint;
+pub type ImFontAtlasFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImFont,
 }
 impl Default for ImVector_ImFontPtr {
@@ -2007,8 +2016,8 @@ impl Default for ImVector_ImFontPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontAtlasCustomRect {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontAtlasCustomRect,
 }
 impl Default for ImVector_ImFontAtlasCustomRect {
@@ -2023,8 +2032,8 @@ impl Default for ImVector_ImFontAtlasCustomRect {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontConfig {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontConfig,
 }
 impl Default for ImVector_ImFontConfig {
@@ -2041,16 +2050,16 @@ impl Default for ImVector_ImFontConfig {
 pub struct ImFontAtlas {
     pub Flags: ImFontAtlasFlags,
     pub TexID: ImTextureID,
-    pub TexDesiredWidth: cty::c_int,
-    pub TexGlyphPadding: cty::c_int,
+    pub TexDesiredWidth: core::ffi::c_int,
+    pub TexGlyphPadding: core::ffi::c_int,
     pub Locked: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub TexReady: bool,
     pub TexPixelsUseColors: bool,
-    pub TexPixelsAlpha8: *mut cty::c_uchar,
-    pub TexPixelsRGBA32: *mut cty::c_uint,
-    pub TexWidth: cty::c_int,
-    pub TexHeight: cty::c_int,
+    pub TexPixelsAlpha8: *mut core::ffi::c_uchar,
+    pub TexPixelsRGBA32: *mut core::ffi::c_uint,
+    pub TexWidth: core::ffi::c_int,
+    pub TexHeight: core::ffi::c_int,
     pub TexUvScale: ImVec2,
     pub TexUvWhitePixel: ImVec2,
     pub Fonts: ImVector_ImFontPtr,
@@ -2058,9 +2067,9 @@ pub struct ImFontAtlas {
     pub ConfigData: ImVector_ImFontConfig,
     pub TexUvLines: [ImVec4; 64usize],
     pub FontBuilderIO: *const ImFontBuilderIO,
-    pub FontBuilderFlags: cty::c_uint,
-    pub PackIdMouseCursors: cty::c_int,
-    pub PackIdLines: cty::c_int,
+    pub FontBuilderFlags: core::ffi::c_uint,
+    pub PackIdMouseCursors: core::ffi::c_int,
+    pub PackIdLines: core::ffi::c_int,
 }
 impl Default for ImFontAtlas {
     fn default() -> Self {
@@ -2074,8 +2083,8 @@ impl Default for ImFontAtlas {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_float {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut f32,
 }
 impl Default for ImVector_float {
@@ -2090,8 +2099,8 @@ impl Default for ImVector_float {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontGlyph {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontGlyph,
 }
 impl Default for ImVector_ImFontGlyph {
@@ -2114,17 +2123,17 @@ pub struct ImFont {
     pub FallbackGlyph: *const ImFontGlyph,
     pub ContainerAtlas: *mut ImFontAtlas,
     pub ConfigData: *const ImFontConfig,
-    pub ConfigDataCount: cty::c_short,
+    pub ConfigDataCount: core::ffi::c_short,
     pub FallbackChar: ImWchar,
     pub EllipsisChar: ImWchar,
-    pub EllipsisCharCount: cty::c_short,
+    pub EllipsisCharCount: core::ffi::c_short,
     pub EllipsisWidth: f32,
     pub EllipsisCharStep: f32,
     pub DirtyLookupTables: bool,
     pub Scale: f32,
     pub Ascent: f32,
     pub Descent: f32,
-    pub MetricsTotalSurface: cty::c_int,
+    pub MetricsTotalSurface: core::ffi::c_int,
     pub Used4kPagesMap: [ImU8; 34usize],
 }
 impl Default for ImFont {
@@ -2151,7 +2160,7 @@ pub const ImGuiViewportFlags_TopMost: ImGuiViewportFlags_ = 1024;
 pub const ImGuiViewportFlags_CanHostOtherWindows: ImGuiViewportFlags_ = 2048;
 pub const ImGuiViewportFlags_IsMinimized: ImGuiViewportFlags_ = 4096;
 pub const ImGuiViewportFlags_IsFocused: ImGuiViewportFlags_ = 8192;
-pub type ImGuiViewportFlags_ = cty::c_uint;
+pub type ImGuiViewportFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiViewport {
@@ -2164,10 +2173,10 @@ pub struct ImGuiViewport {
     pub DpiScale: f32,
     pub ParentViewportId: ImGuiID,
     pub DrawData: *mut ImDrawData,
-    pub RendererUserData: *mut cty::c_void,
-    pub PlatformUserData: *mut cty::c_void,
-    pub PlatformHandle: *mut cty::c_void,
-    pub PlatformHandleRaw: *mut cty::c_void,
+    pub RendererUserData: *mut core::ffi::c_void,
+    pub PlatformUserData: *mut core::ffi::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
+    pub PlatformHandleRaw: *mut core::ffi::c_void,
     pub PlatformWindowCreated: bool,
     pub PlatformRequestMove: bool,
     pub PlatformRequestResize: bool,
@@ -2185,8 +2194,8 @@ impl Default for ImGuiViewport {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPlatformMonitor {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPlatformMonitor,
 }
 impl Default for ImVector_ImGuiPlatformMonitor {
@@ -2201,8 +2210,8 @@ impl Default for ImVector_ImGuiPlatformMonitor {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiViewportPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiViewport,
 }
 impl Default for ImVector_ImGuiViewportPtr {
@@ -2217,16 +2226,17 @@ impl Default for ImVector_ImGuiViewportPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPlatformIO {
-    pub Platform_GetClipboardTextFn:
-        ::core::option::Option<unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const cty::c_char>,
+    pub Platform_GetClipboardTextFn: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const core::ffi::c_char,
+    >,
     pub Platform_SetClipboardTextFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const cty::c_char),
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const core::ffi::c_char),
     >,
-    pub Platform_ClipboardUserData: *mut cty::c_void,
+    pub Platform_ClipboardUserData: *mut core::ffi::c_void,
     pub Platform_OpenInShellFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const cty::c_char) -> bool,
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const core::ffi::c_char) -> bool,
     >,
-    pub Platform_OpenInShellUserData: *mut cty::c_void,
+    pub Platform_OpenInShellUserData: *mut core::ffi::c_void,
     pub Platform_SetImeDataFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
@@ -2234,7 +2244,7 @@ pub struct ImGuiPlatformIO {
             data: *mut ImGuiPlatformImeData,
         ),
     >,
-    pub Platform_ImeUserData: *mut cty::c_void,
+    pub Platform_ImeUserData: *mut core::ffi::c_void,
     pub Platform_LocaleDecimalPoint: ImWchar,
     pub Platform_CreateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Platform_DestroyWindow:
@@ -2255,16 +2265,16 @@ pub struct ImGuiPlatformIO {
     pub Platform_GetWindowMinimized:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> bool>,
     pub Platform_SetWindowTitle: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, str_: *const cty::c_char),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, str_: *const core::ffi::c_char),
     >,
     pub Platform_SetWindowAlpha:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, alpha: f32)>,
     pub Platform_UpdateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Platform_RenderWindow: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Platform_SwapBuffers: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Platform_GetWindowDpiScale:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> f32>,
@@ -2276,9 +2286,9 @@ pub struct ImGuiPlatformIO {
         unsafe extern "C" fn(
             vp: *mut ImGuiViewport,
             vk_inst: ImU64,
-            vk_allocators: *const cty::c_void,
+            vk_allocators: *const core::ffi::c_void,
             out_vk_surface: *mut ImU64,
-        ) -> cty::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub Renderer_CreateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Renderer_DestroyWindow:
@@ -2286,10 +2296,10 @@ pub struct ImGuiPlatformIO {
     pub Renderer_SetWindowSize:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, size: ImVec2)>,
     pub Renderer_RenderWindow: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Renderer_SwapBuffers: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Monitors: ImVector_ImGuiPlatformMonitor,
     pub Viewports: ImVector_ImGuiViewportPtr,
@@ -2311,7 +2321,7 @@ pub struct ImGuiPlatformMonitor {
     pub WorkPos: ImVec2,
     pub WorkSize: ImVec2,
     pub DpiScale: f32,
-    pub PlatformHandle: *mut cty::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
 }
 impl Default for ImGuiPlatformMonitor {
     fn default() -> Self {
@@ -2329,23 +2339,23 @@ pub struct ImGuiPlatformImeData {
     pub InputPos: ImVec2,
     pub InputLineHeight: f32,
 }
-pub type ImGuiDataAuthority = cty::c_int;
-pub type ImGuiLayoutType = cty::c_int;
-pub type ImGuiActivateFlags = cty::c_int;
-pub type ImGuiDebugLogFlags = cty::c_int;
-pub type ImGuiFocusRequestFlags = cty::c_int;
-pub type ImGuiItemStatusFlags = cty::c_int;
-pub type ImGuiOldColumnFlags = cty::c_int;
-pub type ImGuiNavHighlightFlags = cty::c_int;
-pub type ImGuiNavMoveFlags = cty::c_int;
-pub type ImGuiNextItemDataFlags = cty::c_int;
-pub type ImGuiNextWindowDataFlags = cty::c_int;
-pub type ImGuiScrollFlags = cty::c_int;
-pub type ImGuiSeparatorFlags = cty::c_int;
-pub type ImGuiTextFlags = cty::c_int;
-pub type ImGuiTooltipFlags = cty::c_int;
-pub type ImGuiTypingSelectFlags = cty::c_int;
-pub type ImGuiWindowRefreshFlags = cty::c_int;
+pub type ImGuiDataAuthority = core::ffi::c_int;
+pub type ImGuiLayoutType = core::ffi::c_int;
+pub type ImGuiActivateFlags = core::ffi::c_int;
+pub type ImGuiDebugLogFlags = core::ffi::c_int;
+pub type ImGuiFocusRequestFlags = core::ffi::c_int;
+pub type ImGuiItemStatusFlags = core::ffi::c_int;
+pub type ImGuiOldColumnFlags = core::ffi::c_int;
+pub type ImGuiNavHighlightFlags = core::ffi::c_int;
+pub type ImGuiNavMoveFlags = core::ffi::c_int;
+pub type ImGuiNextItemDataFlags = core::ffi::c_int;
+pub type ImGuiNextWindowDataFlags = core::ffi::c_int;
+pub type ImGuiScrollFlags = core::ffi::c_int;
+pub type ImGuiSeparatorFlags = core::ffi::c_int;
+pub type ImGuiTextFlags = core::ffi::c_int;
+pub type ImGuiTooltipFlags = core::ffi::c_int;
+pub type ImGuiTypingSelectFlags = core::ffi::c_int;
+pub type ImGuiWindowRefreshFlags = core::ffi::c_int;
 pub type ImFileHandle = *mut FILE;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -2355,8 +2365,8 @@ pub struct ImVec1 {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVec2ih {
-    pub x: cty::c_short,
-    pub y: cty::c_short,
+    pub x: core::ffi::c_short,
+    pub y: core::ffi::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -2379,13 +2389,13 @@ impl Default for ImBitVector {
         }
     }
 }
-pub type ImPoolIdx = cty::c_int;
+pub type ImPoolIdx = core::ffi::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_int {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_int,
 }
 impl Default for ImVector_int {
     fn default() -> Self {
@@ -2400,7 +2410,7 @@ impl Default for ImVector_int {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextIndex {
     pub LineOffsets: ImVector_int,
-    pub EndOffset: cty::c_int,
+    pub EndOffset: core::ffi::c_int,
 }
 impl Default for ImGuiTextIndex {
     fn default() -> Self {
@@ -2468,9 +2478,9 @@ pub struct ImGuiDataTypeStorage {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDataTypeInfo {
     pub Size: usize,
-    pub Name: *const cty::c_char,
-    pub PrintFmt: *const cty::c_char,
-    pub ScanFmt: *const cty::c_char,
+    pub Name: *const core::ffi::c_char,
+    pub PrintFmt: *const core::ffi::c_char,
+    pub ScanFmt: *const core::ffi::c_char,
 }
 impl Default for ImGuiDataTypeInfo {
     fn default() -> Self {
@@ -2484,7 +2494,7 @@ impl Default for ImGuiDataTypeInfo {
 pub const ImGuiDataType_String: ImGuiDataTypePrivate_ = 12;
 pub const ImGuiDataType_Pointer: ImGuiDataTypePrivate_ = 13;
 pub const ImGuiDataType_ID: ImGuiDataTypePrivate_ = 14;
-pub type ImGuiDataTypePrivate_ = cty::c_uint;
+pub type ImGuiDataTypePrivate_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_Disabled: ImGuiItemFlagsPrivate_ = 1024;
 pub const ImGuiItemFlags_ReadOnly: ImGuiItemFlagsPrivate_ = 2048;
 pub const ImGuiItemFlags_MixedValue: ImGuiItemFlagsPrivate_ = 4096;
@@ -2494,7 +2504,7 @@ pub const ImGuiItemFlags_Inputable: ImGuiItemFlagsPrivate_ = 1048576;
 pub const ImGuiItemFlags_HasSelectionUserData: ImGuiItemFlagsPrivate_ = 2097152;
 pub const ImGuiItemFlags_IsMultiSelect: ImGuiItemFlagsPrivate_ = 4194304;
 pub const ImGuiItemFlags_Default_: ImGuiItemFlagsPrivate_ = 16;
-pub type ImGuiItemFlagsPrivate_ = cty::c_uint;
+pub type ImGuiItemFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiItemStatusFlags_None: ImGuiItemStatusFlags_ = 0;
 pub const ImGuiItemStatusFlags_HoveredRect: ImGuiItemStatusFlags_ = 1;
 pub const ImGuiItemStatusFlags_HasDisplayRect: ImGuiItemStatusFlags_ = 2;
@@ -2507,16 +2517,16 @@ pub const ImGuiItemStatusFlags_HoveredWindow: ImGuiItemStatusFlags_ = 128;
 pub const ImGuiItemStatusFlags_Visible: ImGuiItemStatusFlags_ = 256;
 pub const ImGuiItemStatusFlags_HasClipRect: ImGuiItemStatusFlags_ = 512;
 pub const ImGuiItemStatusFlags_HasShortcut: ImGuiItemStatusFlags_ = 1024;
-pub type ImGuiItemStatusFlags_ = cty::c_uint;
+pub type ImGuiItemStatusFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_DelayMask_: ImGuiHoveredFlagsPrivate_ = 245760;
 pub const ImGuiHoveredFlags_AllowedMaskForIsWindowHovered: ImGuiHoveredFlagsPrivate_ = 12479;
 pub const ImGuiHoveredFlags_AllowedMaskForIsItemHovered: ImGuiHoveredFlagsPrivate_ = 262048;
-pub type ImGuiHoveredFlagsPrivate_ = cty::c_uint;
+pub type ImGuiHoveredFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_Multiline: ImGuiInputTextFlagsPrivate_ = 67108864;
 pub const ImGuiInputTextFlags_NoMarkEdited: ImGuiInputTextFlagsPrivate_ = 134217728;
 pub const ImGuiInputTextFlags_MergedItem: ImGuiInputTextFlagsPrivate_ = 268435456;
 pub const ImGuiInputTextFlags_LocalizeDecimalPoint: ImGuiInputTextFlagsPrivate_ = 536870912;
-pub type ImGuiInputTextFlagsPrivate_ = cty::c_uint;
+pub type ImGuiInputTextFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_PressedOnClick: ImGuiButtonFlagsPrivate_ = 16;
 pub const ImGuiButtonFlags_PressedOnClickRelease: ImGuiButtonFlagsPrivate_ = 32;
 pub const ImGuiButtonFlags_PressedOnClickReleaseAnywhere: ImGuiButtonFlagsPrivate_ = 64;
@@ -2536,12 +2546,12 @@ pub const ImGuiButtonFlags_NoSetKeyOwner: ImGuiButtonFlagsPrivate_ = 1048576;
 pub const ImGuiButtonFlags_NoTestKeyOwner: ImGuiButtonFlagsPrivate_ = 2097152;
 pub const ImGuiButtonFlags_PressedOnMask_: ImGuiButtonFlagsPrivate_ = 1008;
 pub const ImGuiButtonFlags_PressedOnDefault_: ImGuiButtonFlagsPrivate_ = 32;
-pub type ImGuiButtonFlagsPrivate_ = cty::c_uint;
+pub type ImGuiButtonFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_CustomPreview: ImGuiComboFlagsPrivate_ = 1048576;
-pub type ImGuiComboFlagsPrivate_ = cty::c_uint;
+pub type ImGuiComboFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_Vertical: ImGuiSliderFlagsPrivate_ = 1048576;
 pub const ImGuiSliderFlags_ReadOnly: ImGuiSliderFlagsPrivate_ = 2097152;
-pub type ImGuiSliderFlagsPrivate_ = cty::c_uint;
+pub type ImGuiSliderFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_NoHoldingActiveID: ImGuiSelectableFlagsPrivate_ = 1048576;
 pub const ImGuiSelectableFlags_SelectOnNav: ImGuiSelectableFlagsPrivate_ = 2097152;
 pub const ImGuiSelectableFlags_SelectOnClick: ImGuiSelectableFlagsPrivate_ = 4194304;
@@ -2550,42 +2560,42 @@ pub const ImGuiSelectableFlags_SpanAvailWidth: ImGuiSelectableFlagsPrivate_ = 16
 pub const ImGuiSelectableFlags_SetNavIdOnHover: ImGuiSelectableFlagsPrivate_ = 33554432;
 pub const ImGuiSelectableFlags_NoPadWithHalfSpacing: ImGuiSelectableFlagsPrivate_ = 67108864;
 pub const ImGuiSelectableFlags_NoSetKeyOwner: ImGuiSelectableFlagsPrivate_ = 134217728;
-pub type ImGuiSelectableFlagsPrivate_ = cty::c_uint;
+pub type ImGuiSelectableFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_ClipLabelForTrailingButton: ImGuiTreeNodeFlagsPrivate_ = 268435456;
 pub const ImGuiTreeNodeFlags_UpsideDownArrow: ImGuiTreeNodeFlagsPrivate_ = 536870912;
 pub const ImGuiTreeNodeFlags_OpenOnMask_: ImGuiTreeNodeFlagsPrivate_ = 192;
-pub type ImGuiTreeNodeFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTreeNodeFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSeparatorFlags_None: ImGuiSeparatorFlags_ = 0;
 pub const ImGuiSeparatorFlags_Horizontal: ImGuiSeparatorFlags_ = 1;
 pub const ImGuiSeparatorFlags_Vertical: ImGuiSeparatorFlags_ = 2;
 pub const ImGuiSeparatorFlags_SpanAllColumns: ImGuiSeparatorFlags_ = 4;
-pub type ImGuiSeparatorFlags_ = cty::c_uint;
+pub type ImGuiSeparatorFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusRequestFlags_None: ImGuiFocusRequestFlags_ = 0;
 pub const ImGuiFocusRequestFlags_RestoreFocusedChild: ImGuiFocusRequestFlags_ = 1;
 pub const ImGuiFocusRequestFlags_UnlessBelowModal: ImGuiFocusRequestFlags_ = 2;
-pub type ImGuiFocusRequestFlags_ = cty::c_uint;
+pub type ImGuiFocusRequestFlags_ = core::ffi::c_uint;
 pub const ImGuiTextFlags_None: ImGuiTextFlags_ = 0;
 pub const ImGuiTextFlags_NoWidthForLargeClippedText: ImGuiTextFlags_ = 1;
-pub type ImGuiTextFlags_ = cty::c_uint;
+pub type ImGuiTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTooltipFlags_None: ImGuiTooltipFlags_ = 0;
 pub const ImGuiTooltipFlags_OverridePrevious: ImGuiTooltipFlags_ = 2;
-pub type ImGuiTooltipFlags_ = cty::c_uint;
+pub type ImGuiTooltipFlags_ = core::ffi::c_uint;
 pub const ImGuiLayoutType_Horizontal: ImGuiLayoutType_ = 0;
 pub const ImGuiLayoutType_Vertical: ImGuiLayoutType_ = 1;
-pub type ImGuiLayoutType_ = cty::c_uint;
+pub type ImGuiLayoutType_ = core::ffi::c_uint;
 pub const ImGuiLogType_None: ImGuiLogType = 0;
 pub const ImGuiLogType_TTY: ImGuiLogType = 1;
 pub const ImGuiLogType_File: ImGuiLogType = 2;
 pub const ImGuiLogType_Buffer: ImGuiLogType = 3;
 pub const ImGuiLogType_Clipboard: ImGuiLogType = 4;
-pub type ImGuiLogType = cty::c_uint;
+pub type ImGuiLogType = core::ffi::c_uint;
 pub const ImGuiAxis_None: ImGuiAxis = -1;
 pub const ImGuiAxis_X: ImGuiAxis = 0;
 pub const ImGuiAxis_Y: ImGuiAxis = 1;
-pub type ImGuiAxis = cty::c_int;
+pub type ImGuiAxis = core::ffi::c_int;
 pub const ImGuiPlotType_Lines: ImGuiPlotType = 0;
 pub const ImGuiPlotType_Histogram: ImGuiPlotType = 1;
-pub type ImGuiPlotType = cty::c_uint;
+pub type ImGuiPlotType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiColorMod {
@@ -2601,7 +2611,7 @@ pub struct ImGuiStyleMod {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStyleMod__bindgen_ty_1 {
-    pub BackupInt: [cty::c_int; 2usize],
+    pub BackupInt: [core::ffi::c_int; 2usize],
     pub BackupFloat: [f32; 2usize],
 }
 impl Default for ImGuiStyleMod__bindgen_ty_1 {
@@ -2697,11 +2707,11 @@ pub struct ImGuiInputTextState {
     pub Ctx: *mut ImGuiContext,
     pub Stb: *mut ImStbTexteditState,
     pub ID: ImGuiID,
-    pub CurLenA: cty::c_int,
+    pub CurLenA: core::ffi::c_int,
     pub TextA: ImVector_char,
     pub InitialTextA: ImVector_char,
     pub CallbackTextBackup: ImVector_char,
-    pub BufCapacityA: cty::c_int,
+    pub BufCapacityA: core::ffi::c_int,
     pub Scroll: ImVec2,
     pub CursorAnim: f32,
     pub CursorFollow: bool,
@@ -2709,8 +2719,8 @@ pub struct ImGuiInputTextState {
     pub Edited: bool,
     pub Flags: ImGuiInputTextFlags,
     pub ReloadUserBuf: bool,
-    pub ReloadSelectionStart: cty::c_int,
-    pub ReloadSelectionEnd: cty::c_int,
+    pub ReloadSelectionStart: core::ffi::c_int,
+    pub ReloadSelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextState {
     fn default() -> Self {
@@ -2725,7 +2735,7 @@ pub const ImGuiWindowRefreshFlags_None: ImGuiWindowRefreshFlags_ = 0;
 pub const ImGuiWindowRefreshFlags_TryToAvoidRefresh: ImGuiWindowRefreshFlags_ = 1;
 pub const ImGuiWindowRefreshFlags_RefreshOnHover: ImGuiWindowRefreshFlags_ = 2;
 pub const ImGuiWindowRefreshFlags_RefreshOnFocus: ImGuiWindowRefreshFlags_ = 4;
-pub type ImGuiWindowRefreshFlags_ = cty::c_uint;
+pub type ImGuiWindowRefreshFlags_ = core::ffi::c_uint;
 pub const ImGuiNextWindowDataFlags_None: ImGuiNextWindowDataFlags_ = 0;
 pub const ImGuiNextWindowDataFlags_HasPos: ImGuiNextWindowDataFlags_ = 1;
 pub const ImGuiNextWindowDataFlags_HasSize: ImGuiNextWindowDataFlags_ = 2;
@@ -2740,7 +2750,7 @@ pub const ImGuiNextWindowDataFlags_HasRefreshPolicy: ImGuiNextWindowDataFlags_ =
 pub const ImGuiNextWindowDataFlags_HasViewport: ImGuiNextWindowDataFlags_ = 1024;
 pub const ImGuiNextWindowDataFlags_HasDock: ImGuiNextWindowDataFlags_ = 2048;
 pub const ImGuiNextWindowDataFlags_HasWindowClass: ImGuiNextWindowDataFlags_ = 4096;
-pub type ImGuiNextWindowDataFlags_ = cty::c_uint;
+pub type ImGuiNextWindowDataFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiNextWindowData {
@@ -2759,7 +2769,7 @@ pub struct ImGuiNextWindowData {
     pub CollapsedVal: bool,
     pub SizeConstraintRect: ImRect,
     pub SizeCallback: ImGuiSizeCallback,
-    pub SizeCallbackUserData: *mut cty::c_void,
+    pub SizeCallbackUserData: *mut core::ffi::c_void,
     pub BgAlphaVal: f32,
     pub ViewportId: ImGuiID,
     pub DockId: ImGuiID,
@@ -2782,7 +2792,7 @@ pub const ImGuiNextItemDataFlags_HasOpen: ImGuiNextItemDataFlags_ = 2;
 pub const ImGuiNextItemDataFlags_HasShortcut: ImGuiNextItemDataFlags_ = 4;
 pub const ImGuiNextItemDataFlags_HasRefVal: ImGuiNextItemDataFlags_ = 8;
 pub const ImGuiNextItemDataFlags_HasStorageID: ImGuiNextItemDataFlags_ = 16;
-pub type ImGuiNextItemDataFlags_ = cty::c_uint;
+pub type ImGuiNextItemDataFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiNextItemData {
@@ -2821,17 +2831,17 @@ pub struct ImGuiTreeNodeStackData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiErrorRecoveryState {
-    pub SizeOfWindowStack: cty::c_short,
-    pub SizeOfIDStack: cty::c_short,
-    pub SizeOfTreeStack: cty::c_short,
-    pub SizeOfColorStack: cty::c_short,
-    pub SizeOfStyleVarStack: cty::c_short,
-    pub SizeOfFontStack: cty::c_short,
-    pub SizeOfFocusScopeStack: cty::c_short,
-    pub SizeOfGroupStack: cty::c_short,
-    pub SizeOfItemFlagsStack: cty::c_short,
-    pub SizeOfBeginPopupStack: cty::c_short,
-    pub SizeOfDisabledStack: cty::c_short,
+    pub SizeOfWindowStack: core::ffi::c_short,
+    pub SizeOfIDStack: core::ffi::c_short,
+    pub SizeOfTreeStack: core::ffi::c_short,
+    pub SizeOfColorStack: core::ffi::c_short,
+    pub SizeOfStyleVarStack: core::ffi::c_short,
+    pub SizeOfFontStack: core::ffi::c_short,
+    pub SizeOfFocusScopeStack: core::ffi::c_short,
+    pub SizeOfGroupStack: core::ffi::c_short,
+    pub SizeOfItemFlagsStack: core::ffi::c_short,
+    pub SizeOfBeginPopupStack: core::ffi::c_short,
+    pub SizeOfDisabledStack: core::ffi::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -2853,15 +2863,15 @@ impl Default for ImGuiWindowStackData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiShrinkWidthItem {
-    pub Index: cty::c_int,
+    pub Index: core::ffi::c_int,
     pub Width: f32,
     pub InitialWidth: f32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPtrOrIndex {
-    pub Ptr: *mut cty::c_void,
-    pub Index: cty::c_int,
+    pub Ptr: *mut core::ffi::c_void,
+    pub Index: core::ffi::c_int,
 }
 impl Default for ImGuiPtrOrIndex {
     fn default() -> Self {
@@ -2875,15 +2885,15 @@ impl Default for ImGuiPtrOrIndex {
 pub const ImGuiPopupPositionPolicy_Default: ImGuiPopupPositionPolicy = 0;
 pub const ImGuiPopupPositionPolicy_ComboBox: ImGuiPopupPositionPolicy = 1;
 pub const ImGuiPopupPositionPolicy_Tooltip: ImGuiPopupPositionPolicy = 2;
-pub type ImGuiPopupPositionPolicy = cty::c_uint;
+pub type ImGuiPopupPositionPolicy = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiPopupData {
     pub PopupId: ImGuiID,
     pub Window: *mut ImGuiWindow,
     pub RestoreNavWindow: *mut ImGuiWindow,
-    pub ParentNavLayer: cty::c_int,
-    pub OpenFrameCount: cty::c_int,
+    pub ParentNavLayer: core::ffi::c_int,
+    pub OpenFrameCount: core::ffi::c_int,
     pub OpenParentId: ImGuiID,
     pub OpenPopupPos: ImVec2,
     pub OpenMousePos: ImVec2,
@@ -2912,13 +2922,13 @@ pub const ImGuiInputEventType_Key: ImGuiInputEventType = 5;
 pub const ImGuiInputEventType_Text: ImGuiInputEventType = 6;
 pub const ImGuiInputEventType_Focus: ImGuiInputEventType = 7;
 pub const ImGuiInputEventType_COUNT: ImGuiInputEventType = 8;
-pub type ImGuiInputEventType = cty::c_uint;
+pub type ImGuiInputEventType = core::ffi::c_uint;
 pub const ImGuiInputSource_None: ImGuiInputSource = 0;
 pub const ImGuiInputSource_Mouse: ImGuiInputSource = 1;
 pub const ImGuiInputSource_Keyboard: ImGuiInputSource = 2;
 pub const ImGuiInputSource_Gamepad: ImGuiInputSource = 3;
 pub const ImGuiInputSource_COUNT: ImGuiInputSource = 4;
-pub type ImGuiInputSource = cty::c_uint;
+pub type ImGuiInputSource = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiInputEventMousePos {
@@ -2954,7 +2964,7 @@ impl Default for ImGuiInputEventMouseWheel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiInputEventMouseButton {
-    pub Button: cty::c_int,
+    pub Button: core::ffi::c_int,
     pub Down: bool,
     pub MouseSource: ImGuiMouseSource,
 }
@@ -2991,7 +3001,7 @@ impl Default for ImGuiInputEventKey {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiInputEventText {
-    pub Char: cty::c_uint,
+    pub Char: core::ffi::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -3060,8 +3070,8 @@ pub struct ImGuiKeyRoutingData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiKeyRoutingData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiKeyRoutingData,
 }
 impl Default for ImVector_ImGuiKeyRoutingData {
@@ -3121,12 +3131,12 @@ pub const ImGuiInputFlags_SupportedByShortcut: ImGuiInputFlagsPrivate_ = 261375;
 pub const ImGuiInputFlags_SupportedBySetNextItemShortcut: ImGuiInputFlagsPrivate_ = 523519;
 pub const ImGuiInputFlags_SupportedBySetKeyOwner: ImGuiInputFlagsPrivate_ = 3145728;
 pub const ImGuiInputFlags_SupportedBySetItemKeyOwner: ImGuiInputFlagsPrivate_ = 15728640;
-pub type ImGuiInputFlagsPrivate_ = cty::c_uint;
+pub type ImGuiInputFlagsPrivate_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiListClipperRange {
-    pub Min: cty::c_int,
-    pub Max: cty::c_int,
+    pub Min: core::ffi::c_int,
+    pub Max: core::ffi::c_int,
     pub PosToIndexConvert: bool,
     pub PosToIndexOffsetMin: ImS8,
     pub PosToIndexOffsetMax: ImS8,
@@ -3134,8 +3144,8 @@ pub struct ImGuiListClipperRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiListClipperRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiListClipperRange,
 }
 impl Default for ImVector_ImGuiListClipperRange {
@@ -3152,8 +3162,8 @@ impl Default for ImVector_ImGuiListClipperRange {
 pub struct ImGuiListClipperData {
     pub ListClipper: *mut ImGuiListClipper,
     pub LossynessOffset: f32,
-    pub StepNo: cty::c_int,
-    pub ItemsFrozen: cty::c_int,
+    pub StepNo: core::ffi::c_int,
+    pub ItemsFrozen: core::ffi::c_int,
     pub Ranges: ImVector_ImGuiListClipperRange,
 }
 impl Default for ImGuiListClipperData {
@@ -3171,7 +3181,7 @@ pub const ImGuiActivateFlags_PreferTweak: ImGuiActivateFlags_ = 2;
 pub const ImGuiActivateFlags_TryToPreserveState: ImGuiActivateFlags_ = 4;
 pub const ImGuiActivateFlags_FromTabbing: ImGuiActivateFlags_ = 8;
 pub const ImGuiActivateFlags_FromShortcut: ImGuiActivateFlags_ = 16;
-pub type ImGuiActivateFlags_ = cty::c_uint;
+pub type ImGuiActivateFlags_ = core::ffi::c_uint;
 pub const ImGuiScrollFlags_None: ImGuiScrollFlags_ = 0;
 pub const ImGuiScrollFlags_KeepVisibleEdgeX: ImGuiScrollFlags_ = 1;
 pub const ImGuiScrollFlags_KeepVisibleEdgeY: ImGuiScrollFlags_ = 2;
@@ -3182,12 +3192,12 @@ pub const ImGuiScrollFlags_AlwaysCenterY: ImGuiScrollFlags_ = 32;
 pub const ImGuiScrollFlags_NoScrollParent: ImGuiScrollFlags_ = 64;
 pub const ImGuiScrollFlags_MaskX_: ImGuiScrollFlags_ = 21;
 pub const ImGuiScrollFlags_MaskY_: ImGuiScrollFlags_ = 42;
-pub type ImGuiScrollFlags_ = cty::c_uint;
+pub type ImGuiScrollFlags_ = core::ffi::c_uint;
 pub const ImGuiNavHighlightFlags_None: ImGuiNavHighlightFlags_ = 0;
 pub const ImGuiNavHighlightFlags_Compact: ImGuiNavHighlightFlags_ = 2;
 pub const ImGuiNavHighlightFlags_AlwaysDraw: ImGuiNavHighlightFlags_ = 4;
 pub const ImGuiNavHighlightFlags_NoRounding: ImGuiNavHighlightFlags_ = 8;
-pub type ImGuiNavHighlightFlags_ = cty::c_uint;
+pub type ImGuiNavHighlightFlags_ = core::ffi::c_uint;
 pub const ImGuiNavMoveFlags_None: ImGuiNavMoveFlags_ = 0;
 pub const ImGuiNavMoveFlags_LoopX: ImGuiNavMoveFlags_ = 1;
 pub const ImGuiNavMoveFlags_LoopY: ImGuiNavMoveFlags_ = 2;
@@ -3206,11 +3216,11 @@ pub const ImGuiNavMoveFlags_Activate: ImGuiNavMoveFlags_ = 4096;
 pub const ImGuiNavMoveFlags_NoSelect: ImGuiNavMoveFlags_ = 8192;
 pub const ImGuiNavMoveFlags_NoSetNavHighlight: ImGuiNavMoveFlags_ = 16384;
 pub const ImGuiNavMoveFlags_NoClearActiveId: ImGuiNavMoveFlags_ = 32768;
-pub type ImGuiNavMoveFlags_ = cty::c_uint;
+pub type ImGuiNavMoveFlags_ = core::ffi::c_uint;
 pub const ImGuiNavLayer_Main: ImGuiNavLayer = 0;
 pub const ImGuiNavLayer_Menu: ImGuiNavLayer = 1;
 pub const ImGuiNavLayer_COUNT: ImGuiNavLayer = 2;
-pub type ImGuiNavLayer = cty::c_uint;
+pub type ImGuiNavLayer = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiNavItemData {
@@ -3242,13 +3252,13 @@ pub struct ImGuiFocusScopeData {
 pub const ImGuiTypingSelectFlags_None: ImGuiTypingSelectFlags_ = 0;
 pub const ImGuiTypingSelectFlags_AllowBackspace: ImGuiTypingSelectFlags_ = 1;
 pub const ImGuiTypingSelectFlags_AllowSingleCharMode: ImGuiTypingSelectFlags_ = 2;
-pub type ImGuiTypingSelectFlags_ = cty::c_uint;
+pub type ImGuiTypingSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTypingSelectRequest {
     pub Flags: ImGuiTypingSelectFlags,
-    pub SearchBufferLen: cty::c_int,
-    pub SearchBuffer: *const cty::c_char,
+    pub SearchBufferLen: core::ffi::c_int,
+    pub SearchBuffer: *const core::ffi::c_char,
     pub SelectRequest: bool,
     pub SingleCharMode: bool,
     pub SingleCharSize: ImS8,
@@ -3266,9 +3276,9 @@ impl Default for ImGuiTypingSelectRequest {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTypingSelectState {
     pub Request: ImGuiTypingSelectRequest,
-    pub SearchBuffer: [cty::c_char; 64usize],
+    pub SearchBuffer: [core::ffi::c_char; 64usize],
     pub FocusScope: ImGuiID,
-    pub LastRequestFrame: cty::c_int,
+    pub LastRequestFrame: core::ffi::c_int,
     pub LastRequestTime: f32,
     pub SingleCharModeLock: bool,
 }
@@ -3287,7 +3297,7 @@ pub const ImGuiOldColumnFlags_NoResize: ImGuiOldColumnFlags_ = 2;
 pub const ImGuiOldColumnFlags_NoPreserveWidths: ImGuiOldColumnFlags_ = 4;
 pub const ImGuiOldColumnFlags_NoForceWithinWindow: ImGuiOldColumnFlags_ = 8;
 pub const ImGuiOldColumnFlags_GrowParentContentsSize: ImGuiOldColumnFlags_ = 16;
-pub type ImGuiOldColumnFlags_ = cty::c_uint;
+pub type ImGuiOldColumnFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiOldColumnData {
@@ -3299,8 +3309,8 @@ pub struct ImGuiOldColumnData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiOldColumnData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiOldColumnData,
 }
 impl Default for ImVector_ImGuiOldColumnData {
@@ -3319,8 +3329,8 @@ pub struct ImGuiOldColumns {
     pub Flags: ImGuiOldColumnFlags,
     pub IsFirstFrame: bool,
     pub IsBeingResized: bool,
-    pub Current: cty::c_int,
-    pub Count: cty::c_int,
+    pub Current: core::ffi::c_int,
+    pub Count: core::ffi::c_int,
     pub OffMinX: f32,
     pub OffMaxX: f32,
     pub LineMinY: f32,
@@ -3427,8 +3437,8 @@ impl Default for ImGuiMultiSelectTempData {
 pub struct ImGuiMultiSelectState {
     pub Window: *mut ImGuiWindow,
     pub ID: ImGuiID,
-    pub LastFrameActive: cty::c_int,
-    pub LastSelectionSize: cty::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastSelectionSize: core::ffi::c_int,
     pub RangeSelected: ImS8,
     pub NavIdSelected: ImS8,
     pub RangeSrcItem: ImGuiSelectionUserData,
@@ -3461,21 +3471,21 @@ pub const ImGuiDockNodeFlags_SharedFlagsInheritMask_: ImGuiDockNodeFlagsPrivate_
 pub const ImGuiDockNodeFlags_NoResizeFlagsMask_: ImGuiDockNodeFlagsPrivate_ = 196640;
 pub const ImGuiDockNodeFlags_LocalFlagsTransferMask_: ImGuiDockNodeFlagsPrivate_ = 260208;
 pub const ImGuiDockNodeFlags_SavedFlagsMask_: ImGuiDockNodeFlagsPrivate_ = 261152;
-pub type ImGuiDockNodeFlagsPrivate_ = cty::c_int;
+pub type ImGuiDockNodeFlagsPrivate_ = core::ffi::c_int;
 pub const ImGuiDataAuthority_Auto: ImGuiDataAuthority_ = 0;
 pub const ImGuiDataAuthority_DockNode: ImGuiDataAuthority_ = 1;
 pub const ImGuiDataAuthority_Window: ImGuiDataAuthority_ = 2;
-pub type ImGuiDataAuthority_ = cty::c_uint;
+pub type ImGuiDataAuthority_ = core::ffi::c_uint;
 pub const ImGuiDockNodeState_Unknown: ImGuiDockNodeState = 0;
 pub const ImGuiDockNodeState_HostWindowHiddenBecauseSingleWindow: ImGuiDockNodeState = 1;
 pub const ImGuiDockNodeState_HostWindowHiddenBecauseWindowsAreResizing: ImGuiDockNodeState = 2;
 pub const ImGuiDockNodeState_HostWindowVisible: ImGuiDockNodeState = 3;
-pub type ImGuiDockNodeState = cty::c_uint;
+pub type ImGuiDockNodeState = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiWindowPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiWindow,
 }
 impl Default for ImVector_ImGuiWindowPtr {
@@ -3510,10 +3520,10 @@ pub struct ImGuiDockNode {
     pub VisibleWindow: *mut ImGuiWindow,
     pub CentralNode: *mut ImGuiDockNode,
     pub OnlyNodeWithWindows: *mut ImGuiDockNode,
-    pub CountNodeWithWindows: cty::c_int,
-    pub LastFrameAlive: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub LastFrameFocused: cty::c_int,
+    pub CountNodeWithWindows: core::ffi::c_int,
+    pub LastFrameAlive: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFrameFocused: core::ffi::c_int,
     pub LastFocusedNodeId: ImGuiID,
     pub SelectedTabId: ImGuiID,
     pub WantCloseTabId: ImGuiID,
@@ -3774,7 +3784,7 @@ pub const ImGuiWindowDockStyleCol_TabDimmed: ImGuiWindowDockStyleCol = 5;
 pub const ImGuiWindowDockStyleCol_TabDimmedSelected: ImGuiWindowDockStyleCol = 6;
 pub const ImGuiWindowDockStyleCol_TabDimmedSelectedOverline: ImGuiWindowDockStyleCol = 7;
 pub const ImGuiWindowDockStyleCol_COUNT: ImGuiWindowDockStyleCol = 8;
-pub type ImGuiWindowDockStyleCol = cty::c_uint;
+pub type ImGuiWindowDockStyleCol = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiWindowDockStyle {
@@ -3783,8 +3793,8 @@ pub struct ImGuiWindowDockStyle {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiDockRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiDockRequest,
 }
 impl Default for ImVector_ImGuiDockRequest {
@@ -3799,8 +3809,8 @@ impl Default for ImVector_ImGuiDockRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiDockNodeSettings {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiDockNodeSettings,
 }
 impl Default for ImVector_ImGuiDockNodeSettings {
@@ -3834,17 +3844,17 @@ impl Default for ImGuiDockContext {
 pub struct ImGuiViewportP {
     pub _ImGuiViewport: ImGuiViewport,
     pub Window: *mut ImGuiWindow,
-    pub Idx: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub LastFocusedStampCount: cty::c_int,
+    pub Idx: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFocusedStampCount: core::ffi::c_int,
     pub LastNameHash: ImGuiID,
     pub LastPos: ImVec2,
     pub LastSize: ImVec2,
     pub Alpha: f32,
     pub LastAlpha: f32,
     pub LastFocusedHadNavWindow: bool,
-    pub PlatformMonitor: cty::c_short,
-    pub BgFgDrawListsLastFrame: [cty::c_int; 2usize],
+    pub PlatformMonitor: core::ffi::c_short,
+    pub BgFgDrawListsLastFrame: [core::ffi::c_int; 2usize],
     pub BgFgDrawLists: [*mut ImDrawList; 2usize],
     pub DrawDataP: ImDrawData,
     pub DrawDataBuilder: ImDrawDataBuilder,
@@ -3875,7 +3885,7 @@ pub struct ImGuiWindowSettings {
     pub ViewportId: ImGuiID,
     pub DockId: ImGuiID,
     pub ClassId: ImGuiID,
-    pub DockOrder: cty::c_short,
+    pub DockOrder: core::ffi::c_short,
     pub Collapsed: bool,
     pub IsChild: bool,
     pub WantApply: bool,
@@ -3884,7 +3894,7 @@ pub struct ImGuiWindowSettings {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSettingsHandler {
-    pub TypeName: *const cty::c_char,
+    pub TypeName: *const core::ffi::c_char,
     pub TypeHash: ImGuiID,
     pub ClearAllFn: ::core::option::Option<
         unsafe extern "C" fn(ctx: *mut ImGuiContext, handler: *mut ImGuiSettingsHandler),
@@ -3896,15 +3906,15 @@ pub struct ImGuiSettingsHandler {
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
             handler: *mut ImGuiSettingsHandler,
-            name: *const cty::c_char,
-        ) -> *mut cty::c_void,
+            name: *const core::ffi::c_char,
+        ) -> *mut core::ffi::c_void,
     >,
     pub ReadLineFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
             handler: *mut ImGuiSettingsHandler,
-            entry: *mut cty::c_void,
-            line: *const cty::c_char,
+            entry: *mut core::ffi::c_void,
+            line: *const core::ffi::c_char,
         ),
     >,
     pub ApplyAllFn: ::core::option::Option<
@@ -3917,7 +3927,7 @@ pub struct ImGuiSettingsHandler {
             out_buf: *mut ImGuiTextBuffer,
         ),
     >,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiSettingsHandler {
     fn default() -> Self {
@@ -3942,12 +3952,12 @@ pub const ImGuiLocKey_DockingHideTabBar: ImGuiLocKey = 10;
 pub const ImGuiLocKey_DockingHoldShiftToDock: ImGuiLocKey = 11;
 pub const ImGuiLocKey_DockingDragToUndockOrMoveNode: ImGuiLocKey = 12;
 pub const ImGuiLocKey_COUNT: ImGuiLocKey = 13;
-pub type ImGuiLocKey = cty::c_uint;
+pub type ImGuiLocKey = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiLocEntry {
     pub Key: ImGuiLocKey,
-    pub Text: *const cty::c_char,
+    pub Text: *const core::ffi::c_char,
 }
 impl Default for ImGuiLocEntry {
     fn default() -> Self {
@@ -3961,8 +3971,8 @@ impl Default for ImGuiLocEntry {
 pub type ImGuiErrorCallback = ::core::option::Option<
     unsafe extern "C" fn(
         ctx: *mut ImGuiContext,
-        user_data: *mut cty::c_void,
-        msg: *const cty::c_char,
+        user_data: *mut core::ffi::c_void,
+        msg: *const core::ffi::c_char,
     ),
 >;
 pub const ImGuiDebugLogFlags_None: ImGuiDebugLogFlags_ = 0;
@@ -3980,19 +3990,19 @@ pub const ImGuiDebugLogFlags_EventViewport: ImGuiDebugLogFlags_ = 1024;
 pub const ImGuiDebugLogFlags_EventMask_: ImGuiDebugLogFlags_ = 2047;
 pub const ImGuiDebugLogFlags_OutputToTTY: ImGuiDebugLogFlags_ = 1048576;
 pub const ImGuiDebugLogFlags_OutputToTestEngine: ImGuiDebugLogFlags_ = 2097152;
-pub type ImGuiDebugLogFlags_ = cty::c_uint;
+pub type ImGuiDebugLogFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDebugAllocEntry {
-    pub FrameCount: cty::c_int,
+    pub FrameCount: core::ffi::c_int,
     pub AllocCount: ImS16,
     pub FreeCount: ImS16,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDebugAllocInfo {
-    pub TotalAllocCount: cty::c_int,
-    pub TotalFreeCount: cty::c_int,
+    pub TotalAllocCount: core::ffi::c_int,
+    pub TotalFreeCount: core::ffi::c_int,
     pub LastEntriesIdx: ImS16,
     pub LastEntriesBuf: [ImGuiDebugAllocEntry; 6usize],
 }
@@ -4009,9 +4019,9 @@ pub struct ImGuiMetricsConfig {
     pub ShowTextEncodingViewer: bool,
     pub ShowAtlasTintedWithTextColor: bool,
     pub ShowDockingNodes: bool,
-    pub ShowWindowsRectsType: cty::c_int,
-    pub ShowTablesRectsType: cty::c_int,
-    pub HighlightMonitorIdx: cty::c_int,
+    pub ShowWindowsRectsType: core::ffi::c_int,
+    pub ShowTablesRectsType: core::ffi::c_int,
+    pub HighlightMonitorIdx: core::ffi::c_int,
     pub HighlightViewportID: ImGuiID,
 }
 #[repr(C)]
@@ -4022,7 +4032,7 @@ pub struct ImGuiStackLevelInfo {
     pub QuerySuccess: bool,
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub Desc: [cty::c_char; 57usize],
+    pub Desc: [core::ffi::c_char; 57usize],
 }
 impl Default for ImGuiStackLevelInfo {
     fn default() -> Self {
@@ -4058,8 +4068,8 @@ impl ImGuiStackLevelInfo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStackLevelInfo {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStackLevelInfo,
 }
 impl Default for ImVector_ImGuiStackLevelInfo {
@@ -4074,8 +4084,8 @@ impl Default for ImVector_ImGuiStackLevelInfo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiIDStackTool {
-    pub LastActiveFrame: cty::c_int,
-    pub StackLevel: cty::c_int,
+    pub LastActiveFrame: core::ffi::c_int,
+    pub StackLevel: core::ffi::c_int,
     pub QueryId: ImGuiID,
     pub Results: ImVector_ImGuiStackLevelInfo,
     pub CopyToClipboardOnCtrlC: bool,
@@ -4101,7 +4111,7 @@ pub const ImGuiContextHookType_RenderPre: ImGuiContextHookType = 4;
 pub const ImGuiContextHookType_RenderPost: ImGuiContextHookType = 5;
 pub const ImGuiContextHookType_Shutdown: ImGuiContextHookType = 6;
 pub const ImGuiContextHookType_PendingRemoval_: ImGuiContextHookType = 7;
-pub type ImGuiContextHookType = cty::c_uint;
+pub type ImGuiContextHookType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiContextHook {
@@ -4109,7 +4119,7 @@ pub struct ImGuiContextHook {
     pub Type: ImGuiContextHookType,
     pub Owner: ImGuiID,
     pub Callback: ImGuiContextHookCallback,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiContextHook {
     fn default() -> Self {
@@ -4123,8 +4133,8 @@ impl Default for ImGuiContextHook {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiInputEvent {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiInputEvent,
 }
 impl Default for ImVector_ImGuiInputEvent {
@@ -4139,8 +4149,8 @@ impl Default for ImVector_ImGuiInputEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiWindowStackData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiWindowStackData,
 }
 impl Default for ImVector_ImGuiWindowStackData {
@@ -4155,8 +4165,8 @@ impl Default for ImVector_ImGuiWindowStackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiColorMod {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiColorMod,
 }
 impl Default for ImVector_ImGuiColorMod {
@@ -4171,8 +4181,8 @@ impl Default for ImVector_ImGuiColorMod {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStyleMod {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStyleMod,
 }
 impl Default for ImVector_ImGuiStyleMod {
@@ -4187,8 +4197,8 @@ impl Default for ImVector_ImGuiStyleMod {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiFocusScopeData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiFocusScopeData,
 }
 impl Default for ImVector_ImGuiFocusScopeData {
@@ -4203,8 +4213,8 @@ impl Default for ImVector_ImGuiFocusScopeData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiItemFlags {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiItemFlags,
 }
 impl Default for ImVector_ImGuiItemFlags {
@@ -4219,8 +4229,8 @@ impl Default for ImVector_ImGuiItemFlags {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiGroupData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiGroupData,
 }
 impl Default for ImVector_ImGuiGroupData {
@@ -4235,8 +4245,8 @@ impl Default for ImVector_ImGuiGroupData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPopupData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPopupData,
 }
 impl Default for ImVector_ImGuiPopupData {
@@ -4251,8 +4261,8 @@ impl Default for ImVector_ImGuiPopupData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTreeNodeStackData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTreeNodeStackData,
 }
 impl Default for ImVector_ImGuiTreeNodeStackData {
@@ -4267,8 +4277,8 @@ impl Default for ImVector_ImGuiTreeNodeStackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiViewportPPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiViewportP,
 }
 impl Default for ImVector_ImGuiViewportPPtr {
@@ -4283,9 +4293,9 @@ impl Default for ImVector_ImGuiViewportPPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_unsigned_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_uchar,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_uchar,
 }
 impl Default for ImVector_unsigned_char {
     fn default() -> Self {
@@ -4299,8 +4309,8 @@ impl Default for ImVector_unsigned_char {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiListClipperData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiListClipperData,
 }
 impl Default for ImVector_ImGuiListClipperData {
@@ -4315,8 +4325,8 @@ impl Default for ImVector_ImGuiListClipperData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableTempData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableTempData,
 }
 impl Default for ImVector_ImGuiTableTempData {
@@ -4331,8 +4341,8 @@ impl Default for ImVector_ImGuiTableTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTable {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTable,
 }
 impl Default for ImVector_ImGuiTable {
@@ -4364,8 +4374,8 @@ impl Default for ImPool_ImGuiTable {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTabBar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTabBar,
 }
 impl Default for ImVector_ImGuiTabBar {
@@ -4397,8 +4407,8 @@ impl Default for ImPool_ImGuiTabBar {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPtrOrIndex {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPtrOrIndex,
 }
 impl Default for ImVector_ImGuiPtrOrIndex {
@@ -4413,8 +4423,8 @@ impl Default for ImVector_ImGuiPtrOrIndex {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiShrinkWidthItem {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiShrinkWidthItem,
 }
 impl Default for ImVector_ImGuiShrinkWidthItem {
@@ -4429,8 +4439,8 @@ impl Default for ImVector_ImGuiShrinkWidthItem {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiMultiSelectTempData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiMultiSelectTempData,
 }
 impl Default for ImVector_ImGuiMultiSelectTempData {
@@ -4445,8 +4455,8 @@ impl Default for ImVector_ImGuiMultiSelectTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiMultiSelectState {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiMultiSelectState,
 }
 impl Default for ImVector_ImGuiMultiSelectState {
@@ -4478,8 +4488,8 @@ impl Default for ImPool_ImGuiMultiSelectState {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiID,
 }
 impl Default for ImVector_ImGuiID {
@@ -4494,8 +4504,8 @@ impl Default for ImVector_ImGuiID {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSettingsHandler {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSettingsHandler,
 }
 impl Default for ImVector_ImGuiSettingsHandler {
@@ -4538,8 +4548,8 @@ impl Default for ImChunkStream_ImGuiTableSettings {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiContextHook {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiContextHook,
 }
 impl Default for ImVector_ImGuiContextHook {
@@ -4568,17 +4578,17 @@ pub struct ImGuiContext {
     pub CurrentDpiScale: f32,
     pub DrawListSharedData: ImDrawListSharedData,
     pub Time: f64,
-    pub FrameCount: cty::c_int,
-    pub FrameCountEnded: cty::c_int,
-    pub FrameCountPlatformEnded: cty::c_int,
-    pub FrameCountRendered: cty::c_int,
+    pub FrameCount: core::ffi::c_int,
+    pub FrameCountEnded: core::ffi::c_int,
+    pub FrameCountPlatformEnded: core::ffi::c_int,
+    pub FrameCountRendered: core::ffi::c_int,
     pub WithinFrameScope: bool,
     pub WithinFrameScopeWithImplicitWindow: bool,
     pub WithinEndChild: bool,
     pub GcCompactAll: bool,
     pub TestEngineHookItems: bool,
-    pub TestEngine: *mut cty::c_void,
-    pub ContextName: [cty::c_char; 16usize],
+    pub TestEngine: *mut core::ffi::c_void,
+    pub ContextName: [core::ffi::c_char; 16usize],
     pub InputEventsQueue: ImVector_ImGuiInputEvent,
     pub InputEventsTrail: ImVector_ImGuiInputEvent,
     pub InputEventsNextMouseSource: ImGuiMouseSource,
@@ -4588,7 +4598,7 @@ pub struct ImGuiContext {
     pub WindowsTempSortBuffer: ImVector_ImGuiWindowPtr,
     pub CurrentWindowStack: ImVector_ImGuiWindowStackData,
     pub WindowsById: ImGuiStorage,
-    pub WindowsActiveCount: cty::c_int,
+    pub WindowsActiveCount: core::ffi::c_int,
     pub WindowsHoverPadding: ImVec2,
     pub DebugBreakInWindow: ImGuiID,
     pub CurrentWindow: *mut ImGuiWindow,
@@ -4598,8 +4608,8 @@ pub struct ImGuiContext {
     pub MovingWindow: *mut ImGuiWindow,
     pub WheelingWindow: *mut ImGuiWindow,
     pub WheelingWindowRefMousePos: ImVec2,
-    pub WheelingWindowStartFrame: cty::c_int,
-    pub WheelingWindowScrolledFrame: cty::c_int,
+    pub WheelingWindowStartFrame: core::ffi::c_int,
+    pub WheelingWindowScrolledFrame: core::ffi::c_int,
     pub WheelingWindowReleaseTimer: f32,
     pub WheelingWindowWheelRemainder: ImVec2,
     pub WheelingAxisAvg: ImVec2,
@@ -4607,7 +4617,7 @@ pub struct ImGuiContext {
     pub DebugHookIdInfo: ImGuiID,
     pub HoveredId: ImGuiID,
     pub HoveredIdPreviousFrame: ImGuiID,
-    pub HoveredIdPreviousFrameItemCount: cty::c_int,
+    pub HoveredIdPreviousFrameItemCount: core::ffi::c_int,
     pub HoveredIdTimer: f32,
     pub HoveredIdNotActiveTimer: f32,
     pub HoveredIdAllowOverlap: bool,
@@ -4667,9 +4677,9 @@ pub struct ImGuiContext {
     pub PlatformLastFocusedViewportId: ImGuiID,
     pub FallbackMonitor: ImGuiPlatformMonitor,
     pub PlatformMonitorsFullWorkRect: ImRect,
-    pub ViewportCreatedCount: cty::c_int,
-    pub PlatformWindowsCreatedCount: cty::c_int,
-    pub ViewportFocusedStampCount: cty::c_int,
+    pub ViewportCreatedCount: core::ffi::c_int,
+    pub PlatformWindowsCreatedCount: core::ffi::c_int,
+    pub ViewportFocusedStampCount: core::ffi::c_int,
     pub NavWindow: *mut ImGuiWindow,
     pub NavId: ImGuiID,
     pub NavFocusScopeId: ImGuiID,
@@ -4704,9 +4714,9 @@ pub struct ImGuiContext {
     pub NavMoveClipDir: ImGuiDir,
     pub NavScoringRect: ImRect,
     pub NavScoringNoClipRect: ImRect,
-    pub NavScoringDebugCount: cty::c_int,
-    pub NavTabbingDir: cty::c_int,
-    pub NavTabbingCounter: cty::c_int,
+    pub NavScoringDebugCount: core::ffi::c_int,
+    pub NavTabbingDir: core::ffi::c_int,
+    pub NavTabbingCounter: core::ffi::c_int,
     pub NavMoveResultLocal: ImGuiNavItemData,
     pub NavMoveResultLocalVisible: ImGuiNavItemData,
     pub NavMoveResultOther: ImGuiNavItemData,
@@ -4733,8 +4743,8 @@ pub struct ImGuiContext {
     pub DragDropWithinSource: bool,
     pub DragDropWithinTarget: bool,
     pub DragDropSourceFlags: ImGuiDragDropFlags,
-    pub DragDropSourceFrameCount: cty::c_int,
-    pub DragDropMouseButton: cty::c_int,
+    pub DragDropSourceFrameCount: core::ffi::c_int,
+    pub DragDropMouseButton: core::ffi::c_int,
     pub DragDropPayload: ImGuiPayload,
     pub DragDropTargetRect: ImRect,
     pub DragDropTargetClipRect: ImRect,
@@ -4743,15 +4753,15 @@ pub struct ImGuiContext {
     pub DragDropAcceptIdCurrRectSurface: f32,
     pub DragDropAcceptIdCurr: ImGuiID,
     pub DragDropAcceptIdPrev: ImGuiID,
-    pub DragDropAcceptFrameCount: cty::c_int,
+    pub DragDropAcceptFrameCount: core::ffi::c_int,
     pub DragDropHoldJustPressedId: ImGuiID,
     pub DragDropPayloadBufHeap: ImVector_unsigned_char,
-    pub DragDropPayloadBufLocal: [cty::c_uchar; 16usize],
-    pub ClipperTempDataStacked: cty::c_int,
+    pub DragDropPayloadBufLocal: [core::ffi::c_uchar; 16usize],
+    pub ClipperTempDataStacked: core::ffi::c_int,
     pub ClipperTempData: ImVector_ImGuiListClipperData,
     pub CurrentTable: *mut ImGuiTable,
     pub DebugBreakInTable: ImGuiID,
-    pub TablesTempDataStacked: cty::c_int,
+    pub TablesTempDataStacked: core::ffi::c_int,
     pub TablesTempData: ImVector_ImGuiTableTempData,
     pub Tables: ImPool_ImGuiTable,
     pub TablesLastTimeActive: ImVector_float,
@@ -4762,7 +4772,7 @@ pub struct ImGuiContext {
     pub ShrinkWidthBuffer: ImVector_ImGuiShrinkWidthItem,
     pub BoxSelectState: ImGuiBoxSelectState,
     pub CurrentMultiSelect: *mut ImGuiMultiSelectTempData,
-    pub MultiSelectTempDataStacked: cty::c_int,
+    pub MultiSelectTempDataStacked: core::ffi::c_int,
     pub MultiSelectTempData: ImVector_ImGuiMultiSelectTempData,
     pub MultiSelectStorage: ImPool_ImGuiMultiSelectState,
     pub HoverItemDelayId: ImGuiID,
@@ -4779,8 +4789,8 @@ pub struct ImGuiContext {
     pub InputTextPasswordFont: ImFont,
     pub TempInputId: ImGuiID,
     pub DataTypeZeroValue: ImGuiDataTypeStorage,
-    pub BeginMenuDepth: cty::c_int,
-    pub BeginComboDepth: cty::c_int,
+    pub BeginMenuDepth: core::ffi::c_int,
+    pub BeginComboDepth: core::ffi::c_int,
     pub ColorEditOptions: ImGuiColorEditFlags,
     pub ColorEditCurrentID: ImGuiID,
     pub ColorEditSavedID: ImGuiID,
@@ -4791,7 +4801,7 @@ pub struct ImGuiContext {
     pub ComboPreviewData: ImGuiComboPreviewData,
     pub WindowResizeBorderExpectedRect: ImRect,
     pub WindowResizeRelativeMode: bool,
-    pub ScrollbarSeekMode: cty::c_short,
+    pub ScrollbarSeekMode: core::ffi::c_short,
     pub ScrollbarClickDeltaToGrabCenter: f32,
     pub SliderGrabClickOffset: f32,
     pub SliderCurrentAccum: f32,
@@ -4800,9 +4810,9 @@ pub struct ImGuiContext {
     pub DragCurrentAccum: f32,
     pub DragSpeedDefaultRatio: f32,
     pub DisabledAlphaBackup: f32,
-    pub DisabledStackSize: cty::c_short,
-    pub LockMarkEdited: cty::c_short,
-    pub TooltipOverrideCount: cty::c_short,
+    pub DisabledStackSize: core::ffi::c_short,
+    pub LockMarkEdited: core::ffi::c_short,
+    pub TooltipOverrideCount: core::ffi::c_short,
     pub TooltipPreviousWindow: *mut ImGuiWindow,
     pub ClipboardHandlerData: ImVector_char,
     pub MenusIdSubmittedThisFrame: ImVector_ImGuiID,
@@ -4826,30 +4836,30 @@ pub struct ImGuiContext {
     pub SettingsTables: ImChunkStream_ImGuiTableSettings,
     pub Hooks: ImVector_ImGuiContextHook,
     pub HookIdNext: ImGuiID,
-    pub LocalizationTable: [*const cty::c_char; 13usize],
+    pub LocalizationTable: [*const core::ffi::c_char; 13usize],
     pub LogEnabled: bool,
     pub LogType: ImGuiLogType,
     pub LogFile: ImFileHandle,
     pub LogBuffer: ImGuiTextBuffer,
-    pub LogNextPrefix: *const cty::c_char,
-    pub LogNextSuffix: *const cty::c_char,
+    pub LogNextPrefix: *const core::ffi::c_char,
+    pub LogNextSuffix: *const core::ffi::c_char,
     pub LogLinePosY: f32,
     pub LogLineFirstItem: bool,
-    pub LogDepthRef: cty::c_int,
-    pub LogDepthToExpand: cty::c_int,
-    pub LogDepthToExpandDefault: cty::c_int,
+    pub LogDepthRef: core::ffi::c_int,
+    pub LogDepthToExpand: core::ffi::c_int,
+    pub LogDepthToExpandDefault: core::ffi::c_int,
     pub ErrorCallback: ImGuiErrorCallback,
-    pub ErrorCallbackUserData: *mut cty::c_void,
+    pub ErrorCallbackUserData: *mut core::ffi::c_void,
     pub ErrorTooltipLockedPos: ImVec2,
     pub ErrorFirst: bool,
-    pub ErrorCountCurrentFrame: cty::c_int,
+    pub ErrorCountCurrentFrame: core::ffi::c_int,
     pub StackSizesInNewFrame: ImGuiErrorRecoveryState,
     pub StackSizesInBeginForCurrentWindow: *mut ImGuiErrorRecoveryState,
-    pub DebugDrawIdConflictsCount: cty::c_int,
+    pub DebugDrawIdConflictsCount: core::ffi::c_int,
     pub DebugLogFlags: ImGuiDebugLogFlags,
     pub DebugLogBuf: ImGuiTextBuffer,
     pub DebugLogIndex: ImGuiTextIndex,
-    pub DebugLogSkippedErrors: cty::c_int,
+    pub DebugLogSkippedErrors: core::ffi::c_int,
     pub DebugLogAutoDisableFlags: ImGuiDebugLogFlags,
     pub DebugLogAutoDisableFrames: ImU8,
     pub DebugLocateFrames: ImU8,
@@ -4866,14 +4876,14 @@ pub struct ImGuiContext {
     pub DebugAllocInfo: ImGuiDebugAllocInfo,
     pub DebugHoveredDockNode: *mut ImGuiDockNode,
     pub FramerateSecPerFrame: [f32; 60usize],
-    pub FramerateSecPerFrameIdx: cty::c_int,
-    pub FramerateSecPerFrameCount: cty::c_int,
+    pub FramerateSecPerFrameIdx: core::ffi::c_int,
+    pub FramerateSecPerFrameCount: core::ffi::c_int,
     pub FramerateSecPerFrameAccum: f32,
-    pub WantCaptureMouseNextFrame: cty::c_int,
-    pub WantCaptureKeyboardNextFrame: cty::c_int,
-    pub WantTextInputNextFrame: cty::c_int,
+    pub WantCaptureMouseNextFrame: core::ffi::c_int,
+    pub WantCaptureKeyboardNextFrame: core::ffi::c_int,
+    pub WantTextInputNextFrame: core::ffi::c_int,
     pub TempBuffer: ImVector_char,
-    pub TempKeychordName: [cty::c_char; 64usize],
+    pub TempKeychordName: [core::ffi::c_char; 64usize],
 }
 impl Default for ImGuiContext {
     fn default() -> Self {
@@ -4886,18 +4896,20 @@ impl Default for ImGuiContext {
 }
 impl ImGuiContext {
     #[inline]
-    pub fn ActiveIdMouseButton(&self) -> cty::c_int {
+    pub fn ActiveIdMouseButton(&self) -> core::ffi::c_int {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
     }
     #[inline]
-    pub fn set_ActiveIdMouseButton(&mut self, val: cty::c_int) {
+    pub fn set_ActiveIdMouseButton(&mut self, val: core::ffi::c_int) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 8u8, val as u64)
         }
     }
     #[inline]
-    pub fn new_bitfield_1(ActiveIdMouseButton: cty::c_int) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+    pub fn new_bitfield_1(
+        ActiveIdMouseButton: core::ffi::c_int,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 8u8, {
             let ActiveIdMouseButton: u32 = unsafe { ::core::mem::transmute(ActiveIdMouseButton) };
@@ -4925,20 +4937,20 @@ pub struct ImGuiWindowTempData {
     pub GroupOffset: ImVec1,
     pub CursorStartPosLossyness: ImVec2,
     pub NavLayerCurrent: ImGuiNavLayer,
-    pub NavLayersActiveMask: cty::c_short,
-    pub NavLayersActiveMaskNext: cty::c_short,
+    pub NavLayersActiveMask: core::ffi::c_short,
+    pub NavLayersActiveMaskNext: core::ffi::c_short,
     pub NavIsScrollPushableX: bool,
     pub NavHideHighlightOneFrame: bool,
     pub NavWindowHasScrollY: bool,
     pub MenuBarAppending: bool,
     pub MenuBarOffset: ImVec2,
     pub MenuColumns: ImGuiMenuColumns,
-    pub TreeDepth: cty::c_int,
+    pub TreeDepth: core::ffi::c_int,
     pub TreeHasStackDataDepthMask: ImU32,
     pub ChildWindows: ImVector_ImGuiWindowPtr,
     pub StateStorage: *mut ImGuiStorage,
     pub CurrentColumns: *mut ImGuiOldColumns,
-    pub CurrentTableIdx: cty::c_int,
+    pub CurrentTableIdx: core::ffi::c_int,
     pub LayoutType: ImGuiLayoutType,
     pub ParentLayoutType: ImGuiLayoutType,
     pub ModalDimBgColor: ImU32,
@@ -4959,8 +4971,8 @@ impl Default for ImGuiWindowTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiOldColumns {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiOldColumns,
 }
 impl Default for ImVector_ImGuiOldColumns {
@@ -4976,7 +4988,7 @@ impl Default for ImVector_ImGuiOldColumns {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiWindow {
     pub Ctx: *mut ImGuiContext,
-    pub Name: *mut cty::c_char,
+    pub Name: *mut core::ffi::c_char,
     pub ID: ImGuiID,
     pub Flags: ImGuiWindowFlags,
     pub FlagsPreviousFrame: ImGuiWindowFlags,
@@ -4985,7 +4997,7 @@ pub struct ImGuiWindow {
     pub Viewport: *mut ImGuiViewportP,
     pub ViewportId: ImGuiID,
     pub ViewportPos: ImVec2,
-    pub ViewportAllowPlatformMonitorExtend: cty::c_int,
+    pub ViewportAllowPlatformMonitorExtend: core::ffi::c_int,
     pub Pos: ImVec2,
     pub Size: ImVec2,
     pub SizeFull: ImVec2,
@@ -5003,7 +5015,7 @@ pub struct ImGuiWindow {
     pub DecoOuterSizeY2: f32,
     pub DecoInnerSizeX1: f32,
     pub DecoInnerSizeY1: f32,
-    pub NameBufLen: cty::c_int,
+    pub NameBufLen: core::ffi::c_int,
     pub MoveId: ImGuiID,
     pub TabId: ImGuiID,
     pub ChildId: ImGuiID,
@@ -5029,13 +5041,13 @@ pub struct ImGuiWindow {
     pub IsFallbackWindow: bool,
     pub IsExplicitChild: bool,
     pub HasCloseButton: bool,
-    pub ResizeBorderHovered: cty::c_schar,
-    pub ResizeBorderHeld: cty::c_schar,
-    pub BeginCount: cty::c_short,
-    pub BeginCountPreviousFrame: cty::c_short,
-    pub BeginOrderWithinParent: cty::c_short,
-    pub BeginOrderWithinContext: cty::c_short,
-    pub FocusOrder: cty::c_short,
+    pub ResizeBorderHovered: core::ffi::c_schar,
+    pub ResizeBorderHeld: core::ffi::c_schar,
+    pub BeginCount: core::ffi::c_short,
+    pub BeginCountPreviousFrame: core::ffi::c_short,
+    pub BeginOrderWithinParent: core::ffi::c_short,
+    pub BeginOrderWithinContext: core::ffi::c_short,
+    pub FocusOrder: core::ffi::c_short,
     pub AutoFitFramesX: ImS8,
     pub AutoFitFramesY: ImS8,
     pub AutoFitOnlyGrows: bool,
@@ -5059,15 +5071,15 @@ pub struct ImGuiWindow {
     pub ContentRegionRect: ImRect,
     pub HitTestHoleSize: ImVec2ih,
     pub HitTestHoleOffset: ImVec2ih,
-    pub LastFrameActive: cty::c_int,
-    pub LastFrameJustFocused: cty::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFrameJustFocused: core::ffi::c_int,
     pub LastTimeActive: f32,
     pub ItemWidthDefault: f32,
     pub StateStorage: ImGuiStorage,
     pub ColumnsStorage: ImVector_ImGuiOldColumns,
     pub FontWindowScale: f32,
     pub FontDpiScale: f32,
-    pub SettingsOffset: cty::c_int,
+    pub SettingsOffset: core::ffi::c_int,
     pub DrawList: *mut ImDrawList,
     pub DrawListInst: ImDrawList,
     pub ParentWindow: *mut ImGuiWindow,
@@ -5083,12 +5095,12 @@ pub struct ImGuiWindow {
     pub NavRectRel: [ImRect; 2usize],
     pub NavPreferredScoringPosRel: [ImVec2; 2usize],
     pub NavRootFocusScopeId: ImGuiID,
-    pub MemoryDrawListIdxCapacity: cty::c_int,
-    pub MemoryDrawListVtxCapacity: cty::c_int,
+    pub MemoryDrawListIdxCapacity: core::ffi::c_int,
+    pub MemoryDrawListVtxCapacity: core::ffi::c_int,
     pub MemoryCompacted: bool,
     pub _bitfield_align_2: [u8; 0],
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub DockOrder: cty::c_short,
+    pub DockOrder: core::ffi::c_short,
     pub DockStyle: ImGuiWindowDockStyle,
     pub DockNode: *mut ImGuiDockNode,
     pub DockNodeAsHost: *mut ImGuiDockNode,
@@ -5254,20 +5266,20 @@ impl ImGuiWindow {
 pub const ImGuiTabBarFlags_DockNode: ImGuiTabBarFlagsPrivate_ = 1048576;
 pub const ImGuiTabBarFlags_IsFocused: ImGuiTabBarFlagsPrivate_ = 2097152;
 pub const ImGuiTabBarFlags_SaveSettings: ImGuiTabBarFlagsPrivate_ = 4194304;
-pub type ImGuiTabBarFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTabBarFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_SectionMask_: ImGuiTabItemFlagsPrivate_ = 192;
 pub const ImGuiTabItemFlags_NoCloseButton: ImGuiTabItemFlagsPrivate_ = 1048576;
 pub const ImGuiTabItemFlags_Button: ImGuiTabItemFlagsPrivate_ = 2097152;
 pub const ImGuiTabItemFlags_Unsorted: ImGuiTabItemFlagsPrivate_ = 4194304;
-pub type ImGuiTabItemFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTabItemFlagsPrivate_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTabItem {
     pub ID: ImGuiID,
     pub Flags: ImGuiTabItemFlags,
     pub Window: *mut ImGuiWindow,
-    pub LastFrameVisible: cty::c_int,
-    pub LastFrameSelected: cty::c_int,
+    pub LastFrameVisible: core::ffi::c_int,
+    pub LastFrameSelected: core::ffi::c_int,
     pub Offset: f32,
     pub Width: f32,
     pub ContentWidth: f32,
@@ -5289,8 +5301,8 @@ impl Default for ImGuiTabItem {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTabItem {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTabItem,
 }
 impl Default for ImVector_ImGuiTabItem {
@@ -5312,8 +5324,8 @@ pub struct ImGuiTabBar {
     pub SelectedTabId: ImGuiID,
     pub NextSelectedTabId: ImGuiID,
     pub VisibleTabId: ImGuiID,
-    pub CurrFrameVisible: cty::c_int,
-    pub PrevFrameVisible: cty::c_int,
+    pub CurrFrameVisible: core::ffi::c_int,
+    pub PrevFrameVisible: core::ffi::c_int,
     pub BarRect: ImRect,
     pub CurrTabsContentsHeight: f32,
     pub PrevTabsContentsHeight: f32,
@@ -5475,8 +5487,8 @@ pub struct ImGuiTableInstanceData {
     pub LastOuterHeight: f32,
     pub LastTopHeadersRowHeight: f32,
     pub LastFrozenHeight: f32,
-    pub HoveredRowLast: cty::c_int,
-    pub HoveredRowNext: cty::c_int,
+    pub HoveredRowLast: core::ffi::c_int,
+    pub HoveredRowNext: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -5526,8 +5538,8 @@ impl Default for ImSpan_ImGuiTableCellData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableInstanceData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableInstanceData,
 }
 impl Default for ImVector_ImGuiTableInstanceData {
@@ -5542,8 +5554,8 @@ impl Default for ImVector_ImGuiTableInstanceData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableColumnSortSpecs {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableColumnSortSpecs,
 }
 impl Default for ImVector_ImGuiTableColumnSortSpecs {
@@ -5560,7 +5572,7 @@ impl Default for ImVector_ImGuiTableColumnSortSpecs {
 pub struct ImGuiTable {
     pub ID: ImGuiID,
     pub Flags: ImGuiTableFlags,
-    pub RawData: *mut cty::c_void,
+    pub RawData: *mut core::ffi::c_void,
     pub TempData: *mut ImGuiTableTempData,
     pub Columns: ImSpan_ImGuiTableColumn,
     pub DisplayOrderToIndex: ImSpan_ImGuiTableColumnIdx,
@@ -5569,11 +5581,11 @@ pub struct ImGuiTable {
     pub EnabledMaskByIndex: ImBitArrayPtr,
     pub VisibleMaskByIndex: ImBitArrayPtr,
     pub SettingsLoadedFlags: ImGuiTableFlags,
-    pub SettingsOffset: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub ColumnsCount: cty::c_int,
-    pub CurrentRow: cty::c_int,
-    pub CurrentColumn: cty::c_int,
+    pub SettingsOffset: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub ColumnsCount: core::ffi::c_int,
+    pub CurrentRow: core::ffi::c_int,
+    pub CurrentColumn: core::ffi::c_int,
     pub InstanceCurrent: ImS16,
     pub InstanceInteracted: ImS16,
     pub RowPosY1: f32,
@@ -5584,7 +5596,7 @@ pub struct ImGuiTable {
     pub RowIndentOffsetX: f32,
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub RowBgColorCounter: cty::c_int,
+    pub RowBgColorCounter: core::ffi::c_int,
     pub RowBgColor: [ImU32; 2usize],
     pub BorderColorStrong: ImU32,
     pub BorderColorLight: ImU32,
@@ -5723,8 +5735,8 @@ impl ImGuiTable {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableHeaderData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableHeaderData,
 }
 impl Default for ImVector_ImGuiTableHeaderData {
@@ -5739,7 +5751,7 @@ impl Default for ImVector_ImGuiTableHeaderData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTableTempData {
-    pub TableIndex: cty::c_int,
+    pub TableIndex: core::ffi::c_int,
     pub LastTimeActive: f32,
     pub AngledHeadersExtraWidth: f32,
     pub AngledHeadersRequests: ImVector_ImGuiTableHeaderData,
@@ -5752,7 +5764,7 @@ pub struct ImGuiTableTempData {
     pub HostBackupCursorMaxPos: ImVec2,
     pub HostBackupColumnsOffset: ImVec1,
     pub HostBackupItemWidth: f32,
-    pub HostBackupItemWidthStackSize: cty::c_int,
+    pub HostBackupItemWidthStackSize: core::ffi::c_int,
 }
 impl Default for ImGuiTableTempData {
     fn default() -> Self {
@@ -5917,16 +5929,16 @@ extern "C" {
     pub fn igShowStyleEditor(ref_: *mut ImGuiStyle);
 }
 extern "C" {
-    pub fn igShowStyleSelector(label: *const cty::c_char) -> bool;
+    pub fn igShowStyleSelector(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igShowFontSelector(label: *const cty::c_char);
+    pub fn igShowFontSelector(label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igShowUserGuide();
 }
 extern "C" {
-    pub fn igGetVersion() -> *const cty::c_char;
+    pub fn igGetVersion() -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igStyleColorsDark(dst: *mut ImGuiStyle);
@@ -5938,14 +5950,18 @@ extern "C" {
     pub fn igStyleColorsClassic(dst: *mut ImGuiStyle);
 }
 extern "C" {
-    pub fn igBegin(name: *const cty::c_char, p_open: *mut bool, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBegin(
+        name: *const core::ffi::c_char,
+        p_open: *mut bool,
+        flags: ImGuiWindowFlags,
+    ) -> bool;
 }
 extern "C" {
     pub fn igEnd();
 }
 extern "C" {
     pub fn igBeginChild_Str(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         child_flags: ImGuiChildFlags,
         window_flags: ImGuiWindowFlags,
@@ -6006,7 +6022,7 @@ extern "C" {
         size_min: ImVec2,
         size_max: ImVec2,
         custom_callback: ImGuiSizeCallback,
-        custom_callback_data: *mut cty::c_void,
+        custom_callback_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -6043,16 +6059,20 @@ extern "C" {
     pub fn igSetWindowFontScale(scale: f32);
 }
 extern "C" {
-    pub fn igSetWindowPos_Str(name: *const cty::c_char, pos: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowPos_Str(name: *const core::ffi::c_char, pos: ImVec2, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igSetWindowSize_Str(name: *const cty::c_char, size: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowSize_Str(name: *const core::ffi::c_char, size: ImVec2, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igSetWindowCollapsed_Str(name: *const cty::c_char, collapsed: bool, cond: ImGuiCond);
+    pub fn igSetWindowCollapsed_Str(
+        name: *const core::ffi::c_char,
+        collapsed: bool,
+        cond: ImGuiCond,
+    );
 }
 extern "C" {
-    pub fn igSetWindowFocus_Str(name: *const cty::c_char);
+    pub fn igSetWindowFocus_Str(name: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igGetScrollX() -> f32;
@@ -6097,7 +6117,7 @@ extern "C" {
     pub fn igPushStyleColor_Vec4(idx: ImGuiCol, col: ImVec4);
 }
 extern "C" {
-    pub fn igPopStyleColor(count: cty::c_int);
+    pub fn igPopStyleColor(count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushStyleVar_Float(idx: ImGuiStyleVar, val: f32);
@@ -6112,7 +6132,7 @@ extern "C" {
     pub fn igPushStyleVarY(idx: ImGuiStyleVar, val_y: f32);
 }
 extern "C" {
-    pub fn igPopStyleVar(count: cty::c_int);
+    pub fn igPopStyleVar(count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushItemFlag(option: ImGuiItemFlags, enabled: bool);
@@ -6232,113 +6252,116 @@ extern "C" {
     pub fn igGetFrameHeightWithSpacing() -> f32;
 }
 extern "C" {
-    pub fn igPushID_Str(str_id: *const cty::c_char);
+    pub fn igPushID_Str(str_id: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igPushID_StrStr(str_id_begin: *const cty::c_char, str_id_end: *const cty::c_char);
+    pub fn igPushID_StrStr(
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
+    );
 }
 extern "C" {
-    pub fn igPushID_Ptr(ptr_id: *const cty::c_void);
+    pub fn igPushID_Ptr(ptr_id: *const core::ffi::c_void);
 }
 extern "C" {
-    pub fn igPushID_Int(int_id: cty::c_int);
+    pub fn igPushID_Int(int_id: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPopID();
 }
 extern "C" {
-    pub fn igGetID_Str(str_id: *const cty::c_char) -> ImGuiID;
+    pub fn igGetID_Str(str_id: *const core::ffi::c_char) -> ImGuiID;
 }
 extern "C" {
     pub fn igGetID_StrStr(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetID_Ptr(ptr_id: *const cty::c_void) -> ImGuiID;
+    pub fn igGetID_Ptr(ptr_id: *const core::ffi::c_void) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetID_Int(int_id: cty::c_int) -> ImGuiID;
+    pub fn igGetID_Int(int_id: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
-    pub fn igTextUnformatted(text: *const cty::c_char, text_end: *const cty::c_char);
+    pub fn igTextUnformatted(text: *const core::ffi::c_char, text_end: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igText(fmt: *const cty::c_char, ...);
+    pub fn igText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextColored(col: ImVec4, fmt: *const cty::c_char, ...);
+    pub fn igTextColored(col: ImVec4, fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextDisabled(fmt: *const cty::c_char, ...);
+    pub fn igTextDisabled(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextWrapped(fmt: *const cty::c_char, ...);
+    pub fn igTextWrapped(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igLabelText(label: *const cty::c_char, fmt: *const cty::c_char, ...);
+    pub fn igLabelText(label: *const core::ffi::c_char, fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igBulletText(fmt: *const cty::c_char, ...);
+    pub fn igBulletText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igSeparatorText(label: *const cty::c_char);
+    pub fn igSeparatorText(label: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igButton(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igButton(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 extern "C" {
-    pub fn igSmallButton(label: *const cty::c_char) -> bool;
+    pub fn igSmallButton(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
     pub fn igInvisibleButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         flags: ImGuiButtonFlags,
     ) -> bool;
 }
 extern "C" {
-    pub fn igArrowButton(str_id: *const cty::c_char, dir: ImGuiDir) -> bool;
+    pub fn igArrowButton(str_id: *const core::ffi::c_char, dir: ImGuiDir) -> bool;
 }
 extern "C" {
-    pub fn igCheckbox(label: *const cty::c_char, v: *mut bool) -> bool;
+    pub fn igCheckbox(label: *const core::ffi::c_char, v: *mut bool) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_IntPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_int,
-        flags_value: cty::c_int,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_int,
+        flags_value: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_UintPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_uint,
-        flags_value: cty::c_uint,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_uint,
+        flags_value: core::ffi::c_uint,
     ) -> bool;
 }
 extern "C" {
-    pub fn igRadioButton_Bool(label: *const cty::c_char, active: bool) -> bool;
+    pub fn igRadioButton_Bool(label: *const core::ffi::c_char, active: bool) -> bool;
 }
 extern "C" {
     pub fn igRadioButton_IntPtr(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_button: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_button: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
-    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const cty::c_char);
+    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igBullet();
 }
 extern "C" {
-    pub fn igTextLink(label: *const cty::c_char) -> bool;
+    pub fn igTextLink(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igTextLinkOpenURL(label: *const cty::c_char, url: *const cty::c_char);
+    pub fn igTextLinkOpenURL(label: *const core::ffi::c_char, url: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igImage(
@@ -6352,7 +6375,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igImageButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         user_texture_id: ImTextureID,
         image_size: ImVec2,
         uv0: ImVec2,
@@ -6363,8 +6386,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginCombo(
-        label: *const cty::c_char,
-        preview_value: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        preview_value: *const core::ffi::c_char,
         flags: ImGuiComboFlags,
     ) -> bool;
 }
@@ -6373,475 +6396,475 @@ extern "C" {
 }
 extern "C" {
     pub fn igCombo_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCombo_Str(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items_separated_by_zeros: *const cty::c_char,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items_separated_by_zeros: *const core::ffi::c_char,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCombo_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloatRange2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_current_min: *mut f32,
         v_current_max: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragIntRange2(
-        label: *const cty::c_char,
-        v_current_min: *mut cty::c_int,
-        v_current_max: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v_current_min: *mut core::ffi::c_int,
+        v_current_max: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderAngle(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_rad: *mut f32,
         v_degrees_min: f32,
         v_degrees_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderInt(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputText(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputTextMultiline(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         size: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputTextWithHint(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         step: f32,
         step_fast: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        step: cty::c_int,
-        step_fast: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        step: core::ffi::c_int,
+        step_fast: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputDouble(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f64,
         step: f64,
         step_fast: f64,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorEdit3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorEdit4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorPicker3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorPicker4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
         ref_col: *const f32,
@@ -6849,7 +6872,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igColorButton(
-        desc_id: *const cty::c_char,
+        desc_id: *const core::ffi::c_char,
         col: ImVec4,
         flags: ImGuiColorEditFlags,
         size: ImVec2,
@@ -6859,38 +6882,46 @@ extern "C" {
     pub fn igSetColorEditOptions(flags: ImGuiColorEditFlags);
 }
 extern "C" {
-    pub fn igTreeNode_Str(label: *const cty::c_char) -> bool;
+    pub fn igTreeNode_Str(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igTreeNode_StrStr(str_id: *const cty::c_char, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_StrStr(
+        str_id: *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 extern "C" {
-    pub fn igTreeNode_Ptr(ptr_id: *const cty::c_void, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_Ptr(
+        ptr_id: *const core::ffi::c_void,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 extern "C" {
-    pub fn igTreeNodeEx_Str(label: *const cty::c_char, flags: ImGuiTreeNodeFlags) -> bool;
+    pub fn igTreeNodeEx_Str(label: *const core::ffi::c_char, flags: ImGuiTreeNodeFlags) -> bool;
 }
 extern "C" {
     pub fn igTreeNodeEx_StrStr(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 extern "C" {
     pub fn igTreeNodeEx_Ptr(
-        ptr_id: *const cty::c_void,
+        ptr_id: *const core::ffi::c_void,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 extern "C" {
-    pub fn igTreePush_Str(str_id: *const cty::c_char);
+    pub fn igTreePush_Str(str_id: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igTreePush_Ptr(ptr_id: *const cty::c_void);
+    pub fn igTreePush_Ptr(ptr_id: *const core::ffi::c_void);
 }
 extern "C" {
     pub fn igTreePop();
@@ -6900,13 +6931,13 @@ extern "C" {
 }
 extern "C" {
     pub fn igCollapsingHeader_TreeNodeFlags(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igCollapsingHeader_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_visible: *mut bool,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
@@ -6919,7 +6950,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igSelectable_Bool(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         selected: bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -6927,7 +6958,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igSelectable_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_selected: *mut bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -6936,8 +6967,8 @@ extern "C" {
 extern "C" {
     pub fn igBeginMultiSelect(
         flags: ImGuiMultiSelectFlags,
-        selection_size: cty::c_int,
-        items_count: cty::c_int,
+        selection_size: core::ffi::c_int,
+        items_count: core::ffi::c_int,
     ) -> *mut ImGuiMultiSelectIO;
 }
 extern "C" {
@@ -6950,58 +6981,58 @@ extern "C" {
     pub fn igIsItemToggledSelection() -> bool;
 }
 extern "C" {
-    pub fn igBeginListBox(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igBeginListBox(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 extern "C" {
     pub fn igEndListBox();
 }
 extern "C" {
     pub fn igListBox_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igListBox_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igPlotLines_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn igPlotLines_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -7009,43 +7040,47 @@ extern "C" {
 }
 extern "C" {
     pub fn igPlotHistogram_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn igPlotHistogram_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
     );
 }
 extern "C" {
-    pub fn igValue_Bool(prefix: *const cty::c_char, b: bool);
+    pub fn igValue_Bool(prefix: *const core::ffi::c_char, b: bool);
 }
 extern "C" {
-    pub fn igValue_Int(prefix: *const cty::c_char, v: cty::c_int);
+    pub fn igValue_Int(prefix: *const core::ffi::c_char, v: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igValue_Uint(prefix: *const cty::c_char, v: cty::c_uint);
+    pub fn igValue_Uint(prefix: *const core::ffi::c_char, v: core::ffi::c_uint);
 }
 extern "C" {
-    pub fn igValue_Float(prefix: *const cty::c_char, v: f32, float_format: *const cty::c_char);
+    pub fn igValue_Float(
+        prefix: *const core::ffi::c_char,
+        v: f32,
+        float_format: *const core::ffi::c_char,
+    );
 }
 extern "C" {
     pub fn igBeginMenuBar() -> bool;
@@ -7060,23 +7095,23 @@ extern "C" {
     pub fn igEndMainMenuBar();
 }
 extern "C" {
-    pub fn igBeginMenu(label: *const cty::c_char, enabled: bool) -> bool;
+    pub fn igBeginMenu(label: *const core::ffi::c_char, enabled: bool) -> bool;
 }
 extern "C" {
     pub fn igEndMenu();
 }
 extern "C" {
     pub fn igMenuItem_Bool(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
 }
 extern "C" {
     pub fn igMenuItem_BoolPtr(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         p_selected: *mut bool,
         enabled: bool,
     ) -> bool;
@@ -7088,20 +7123,20 @@ extern "C" {
     pub fn igEndTooltip();
 }
 extern "C" {
-    pub fn igSetTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetTooltip(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
     pub fn igBeginItemTooltip() -> bool;
 }
 extern "C" {
-    pub fn igSetItemTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetItemTooltip(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igBeginPopup(str_id: *const cty::c_char, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBeginPopup(str_id: *const core::ffi::c_char, flags: ImGuiWindowFlags) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupModal(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiWindowFlags,
     ) -> bool;
@@ -7110,42 +7145,42 @@ extern "C" {
     pub fn igEndPopup();
 }
 extern "C" {
-    pub fn igOpenPopup_Str(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopup_Str(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
     pub fn igOpenPopup_ID(id: ImGuiID, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
-    pub fn igOpenPopupOnItemClick(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopupOnItemClick(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
     pub fn igCloseCurrentPopup();
 }
 extern "C" {
     pub fn igBeginPopupContextItem(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupContextWindow(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupContextVoid(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
-    pub fn igIsPopupOpen_Str(str_id: *const cty::c_char, flags: ImGuiPopupFlags) -> bool;
+    pub fn igIsPopupOpen_Str(str_id: *const core::ffi::c_char, flags: ImGuiPopupFlags) -> bool;
 }
 extern "C" {
     pub fn igBeginTable(
-        str_id: *const cty::c_char,
-        columns: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        columns: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -7161,21 +7196,21 @@ extern "C" {
     pub fn igTableNextColumn() -> bool;
 }
 extern "C" {
-    pub fn igTableSetColumnIndex(column_n: cty::c_int) -> bool;
+    pub fn igTableSetColumnIndex(column_n: core::ffi::c_int) -> bool;
 }
 extern "C" {
     pub fn igTableSetupColumn(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTableColumnFlags,
         init_width_or_weight: f32,
         user_id: ImGuiID,
     );
 }
 extern "C" {
-    pub fn igTableSetupScrollFreeze(cols: cty::c_int, rows: cty::c_int);
+    pub fn igTableSetupScrollFreeze(cols: core::ffi::c_int, rows: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igTableHeader(label: *const cty::c_char);
+    pub fn igTableHeader(label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igTableHeadersRow();
@@ -7187,62 +7222,62 @@ extern "C" {
     pub fn igTableGetSortSpecs() -> *mut ImGuiTableSortSpecs;
 }
 extern "C" {
-    pub fn igTableGetColumnCount() -> cty::c_int;
+    pub fn igTableGetColumnCount() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetColumnIndex() -> cty::c_int;
+    pub fn igTableGetColumnIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetRowIndex() -> cty::c_int;
+    pub fn igTableGetRowIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetColumnName_Int(column_n: cty::c_int) -> *const cty::c_char;
+    pub fn igTableGetColumnName_Int(column_n: core::ffi::c_int) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igTableGetColumnFlags(column_n: cty::c_int) -> ImGuiTableColumnFlags;
+    pub fn igTableGetColumnFlags(column_n: core::ffi::c_int) -> ImGuiTableColumnFlags;
 }
 extern "C" {
-    pub fn igTableSetColumnEnabled(column_n: cty::c_int, v: bool);
+    pub fn igTableSetColumnEnabled(column_n: core::ffi::c_int, v: bool);
 }
 extern "C" {
-    pub fn igTableGetHoveredColumn() -> cty::c_int;
+    pub fn igTableGetHoveredColumn() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: cty::c_int);
+    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igColumns(count: cty::c_int, id: *const cty::c_char, borders: bool);
+    pub fn igColumns(count: core::ffi::c_int, id: *const core::ffi::c_char, borders: bool);
 }
 extern "C" {
     pub fn igNextColumn();
 }
 extern "C" {
-    pub fn igGetColumnIndex() -> cty::c_int;
+    pub fn igGetColumnIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igGetColumnWidth(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnWidth(column_index: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igSetColumnWidth(column_index: cty::c_int, width: f32);
+    pub fn igSetColumnWidth(column_index: core::ffi::c_int, width: f32);
 }
 extern "C" {
-    pub fn igGetColumnOffset(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnOffset(column_index: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igSetColumnOffset(column_index: cty::c_int, offset_x: f32);
+    pub fn igSetColumnOffset(column_index: core::ffi::c_int, offset_x: f32);
 }
 extern "C" {
-    pub fn igGetColumnsCount() -> cty::c_int;
+    pub fn igGetColumnsCount() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igBeginTabBar(str_id: *const cty::c_char, flags: ImGuiTabBarFlags) -> bool;
+    pub fn igBeginTabBar(str_id: *const core::ffi::c_char, flags: ImGuiTabBarFlags) -> bool;
 }
 extern "C" {
     pub fn igEndTabBar();
 }
 extern "C" {
     pub fn igBeginTabItem(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
     ) -> bool;
@@ -7251,10 +7286,10 @@ extern "C" {
     pub fn igEndTabItem();
 }
 extern "C" {
-    pub fn igTabItemButton(label: *const cty::c_char, flags: ImGuiTabItemFlags) -> bool;
+    pub fn igTabItemButton(label: *const core::ffi::c_char, flags: ImGuiTabItemFlags) -> bool;
 }
 extern "C" {
-    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const cty::c_char);
+    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDockSpace(
@@ -7285,13 +7320,13 @@ extern "C" {
     pub fn igIsWindowDocked() -> bool;
 }
 extern "C" {
-    pub fn igLogToTTY(auto_open_depth: cty::c_int);
+    pub fn igLogToTTY(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igLogToFile(auto_open_depth: cty::c_int, filename: *const cty::c_char);
+    pub fn igLogToFile(auto_open_depth: core::ffi::c_int, filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLogToClipboard(auto_open_depth: cty::c_int);
+    pub fn igLogToClipboard(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
     pub fn igLogFinish();
@@ -7304,8 +7339,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igSetDragDropPayload(
-        type_: *const cty::c_char,
-        data: *const cty::c_void,
+        type_: *const core::ffi::c_char,
+        data: *const core::ffi::c_void,
         sz: usize,
         cond: ImGuiCond,
     ) -> bool;
@@ -7318,7 +7353,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igAcceptDragDropPayload(
-        type_: *const cty::c_char,
+        type_: *const core::ffi::c_char,
         flags: ImGuiDragDropFlags,
     ) -> *const ImGuiPayload;
 }
@@ -7348,7 +7383,7 @@ extern "C" {
     pub fn igSetItemDefaultFocus();
 }
 extern "C" {
-    pub fn igSetKeyboardFocusHere(offset: cty::c_int);
+    pub fn igSetKeyboardFocusHere(offset: core::ffi::c_int);
 }
 extern "C" {
     pub fn igSetNextItemAllowOverlap();
@@ -7423,13 +7458,13 @@ extern "C" {
     pub fn igGetTime() -> f64;
 }
 extern "C" {
-    pub fn igGetFrameCount() -> cty::c_int;
+    pub fn igGetFrameCount() -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igGetDrawListSharedData() -> *mut ImDrawListSharedData;
 }
 extern "C" {
-    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const cty::c_char;
+    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetStateStorage(storage: *mut ImGuiStorage);
@@ -7440,8 +7475,8 @@ extern "C" {
 extern "C" {
     pub fn igCalcTextSize(
         pOut: *mut ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_double_hash: bool,
         wrap_width: f32,
     );
@@ -7485,10 +7520,10 @@ extern "C" {
     pub fn igIsKeyChordPressed_Nil(key_chord: ImGuiKeyChord) -> bool;
 }
 extern "C" {
-    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> cty::c_int;
+    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igGetKeyName(key: ImGuiKey) -> *const cty::c_char;
+    pub fn igGetKeyName(key: ImGuiKey) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetNextFrameWantCaptureKeyboard(want_capture_keyboard: bool);
@@ -7515,7 +7550,7 @@ extern "C" {
     pub fn igIsMouseDoubleClicked_Nil(button: ImGuiMouseButton) -> bool;
 }
 extern "C" {
-    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> cty::c_int;
+    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igIsMouseHoveringRect(r_min: ImVec2, r_max: ImVec2, clip: bool) -> bool;
@@ -7551,25 +7586,25 @@ extern "C" {
     pub fn igSetNextFrameWantCaptureMouse(want_capture_mouse: bool);
 }
 extern "C" {
-    pub fn igGetClipboardText() -> *const cty::c_char;
+    pub fn igGetClipboardText() -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igSetClipboardText(text: *const cty::c_char);
+    pub fn igSetClipboardText(text: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLoadIniSettingsFromDisk(ini_filename: *const cty::c_char);
+    pub fn igLoadIniSettingsFromDisk(ini_filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLoadIniSettingsFromMemory(ini_data: *const cty::c_char, ini_size: usize);
+    pub fn igLoadIniSettingsFromMemory(ini_data: *const core::ffi::c_char, ini_size: usize);
 }
 extern "C" {
-    pub fn igSaveIniSettingsToDisk(ini_filename: *const cty::c_char);
+    pub fn igSaveIniSettingsToDisk(ini_filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const cty::c_char;
+    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igDebugTextEncoding(text: *const cty::c_char);
+    pub fn igDebugTextEncoding(text: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugFlashStyleColor(idx: ImGuiCol);
@@ -7579,7 +7614,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igDebugCheckVersionAndDataLayout(
-        version_str: *const cty::c_char,
+        version_str: *const core::ffi::c_char,
         sz_io: usize,
         sz_style: usize,
         sz_vec2: usize,
@@ -7589,35 +7624,35 @@ extern "C" {
     ) -> bool;
 }
 extern "C" {
-    pub fn igDebugLog(fmt: *const cty::c_char, ...);
+    pub fn igDebugLog(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
     pub fn igSetAllocatorFunctions(
         alloc_func: ImGuiMemAllocFunc,
         free_func: ImGuiMemFreeFunc,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
     pub fn igGetAllocatorFunctions(
         p_alloc_func: *mut ImGuiMemAllocFunc,
         p_free_func: *mut ImGuiMemFreeFunc,
-        p_user_data: *mut *mut cty::c_void,
+        p_user_data: *mut *mut core::ffi::c_void,
     );
 }
 extern "C" {
-    pub fn igMemAlloc(size: usize) -> *mut cty::c_void;
+    pub fn igMemAlloc(size: usize) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn igMemFree(ptr: *mut cty::c_void);
+    pub fn igMemFree(ptr: *mut core::ffi::c_void);
 }
 extern "C" {
     pub fn igUpdatePlatformWindows();
 }
 extern "C" {
     pub fn igRenderPlatformWindowsDefault(
-        platform_render_arg: *mut cty::c_void,
-        renderer_render_arg: *mut cty::c_void,
+        platform_render_arg: *mut core::ffi::c_void,
+        renderer_render_arg: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -7627,7 +7662,9 @@ extern "C" {
     pub fn igFindViewportByID(id: ImGuiID) -> *mut ImGuiViewport;
 }
 extern "C" {
-    pub fn igFindViewportByPlatformHandle(platform_handle: *mut cty::c_void) -> *mut ImGuiViewport;
+    pub fn igFindViewportByPlatformHandle(
+        platform_handle: *mut core::ffi::c_void,
+    ) -> *mut ImGuiViewport;
 }
 extern "C" {
     pub fn ImGuiTableSortSpecs_ImGuiTableSortSpecs() -> *mut ImGuiTableSortSpecs;
@@ -7660,7 +7697,7 @@ extern "C" {
     pub fn ImGuiIO_AddMousePosEvent(self_: *mut ImGuiIO, x: f32, y: f32);
 }
 extern "C" {
-    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: cty::c_int, down: bool);
+    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: core::ffi::c_int, down: bool);
 }
 extern "C" {
     pub fn ImGuiIO_AddMouseWheelEvent(self_: *mut ImGuiIO, wheel_x: f32, wheel_y: f32);
@@ -7675,21 +7712,21 @@ extern "C" {
     pub fn ImGuiIO_AddFocusEvent(self_: *mut ImGuiIO, focused: bool);
 }
 extern "C" {
-    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: cty::c_uint);
+    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: core::ffi::c_uint);
 }
 extern "C" {
     pub fn ImGuiIO_AddInputCharacterUTF16(self_: *mut ImGuiIO, c: ImWchar16);
 }
 extern "C" {
-    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const cty::c_char);
+    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn ImGuiIO_SetKeyEventNativeData(
         self_: *mut ImGuiIO,
         key: ImGuiKey,
-        native_keycode: cty::c_int,
-        native_scancode: cty::c_int,
-        native_legacy_index: cty::c_int,
+        native_keycode: core::ffi::c_int,
+        native_scancode: core::ffi::c_int,
+        native_legacy_index: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -7719,16 +7756,16 @@ extern "C" {
 extern "C" {
     pub fn ImGuiInputTextCallbackData_DeleteChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        bytes_count: cty::c_int,
+        pos: core::ffi::c_int,
+        bytes_count: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImGuiInputTextCallbackData_InsertChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        pos: core::ffi::c_int,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -7756,7 +7793,10 @@ extern "C" {
     pub fn ImGuiPayload_Clear(self_: *mut ImGuiPayload);
 }
 extern "C" {
-    pub fn ImGuiPayload_IsDataType(self_: *mut ImGuiPayload, type_: *const cty::c_char) -> bool;
+    pub fn ImGuiPayload_IsDataType(
+        self_: *mut ImGuiPayload,
+        type_: *const core::ffi::c_char,
+    ) -> bool;
 }
 extern "C" {
     pub fn ImGuiPayload_IsPreview(self_: *mut ImGuiPayload) -> bool;
@@ -7772,7 +7812,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiTextFilter_ImGuiTextFilter(
-        default_filter: *const cty::c_char,
+        default_filter: *const core::ffi::c_char,
     ) -> *mut ImGuiTextFilter;
 }
 extern "C" {
@@ -7781,15 +7821,15 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_Draw(
         self_: *mut ImGuiTextFilter,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         width: f32,
     ) -> bool;
 }
 extern "C" {
     pub fn ImGuiTextFilter_PassFilter(
         self_: *mut ImGuiTextFilter,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     ) -> bool;
 }
 extern "C" {
@@ -7809,8 +7849,8 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiTextRange_ImGuiTextRange_Str(
-        _b: *const cty::c_char,
-        _e: *const cty::c_char,
+        _b: *const core::ffi::c_char,
+        _e: *const core::ffi::c_char,
     ) -> *mut ImGuiTextRange;
 }
 extern "C" {
@@ -7819,7 +7859,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextRange_split(
         self_: *mut ImGuiTextRange,
-        separator: cty::c_char,
+        separator: core::ffi::c_char,
         out: *mut ImVector_ImGuiTextRange,
     );
 }
@@ -7830,13 +7870,13 @@ extern "C" {
     pub fn ImGuiTextBuffer_destroy(self_: *mut ImGuiTextBuffer);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> cty::c_int;
+    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiTextBuffer_empty(self_: *mut ImGuiTextBuffer) -> bool;
@@ -7845,22 +7885,22 @@ extern "C" {
     pub fn ImGuiTextBuffer_clear(self_: *mut ImGuiTextBuffer);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: cty::c_int);
+    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiTextBuffer_append(
         self_: *mut ImGuiTextBuffer,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Int(
         _key: ImGuiID,
-        _val: cty::c_int,
+        _val: core::ffi::c_int,
     ) -> *mut ImGuiStoragePair;
 }
 extern "C" {
@@ -7875,7 +7915,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Ptr(
         _key: ImGuiID,
-        _val: *mut cty::c_void,
+        _val: *mut core::ffi::c_void,
     ) -> *mut ImGuiStoragePair;
 }
 extern "C" {
@@ -7885,11 +7925,11 @@ extern "C" {
     pub fn ImGuiStorage_GetInt(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: cty::c_int);
+    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiStorage_GetBool(self_: *mut ImGuiStorage, key: ImGuiID, default_val: bool) -> bool;
@@ -7904,17 +7944,24 @@ extern "C" {
     pub fn ImGuiStorage_SetFloat(self_: *mut ImGuiStorage, key: ImGuiID, val: f32);
 }
 extern "C" {
-    pub fn ImGuiStorage_GetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID) -> *mut cty::c_void;
+    pub fn ImGuiStorage_GetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+    ) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn ImGuiStorage_SetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID, val: *mut cty::c_void);
+    pub fn ImGuiStorage_SetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+        val: *mut core::ffi::c_void,
+    );
 }
 extern "C" {
     pub fn ImGuiStorage_GetIntRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> *mut cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> *mut core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiStorage_GetBoolRef(
@@ -7934,14 +7981,14 @@ extern "C" {
     pub fn ImGuiStorage_GetVoidPtrRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: *mut cty::c_void,
-    ) -> *mut *mut cty::c_void;
+        default_val: *mut core::ffi::c_void,
+    ) -> *mut *mut core::ffi::c_void;
 }
 extern "C" {
     pub fn ImGuiStorage_BuildSortByKey(self_: *mut ImGuiStorage);
 }
 extern "C" {
-    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: cty::c_int);
+    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiListClipper_ImGuiListClipper() -> *mut ImGuiListClipper;
@@ -7952,7 +7999,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_Begin(
         self_: *mut ImGuiListClipper,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         items_height: f32,
     );
 }
@@ -7965,18 +8012,21 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemByIndex(
         self_: *mut ImGuiListClipper,
-        item_index: cty::c_int,
+        item_index: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemsByIndex(
         self_: *mut ImGuiListClipper,
-        item_begin: cty::c_int,
-        item_end: cty::c_int,
+        item_begin: core::ffi::c_int,
+        item_end: core::ffi::c_int,
     );
 }
 extern "C" {
-    pub fn ImGuiListClipper_SeekCursorForItem(self_: *mut ImGuiListClipper, item_index: cty::c_int);
+    pub fn ImGuiListClipper_SeekCursorForItem(
+        self_: *mut ImGuiListClipper,
+        item_index: core::ffi::c_int,
+    );
 }
 extern "C" {
     pub fn ImColor_ImColor_Nil() -> *mut ImColor;
@@ -7992,10 +8042,10 @@ extern "C" {
 }
 extern "C" {
     pub fn ImColor_ImColor_Int(
-        r: cty::c_int,
-        g: cty::c_int,
-        b: cty::c_int,
-        a: cty::c_int,
+        r: core::ffi::c_int,
+        g: core::ffi::c_int,
+        b: core::ffi::c_int,
+        a: core::ffi::c_int,
     ) -> *mut ImColor;
 }
 extern "C" {
@@ -8044,14 +8094,14 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetNextSelectedItem(
         self_: *mut ImGuiSelectionBasicStorage,
-        opaque_it: *mut *mut cty::c_void,
+        opaque_it: *mut *mut core::ffi::c_void,
         out_id: *mut ImGuiID,
     ) -> bool;
 }
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetStorageIdFromIndex(
         self_: *mut ImGuiSelectionBasicStorage,
-        idx: cty::c_int,
+        idx: core::ffi::c_int,
     ) -> ImGuiID;
 }
 extern "C" {
@@ -8092,7 +8142,7 @@ extern "C" {
     pub fn ImDrawListSplitter_Split(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        count: cty::c_int,
+        count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8102,7 +8152,7 @@ extern "C" {
     pub fn ImDrawListSplitter_SetCurrentChannel(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        channel_idx: cty::c_int,
+        channel_idx: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8224,7 +8274,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8234,7 +8284,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8243,7 +8293,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8253,7 +8303,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8263,7 +8313,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8274,7 +8324,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8282,8 +8332,8 @@ extern "C" {
         self_: *mut ImDrawList,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -8293,8 +8343,8 @@ extern "C" {
         font_size: f32,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip_rect: *const ImVec4,
     );
@@ -8308,7 +8358,7 @@ extern "C" {
         p4: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8319,14 +8369,14 @@ extern "C" {
         p3: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImDrawList_AddPolyline(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
         flags: ImDrawFlags,
         thickness: f32,
@@ -8336,7 +8386,7 @@ extern "C" {
     pub fn ImDrawList_AddConvexPolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -8344,7 +8394,7 @@ extern "C" {
     pub fn ImDrawList_AddConcavePolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -8417,7 +8467,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8425,8 +8475,8 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_of_12: cty::c_int,
-        a_max_of_12: cty::c_int,
+        a_min_of_12: core::ffi::c_int,
+        a_max_of_12: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8437,7 +8487,7 @@ extern "C" {
         rot: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8446,7 +8496,7 @@ extern "C" {
         p2: ImVec2,
         p3: ImVec2,
         p4: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8454,7 +8504,7 @@ extern "C" {
         self_: *mut ImDrawList,
         p2: ImVec2,
         p3: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8470,7 +8520,7 @@ extern "C" {
     pub fn ImDrawList_AddCallback(
         self_: *mut ImDrawList,
         callback: ImDrawCallback,
-        callback_data: *mut cty::c_void,
+        callback_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -8480,26 +8530,26 @@ extern "C" {
     pub fn ImDrawList_CloneOutput(self_: *mut ImDrawList) -> *mut ImDrawList;
 }
 extern "C" {
-    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: cty::c_int);
+    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImDrawList_ChannelsMerge(self_: *mut ImDrawList);
 }
 extern "C" {
-    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: cty::c_int);
+    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImDrawList_PrimReserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImDrawList_PrimUnreserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8566,16 +8616,16 @@ extern "C" {
     pub fn ImDrawList__CalcCircleAutoSegmentCount(
         self_: *mut ImDrawList,
         radius: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImDrawList__PathArcToFastEx(
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_sample: cty::c_int,
-        a_max_sample: cty::c_int,
-        a_step: cty::c_int,
+        a_min_sample: core::ffi::c_int,
+        a_max_sample: core::ffi::c_int,
+        a_step: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8585,7 +8635,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8633,8 +8683,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontGlyphRangesBuilder_AddText(
         self_: *mut ImFontGlyphRangesBuilder,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -8679,7 +8729,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromFileTTF(
         self_: *mut ImFontAtlas,
-        filename: *const cty::c_char,
+        filename: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -8688,8 +8738,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryTTF(
         self_: *mut ImFontAtlas,
-        font_data: *mut cty::c_void,
-        font_data_size: cty::c_int,
+        font_data: *mut core::ffi::c_void,
+        font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -8698,8 +8748,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedTTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data: *const cty::c_void,
-        compressed_font_data_size: cty::c_int,
+        compressed_font_data: *const core::ffi::c_void,
+        compressed_font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -8708,7 +8758,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data_base85: *const cty::c_char,
+        compressed_font_data_base85: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -8732,19 +8782,19 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsAlpha8(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsRGBA32(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8785,25 +8835,25 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectRegular(
         self_: *mut ImFontAtlas,
-        width: cty::c_int,
-        height: cty::c_int,
-    ) -> cty::c_int;
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectFontGlyph(
         self_: *mut ImFontAtlas,
         font: *mut ImFont,
         id: ImWchar,
-        width: cty::c_int,
-        height: cty::c_int,
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
         advance_x: f32,
         offset: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImFontAtlas_GetCustomRectByIndex(
         self_: *mut ImFontAtlas,
-        index: cty::c_int,
+        index: core::ffi::c_int,
     ) -> *mut ImFontAtlasCustomRect;
 }
 extern "C" {
@@ -8843,7 +8893,7 @@ extern "C" {
     pub fn ImFont_IsLoaded(self_: *mut ImFont) -> bool;
 }
 extern "C" {
-    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const cty::c_char;
+    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImFont_CalcTextSizeA(
@@ -8852,19 +8902,19 @@ extern "C" {
         size: f32,
         max_width: f32,
         wrap_width: f32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
-        remaining: *mut *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        remaining: *mut *const core::ffi::c_char,
     );
 }
 extern "C" {
     pub fn ImFont_CalcWordWrapPositionA(
         self_: *mut ImFont,
         scale: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImFont_RenderChar(
@@ -8884,8 +8934,8 @@ extern "C" {
         pos: ImVec2,
         col: ImU32,
         clip_rect: ImVec4,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip: bool,
     );
@@ -8897,7 +8947,7 @@ extern "C" {
     pub fn ImFont_ClearOutputData(self_: *mut ImFont);
 }
 extern "C" {
-    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: cty::c_int);
+    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImFont_AddGlyph(
@@ -8924,8 +8974,8 @@ extern "C" {
 extern "C" {
     pub fn ImFont_IsGlyphRangeUnused(
         self_: *mut ImFont,
-        c_begin: cty::c_uint,
-        c_last: cty::c_uint,
+        c_begin: core::ffi::c_uint,
+        c_last: core::ffi::c_uint,
     ) -> bool;
 }
 extern "C" {
@@ -8959,18 +9009,22 @@ extern "C" {
     pub fn ImGuiPlatformImeData_destroy(self_: *mut ImGuiPlatformImeData);
 }
 extern "C" {
-    pub fn igImHashData(data: *const cty::c_void, data_size: usize, seed: ImGuiID) -> ImGuiID;
+    pub fn igImHashData(data: *const core::ffi::c_void, data_size: usize, seed: ImGuiID)
+        -> ImGuiID;
 }
 extern "C" {
-    pub fn igImHashStr(data: *const cty::c_char, data_size: usize, seed: ImGuiID) -> ImGuiID;
+    pub fn igImHashStr(data: *const core::ffi::c_char, data_size: usize, seed: ImGuiID) -> ImGuiID;
 }
 extern "C" {
     pub fn igImQsort(
-        base: *mut cty::c_void,
+        base: *mut core::ffi::c_void,
         count: usize,
         size_of_element: usize,
         compare_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *const cty::c_void, arg2: *const cty::c_void) -> cty::c_int,
+            unsafe extern "C" fn(
+                arg1: *const core::ffi::c_void,
+                arg2: *const core::ffi::c_void,
+            ) -> core::ffi::c_int,
         >,
     );
 }
@@ -8978,193 +9032,202 @@ extern "C" {
     pub fn igImAlphaBlendColors(col_a: ImU32, col_b: ImU32) -> ImU32;
 }
 extern "C" {
-    pub fn igImIsPowerOfTwo_Int(v: cty::c_int) -> bool;
+    pub fn igImIsPowerOfTwo_Int(v: core::ffi::c_int) -> bool;
 }
 extern "C" {
     pub fn igImIsPowerOfTwo_U64(v: ImU64) -> bool;
 }
 extern "C" {
-    pub fn igImUpperPowerOfTwo(v: cty::c_int) -> cty::c_int;
+    pub fn igImUpperPowerOfTwo(v: core::ffi::c_int) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igImStricmp(str1: *const cty::c_char, str2: *const cty::c_char) -> cty::c_int;
+    pub fn igImStricmp(
+        str1: *const core::ffi::c_char,
+        str2: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImStrnicmp(
-        str1: *const cty::c_char,
-        str2: *const cty::c_char,
+        str1: *const core::ffi::c_char,
+        str2: *const core::ffi::c_char,
         count: usize,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igImStrncpy(dst: *mut cty::c_char, src: *const cty::c_char, count: usize);
+    pub fn igImStrncpy(dst: *mut core::ffi::c_char, src: *const core::ffi::c_char, count: usize);
 }
 extern "C" {
-    pub fn igImStrdup(str_: *const cty::c_char) -> *mut cty::c_char;
+    pub fn igImStrdup(str_: *const core::ffi::c_char) -> *mut core::ffi::c_char;
 }
 extern "C" {
     pub fn igImStrdupcpy(
-        dst: *mut cty::c_char,
+        dst: *mut core::ffi::c_char,
         p_dst_size: *mut usize,
-        str_: *const cty::c_char,
-    ) -> *mut cty::c_char;
+        str_: *const core::ffi::c_char,
+    ) -> *mut core::ffi::c_char;
 }
 extern "C" {
     pub fn igImStrchrRange(
-        str_begin: *const cty::c_char,
-        str_end: *const cty::c_char,
-        c: cty::c_char,
-    ) -> *const cty::c_char;
+        str_begin: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
+        c: core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImStreolRange(
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImStristr(
-        haystack: *const cty::c_char,
-        haystack_end: *const cty::c_char,
-        needle: *const cty::c_char,
-        needle_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        haystack: *const core::ffi::c_char,
+        haystack_end: *const core::ffi::c_char,
+        needle: *const core::ffi::c_char,
+        needle_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImStrTrimBlanks(str_: *mut cty::c_char);
+    pub fn igImStrTrimBlanks(str_: *mut core::ffi::c_char);
 }
 extern "C" {
-    pub fn igImStrSkipBlank(str_: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImStrSkipBlank(str_: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImStrlenW(str_: *const ImWchar) -> cty::c_int;
+    pub fn igImStrlenW(str_: *const ImWchar) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImStrbol(
-        buf_mid_line: *const cty::c_char,
-        buf_begin: *const cty::c_char,
-    ) -> *const cty::c_char;
+        buf_mid_line: *const core::ffi::c_char,
+        buf_begin: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImToUpper(c: cty::c_char) -> cty::c_char;
+    pub fn igImToUpper(c: core::ffi::c_char) -> core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImCharIsBlankA(c: cty::c_char) -> bool;
+    pub fn igImCharIsBlankA(c: core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igImCharIsBlankW(c: cty::c_uint) -> bool;
+    pub fn igImCharIsBlankW(c: core::ffi::c_uint) -> bool;
 }
 extern "C" {
-    pub fn igImCharIsXdigitA(c: cty::c_char) -> bool;
+    pub fn igImCharIsXdigitA(c: core::ffi::c_char) -> bool;
 }
 extern "C" {
     pub fn igImFormatString(
-        buf: *mut cty::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImFormatStringToTempBuffer(
-        out_buf: *mut *const cty::c_char,
-        out_buf_end: *mut *const cty::c_char,
-        fmt: *const cty::c_char,
+        out_buf: *mut *const core::ffi::c_char,
+        out_buf_end: *mut *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     );
 }
 extern "C" {
-    pub fn igImParseFormatFindStart(format: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImParseFormatFindStart(format: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImParseFormatFindEnd(format: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImParseFormatFindEnd(format: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImParseFormatTrimDecorations(
-        format: *const cty::c_char,
-        buf: *mut cty::c_char,
+        format: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImParseFormatSanitizeForPrinting(
-        fmt_in: *const cty::c_char,
-        fmt_out: *mut cty::c_char,
+        fmt_in: *const core::ffi::c_char,
+        fmt_out: *mut core::ffi::c_char,
         fmt_out_size: usize,
     );
 }
 extern "C" {
     pub fn igImParseFormatSanitizeForScanning(
-        fmt_in: *const cty::c_char,
-        fmt_out: *mut cty::c_char,
+        fmt_in: *const core::ffi::c_char,
+        fmt_out: *mut core::ffi::c_char,
         fmt_out_size: usize,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImParseFormatPrecision(
-        format: *const cty::c_char,
-        default_value: cty::c_int,
-    ) -> cty::c_int;
+        format: *const core::ffi::c_char,
+        default_value: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igImTextCharToUtf8(out_buf: *mut cty::c_char, c: cty::c_uint) -> *const cty::c_char;
+    pub fn igImTextCharToUtf8(
+        out_buf: *mut core::ffi::c_char,
+        c: core::ffi::c_uint,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImTextStrToUtf8(
-        out_buf: *mut cty::c_char,
-        out_buf_size: cty::c_int,
+        out_buf: *mut core::ffi::c_char,
+        out_buf_size: core::ffi::c_int,
         in_text: *const ImWchar,
         in_text_end: *const ImWchar,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextCharFromUtf8(
-        out_char: *mut cty::c_uint,
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        out_char: *mut core::ffi::c_uint,
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextStrFromUtf8(
         out_buf: *mut ImWchar,
-        out_buf_size: cty::c_int,
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-        in_remaining: *mut *const cty::c_char,
-    ) -> cty::c_int;
+        out_buf_size: core::ffi::c_int,
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+        in_remaining: *mut *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextCountCharsFromUtf8(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextCountUtf8BytesFromChar(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextCountUtf8BytesFromStr(
         in_text: *const ImWchar,
         in_text_end: *const ImWchar,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextFindPreviousUtf8Codepoint(
-        in_text_start: *const cty::c_char,
-        in_text_curr: *const cty::c_char,
-    ) -> *const cty::c_char;
+        in_text_start: *const core::ffi::c_char,
+        in_text_curr: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImTextCountLines(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igImFileOpen(filename: *const cty::c_char, mode: *const cty::c_char) -> ImFileHandle;
+    pub fn igImFileOpen(
+        filename: *const core::ffi::c_char,
+        mode: *const core::ffi::c_char,
+    ) -> ImFileHandle;
 }
 extern "C" {
     pub fn igImFileClose(file: ImFileHandle) -> bool;
@@ -9174,7 +9237,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igImFileRead(
-        data: *mut cty::c_void,
+        data: *mut core::ffi::c_void,
         size: ImU64,
         count: ImU64,
         file: ImFileHandle,
@@ -9182,7 +9245,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igImFileWrite(
-        data: *const cty::c_void,
+        data: *const core::ffi::c_void,
         size: ImU64,
         count: ImU64,
         file: ImFileHandle,
@@ -9190,11 +9253,11 @@ extern "C" {
 }
 extern "C" {
     pub fn igImFileLoadToMemory(
-        filename: *const cty::c_char,
-        mode: *const cty::c_char,
+        filename: *const core::ffi::c_char,
+        mode: *const core::ffi::c_char,
         out_file_size: *mut usize,
-        padding_bytes: cty::c_int,
-    ) -> *mut cty::c_void;
+        padding_bytes: core::ffi::c_int,
+    ) -> *mut core::ffi::c_void;
 }
 extern "C" {
     pub fn igImPow_Float(x: f32, y: f32) -> f32;
@@ -9209,7 +9272,7 @@ extern "C" {
     pub fn igImLog_double(x: f64) -> f64;
 }
 extern "C" {
-    pub fn igImAbs_Int(x: cty::c_int) -> cty::c_int;
+    pub fn igImAbs_Int(x: core::ffi::c_int) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImAbs_Float(x: f32) -> f32;
@@ -9272,7 +9335,7 @@ extern "C" {
     pub fn igImFloor_Vec2(pOut: *mut ImVec2, v: ImVec2);
 }
 extern "C" {
-    pub fn igImModPositive(a: cty::c_int, b: cty::c_int) -> cty::c_int;
+    pub fn igImModPositive(a: core::ffi::c_int, b: core::ffi::c_int) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImDot(a: ImVec2, b: ImVec2) -> f32;
@@ -9293,7 +9356,7 @@ extern "C" {
     pub fn igImIsFloatAboveGuaranteedIntegerPrecision(f: f32) -> bool;
 }
 extern "C" {
-    pub fn igImExponentialMovingAverage(avg: f32, sample: f32, n: cty::c_int) -> f32;
+    pub fn igImExponentialMovingAverage(avg: f32, sample: f32, n: core::ffi::c_int) -> f32;
 }
 extern "C" {
     pub fn igImBezierCubicCalc(
@@ -9313,7 +9376,7 @@ extern "C" {
         p3: ImVec2,
         p4: ImVec2,
         p: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -9372,7 +9435,8 @@ extern "C" {
     pub fn ImVec2ih_destroy(self_: *mut ImVec2ih);
 }
 extern "C" {
-    pub fn ImVec2ih_ImVec2ih_short(_x: cty::c_short, _y: cty::c_short) -> *mut ImVec2ih;
+    pub fn ImVec2ih_ImVec2ih_short(_x: core::ffi::c_short, _y: core::ffi::c_short)
+        -> *mut ImVec2ih;
 }
 extern "C" {
     pub fn ImVec2ih_ImVec2ih_Vec2(rhs: ImVec2) -> *mut ImVec2ih;
@@ -9468,64 +9532,64 @@ extern "C" {
     pub fn ImRect_ToVec4(pOut: *mut ImVec4, self_: *mut ImRect);
 }
 extern "C" {
-    pub fn igImBitArrayGetStorageSizeInBytes(bitcount: cty::c_int) -> usize;
+    pub fn igImBitArrayGetStorageSizeInBytes(bitcount: core::ffi::c_int) -> usize;
 }
 extern "C" {
-    pub fn igImBitArrayClearAllBits(arr: *mut ImU32, bitcount: cty::c_int);
+    pub fn igImBitArrayClearAllBits(arr: *mut ImU32, bitcount: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igImBitArrayTestBit(arr: *const ImU32, n: cty::c_int) -> bool;
+    pub fn igImBitArrayTestBit(arr: *const ImU32, n: core::ffi::c_int) -> bool;
 }
 extern "C" {
-    pub fn igImBitArrayClearBit(arr: *mut ImU32, n: cty::c_int);
+    pub fn igImBitArrayClearBit(arr: *mut ImU32, n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igImBitArraySetBit(arr: *mut ImU32, n: cty::c_int);
+    pub fn igImBitArraySetBit(arr: *mut ImU32, n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igImBitArraySetBitRange(arr: *mut ImU32, n: cty::c_int, n2: cty::c_int);
+    pub fn igImBitArraySetBitRange(arr: *mut ImU32, n: core::ffi::c_int, n2: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImBitVector_Create(self_: *mut ImBitVector, sz: cty::c_int);
+    pub fn ImBitVector_Create(self_: *mut ImBitVector, sz: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImBitVector_Clear(self_: *mut ImBitVector);
 }
 extern "C" {
-    pub fn ImBitVector_TestBit(self_: *mut ImBitVector, n: cty::c_int) -> bool;
+    pub fn ImBitVector_TestBit(self_: *mut ImBitVector, n: core::ffi::c_int) -> bool;
 }
 extern "C" {
-    pub fn ImBitVector_SetBit(self_: *mut ImBitVector, n: cty::c_int);
+    pub fn ImBitVector_SetBit(self_: *mut ImBitVector, n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImBitVector_ClearBit(self_: *mut ImBitVector, n: cty::c_int);
+    pub fn ImBitVector_ClearBit(self_: *mut ImBitVector, n: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiTextIndex_clear(self_: *mut ImGuiTextIndex);
 }
 extern "C" {
-    pub fn ImGuiTextIndex_size(self_: *mut ImGuiTextIndex) -> cty::c_int;
+    pub fn ImGuiTextIndex_size(self_: *mut ImGuiTextIndex) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiTextIndex_get_line_begin(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        n: cty::c_int,
-    ) -> *const cty::c_char;
+        base: *const core::ffi::c_char,
+        n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiTextIndex_get_line_end(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        n: cty::c_int,
-    ) -> *const cty::c_char;
+        base: *const core::ffi::c_char,
+        n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiTextIndex_append(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        old_size: cty::c_int,
-        new_size: cty::c_int,
+        base: *const core::ffi::c_char,
+        old_size: core::ffi::c_int,
+        new_size: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -9556,12 +9620,14 @@ extern "C" {
 extern "C" {
     pub fn ImGuiDataVarInfo_GetVarPtr(
         self_: *mut ImGuiDataVarInfo,
-        parent: *mut cty::c_void,
-    ) -> *mut cty::c_void;
+        parent: *mut core::ffi::c_void,
+    ) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn ImGuiStyleMod_ImGuiStyleMod_Int(idx: ImGuiStyleVar, v: cty::c_int)
-        -> *mut ImGuiStyleMod;
+    pub fn ImGuiStyleMod_ImGuiStyleMod_Int(
+        idx: ImGuiStyleVar,
+        v: core::ffi::c_int,
+    ) -> *mut ImGuiStyleMod;
 }
 extern "C" {
     pub fn ImGuiStyleMod_destroy(self_: *mut ImGuiStyleMod);
@@ -9628,10 +9694,10 @@ extern "C" {
     pub fn ImGuiInputTextState_ClearFreeMemory(self_: *mut ImGuiInputTextState);
 }
 extern "C" {
-    pub fn ImGuiInputTextState_OnKeyPressed(self_: *mut ImGuiInputTextState, key: cty::c_int);
+    pub fn ImGuiInputTextState_OnKeyPressed(self_: *mut ImGuiInputTextState, key: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImGuiInputTextState_OnCharPressed(self_: *mut ImGuiInputTextState, c: cty::c_uint);
+    pub fn ImGuiInputTextState_OnCharPressed(self_: *mut ImGuiInputTextState, c: core::ffi::c_uint);
 }
 extern "C" {
     pub fn ImGuiInputTextState_CursorAnimReset(self_: *mut ImGuiInputTextState);
@@ -9646,13 +9712,16 @@ extern "C" {
     pub fn ImGuiInputTextState_ClearSelection(self_: *mut ImGuiInputTextState);
 }
 extern "C" {
-    pub fn ImGuiInputTextState_GetCursorPos(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetCursorPos(self_: *mut ImGuiInputTextState) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ImGuiInputTextState_GetSelectionStart(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetSelectionStart(
+        self_: *mut ImGuiInputTextState,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ImGuiInputTextState_GetSelectionEnd(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetSelectionEnd(self_: *mut ImGuiInputTextState)
+        -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiInputTextState_SelectAll(self_: *mut ImGuiInputTextState);
@@ -9697,13 +9766,14 @@ extern "C" {
     pub fn ImGuiErrorRecoveryState_destroy(self_: *mut ImGuiErrorRecoveryState);
 }
 extern "C" {
-    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Ptr(ptr: *mut cty::c_void) -> *mut ImGuiPtrOrIndex;
+    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Ptr(ptr: *mut core::ffi::c_void)
+        -> *mut ImGuiPtrOrIndex;
 }
 extern "C" {
     pub fn ImGuiPtrOrIndex_destroy(self_: *mut ImGuiPtrOrIndex);
 }
 extern "C" {
-    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Int(index: cty::c_int) -> *mut ImGuiPtrOrIndex;
+    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Int(index: core::ffi::c_int) -> *mut ImGuiPtrOrIndex;
 }
 extern "C" {
     pub fn ImGuiPopupData_ImGuiPopupData() -> *mut ImGuiPopupData;
@@ -9740,16 +9810,16 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiListClipperRange_FromIndices(
-        min: cty::c_int,
-        max: cty::c_int,
+        min: core::ffi::c_int,
+        max: core::ffi::c_int,
     ) -> ImGuiListClipperRange;
 }
 extern "C" {
     pub fn ImGuiListClipperRange_FromPositions(
         y1: f32,
         y2: f32,
-        off_min: cty::c_int,
-        off_max: cty::c_int,
+        off_min: core::ffi::c_int,
+        off_max: core::ffi::c_int,
     ) -> ImGuiListClipperRange;
 }
 extern "C" {
@@ -9909,7 +9979,7 @@ extern "C" {
     pub fn ImGuiWindowSettings_destroy(self_: *mut ImGuiWindowSettings);
 }
 extern "C" {
-    pub fn ImGuiWindowSettings_GetName(self_: *mut ImGuiWindowSettings) -> *mut cty::c_char;
+    pub fn ImGuiWindowSettings_GetName(self_: *mut ImGuiWindowSettings) -> *mut core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiSettingsHandler_ImGuiSettingsHandler() -> *mut ImGuiSettingsHandler;
@@ -9950,7 +10020,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiWindow_ImGuiWindow(
         context: *mut ImGuiContext,
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
     ) -> *mut ImGuiWindow;
 }
 extern "C" {
@@ -9959,15 +10029,16 @@ extern "C" {
 extern "C" {
     pub fn ImGuiWindow_GetID_Str(
         self_: *mut ImGuiWindow,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn ImGuiWindow_GetID_Ptr(self_: *mut ImGuiWindow, ptr: *const cty::c_void) -> ImGuiID;
+    pub fn ImGuiWindow_GetID_Ptr(self_: *mut ImGuiWindow, ptr: *const core::ffi::c_void)
+        -> ImGuiID;
 }
 extern "C" {
-    pub fn ImGuiWindow_GetID_Int(self_: *mut ImGuiWindow, n: cty::c_int) -> ImGuiID;
+    pub fn ImGuiWindow_GetID_Int(self_: *mut ImGuiWindow, n: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
     pub fn ImGuiWindow_GetIDFromPos(self_: *mut ImGuiWindow, p_abs: ImVec2) -> ImGuiID;
@@ -10050,7 +10121,7 @@ extern "C" {
     pub fn igFindWindowByID(id: ImGuiID) -> *mut ImGuiWindow;
 }
 extern "C" {
-    pub fn igFindWindowByName(name: *const cty::c_char) -> *mut ImGuiWindow;
+    pub fn igFindWindowByName(name: *const core::ffi::c_char) -> *mut ImGuiWindow;
 }
 extern "C" {
     pub fn igUpdateWindowParentAndRootLinks(
@@ -10149,7 +10220,7 @@ extern "C" {
     pub fn igBringWindowToDisplayBehind(window: *mut ImGuiWindow, above_window: *mut ImGuiWindow);
 }
 extern "C" {
-    pub fn igFindWindowDisplayIndex(window: *mut ImGuiWindow) -> cty::c_int;
+    pub fn igFindWindowDisplayIndex(window: *mut ImGuiWindow) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igFindBottomMostVisibleWindowWithinBeginStack(
@@ -10264,13 +10335,13 @@ extern "C" {
     pub fn igAddSettingsHandler(handler: *const ImGuiSettingsHandler);
 }
 extern "C" {
-    pub fn igRemoveSettingsHandler(type_name: *const cty::c_char);
+    pub fn igRemoveSettingsHandler(type_name: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igFindSettingsHandler(type_name: *const cty::c_char) -> *mut ImGuiSettingsHandler;
+    pub fn igFindSettingsHandler(type_name: *const core::ffi::c_char) -> *mut ImGuiSettingsHandler;
 }
 extern "C" {
-    pub fn igCreateNewWindowSettings(name: *const cty::c_char) -> *mut ImGuiWindowSettings;
+    pub fn igCreateNewWindowSettings(name: *const core::ffi::c_char) -> *mut ImGuiWindowSettings;
 }
 extern "C" {
     pub fn igFindWindowSettingsByID(id: ImGuiID) -> *mut ImGuiWindowSettings;
@@ -10279,13 +10350,13 @@ extern "C" {
     pub fn igFindWindowSettingsByWindow(window: *mut ImGuiWindow) -> *mut ImGuiWindowSettings;
 }
 extern "C" {
-    pub fn igClearWindowSettings(name: *const cty::c_char);
+    pub fn igClearWindowSettings(name: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLocalizeRegisterEntries(entries: *const ImGuiLocEntry, count: cty::c_int);
+    pub fn igLocalizeRegisterEntries(entries: *const ImGuiLocEntry, count: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igLocalizeGetMsg(key: ImGuiLocKey) -> *const cty::c_char;
+    pub fn igLocalizeGetMsg(key: ImGuiLocKey) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetScrollX_WindowPtr(window: *mut ImGuiWindow, scroll_x: f32);
@@ -10362,13 +10433,13 @@ extern "C" {
 }
 extern "C" {
     pub fn igGetIDWithSeed_Str(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
         seed: ImGuiID,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetIDWithSeed_Int(n: cty::c_int, seed: ImGuiID) -> ImGuiID;
+    pub fn igGetIDWithSeed_Int(n: core::ffi::c_int, seed: ImGuiID) -> ImGuiID;
 }
 extern "C" {
     pub fn igItemSize_Vec2(size: ImVec2, text_baseline_y: f32);
@@ -10408,10 +10479,14 @@ extern "C" {
     pub fn igCalcWrapWidthForPos(pos: ImVec2, wrap_pos_x: f32) -> f32;
 }
 extern "C" {
-    pub fn igPushMultiItemsWidths(components: cty::c_int, width_full: f32);
+    pub fn igPushMultiItemsWidths(components: core::ffi::c_int, width_full: f32);
 }
 extern "C" {
-    pub fn igShrinkWidths(items: *mut ImGuiShrinkWidthItem, count: cty::c_int, width_excess: f32);
+    pub fn igShrinkWidths(
+        items: *mut ImGuiShrinkWidthItem,
+        count: core::ffi::c_int,
+        width_excess: f32,
+    );
 }
 extern "C" {
     pub fn igGetStyleVarInfo(idx: ImGuiStyleVar) -> *const ImGuiDataVarInfo;
@@ -10423,24 +10498,27 @@ extern "C" {
     pub fn igEndDisabledOverrideReenable();
 }
 extern "C" {
-    pub fn igLogBegin(type_: ImGuiLogType, auto_open_depth: cty::c_int);
+    pub fn igLogBegin(type_: ImGuiLogType, auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igLogToBuffer(auto_open_depth: cty::c_int);
+    pub fn igLogToBuffer(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
     pub fn igLogRenderedText(
         ref_pos: *const ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
-    pub fn igLogSetNextTextDecoration(prefix: *const cty::c_char, suffix: *const cty::c_char);
+    pub fn igLogSetNextTextDecoration(
+        prefix: *const core::ffi::c_char,
+        suffix: *const core::ffi::c_char,
+    );
 }
 extern "C" {
     pub fn igBeginChildEx(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         id: ImGuiID,
         size_arg: ImVec2,
         child_flags: ImGuiChildFlags,
@@ -10454,7 +10532,10 @@ extern "C" {
     pub fn igOpenPopupEx(id: ImGuiID, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
-    pub fn igClosePopupToLevel(remaining: cty::c_int, restore_focus_to_window_under_popup: bool);
+    pub fn igClosePopupToLevel(
+        remaining: core::ffi::c_int,
+        restore_focus_to_window_under_popup: bool,
+    );
 }
 extern "C" {
     pub fn igClosePopupsOverWindow(
@@ -10505,7 +10586,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginViewportSideBar(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         viewport: *mut ImGuiViewport,
         dir: ImGuiDir,
         size: f32,
@@ -10514,16 +10595,16 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginMenuEx(
-        label: *const cty::c_char,
-        icon: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        icon: *const core::ffi::c_char,
         enabled: bool,
     ) -> bool;
 }
 extern "C" {
     pub fn igMenuItemEx(
-        label: *const cty::c_char,
-        icon: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        icon: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
@@ -10649,7 +10730,7 @@ extern "C" {
     pub fn igGetKeyData_Key(key: ImGuiKey) -> *mut ImGuiKeyData;
 }
 extern "C" {
-    pub fn igGetKeyChordName(key_chord: ImGuiKeyChord) -> *const cty::c_char;
+    pub fn igGetKeyChordName(key_chord: ImGuiKeyChord) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igMouseButtonToKey(button: ImGuiMouseButton) -> ImGuiKey;
@@ -10675,7 +10756,7 @@ extern "C" {
         t1: f32,
         repeat_delay: f32,
         repeat_rate: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igGetTypematicRepeatRate(
@@ -10856,7 +10937,7 @@ extern "C" {
     pub fn igDockNodeIsInHierarchyOf(node: *mut ImGuiDockNode, parent: *mut ImGuiDockNode) -> bool;
 }
 extern "C" {
-    pub fn igDockNodeGetDepth(node: *const ImGuiDockNode) -> cty::c_int;
+    pub fn igDockNodeGetDepth(node: *const ImGuiDockNode) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igDockNodeGetWindowMenuButtonId(node: *const ImGuiDockNode) -> ImGuiID;
@@ -10880,7 +10961,7 @@ extern "C" {
     pub fn igSetWindowDock(window: *mut ImGuiWindow, dock_id: ImGuiID, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igDockBuilderDockWindow(window_name: *const cty::c_char, node_id: ImGuiID);
+    pub fn igDockBuilderDockWindow(window_name: *const core::ffi::c_char, node_id: ImGuiID);
 }
 extern "C" {
     pub fn igDockBuilderGetNode(node_id: ImGuiID) -> *mut ImGuiDockNode;
@@ -10931,8 +11012,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igDockBuilderCopyWindowSettings(
-        src_name: *const cty::c_char,
-        dst_name: *const cty::c_char,
+        src_name: *const core::ffi::c_char,
+        dst_name: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -10969,34 +11050,43 @@ extern "C" {
 extern "C" {
     pub fn igTypingSelectFindMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        nav_item_idx: cty::c_int,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+        nav_item_idx: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igTypingSelectFindNextSingleCharMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        nav_item_idx: cty::c_int,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+        nav_item_idx: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igTypingSelectFindBestLeadingMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igBeginBoxSelect(
@@ -11026,7 +11116,7 @@ extern "C" {
     pub fn igMultiSelectAddSetRange(
         ms: *mut ImGuiMultiSelectTempData,
         selected: bool,
-        range_dir: cty::c_int,
+        range_dir: core::ffi::c_int,
         first_item: ImGuiSelectionUserData,
         last_item: ImGuiSelectionUserData,
     );
@@ -11042,8 +11132,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginColumns(
-        str_id: *const cty::c_char,
-        count: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        count: core::ffi::c_int,
         flags: ImGuiOldColumnFlags,
     );
 }
@@ -11051,7 +11141,7 @@ extern "C" {
     pub fn igEndColumns();
 }
 extern "C" {
-    pub fn igPushColumnClipRect(column_index: cty::c_int);
+    pub fn igPushColumnClipRect(column_index: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushColumnsBackground();
@@ -11060,7 +11150,7 @@ extern "C" {
     pub fn igPopColumnsBackground();
 }
 extern "C" {
-    pub fn igGetColumnsID(str_id: *const cty::c_char, count: cty::c_int) -> ImGuiID;
+    pub fn igGetColumnsID(str_id: *const core::ffi::c_char, count: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
     pub fn igFindOrCreateColumns(window: *mut ImGuiWindow, id: ImGuiID) -> *mut ImGuiOldColumns;
@@ -11072,20 +11162,20 @@ extern "C" {
     pub fn igGetColumnNormFromOffset(columns: *const ImGuiOldColumns, offset: f32) -> f32;
 }
 extern "C" {
-    pub fn igTableOpenContextMenu(column_n: cty::c_int);
+    pub fn igTableOpenContextMenu(column_n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igTableSetColumnWidth(column_n: cty::c_int, width: f32);
+    pub fn igTableSetColumnWidth(column_n: core::ffi::c_int, width: f32);
 }
 extern "C" {
     pub fn igTableSetColumnSortDirection(
-        column_n: cty::c_int,
+        column_n: core::ffi::c_int,
         sort_direction: ImGuiSortDirection,
         append_to_sort_specs: bool,
     );
 }
 extern "C" {
-    pub fn igTableGetHoveredRow() -> cty::c_int;
+    pub fn igTableGetHoveredRow() -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igTableGetHeaderRowHeight() -> f32;
@@ -11105,7 +11195,7 @@ extern "C" {
         angle: f32,
         max_label_width: f32,
         data: *const ImGuiTableHeaderData,
-        data_count: cty::c_int,
+        data_count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -11116,16 +11206,16 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginTableEx(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         id: ImGuiID,
-        columns_count: cty::c_int,
+        columns_count: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
     ) -> bool;
 }
 extern "C" {
-    pub fn igTableBeginInitMemory(table: *mut ImGuiTable, columns_count: cty::c_int);
+    pub fn igTableBeginInitMemory(table: *mut ImGuiTable, columns_count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igTableBeginApplyRequests(table: *mut ImGuiTable);
@@ -11160,11 +11250,11 @@ extern "C" {
 extern "C" {
     pub fn igTableGetInstanceData(
         table: *mut ImGuiTable,
-        instance_no: cty::c_int,
+        instance_no: core::ffi::c_int,
     ) -> *mut ImGuiTableInstanceData;
 }
 extern "C" {
-    pub fn igTableGetInstanceID(table: *mut ImGuiTable, instance_no: cty::c_int) -> ImGuiID;
+    pub fn igTableGetInstanceID(table: *mut ImGuiTable, instance_no: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
     pub fn igTableSortSpecsSanitize(table: *mut ImGuiTable);
@@ -11188,32 +11278,36 @@ extern "C" {
     pub fn igTableEndRow(table: *mut ImGuiTable);
 }
 extern "C" {
-    pub fn igTableBeginCell(table: *mut ImGuiTable, column_n: cty::c_int);
+    pub fn igTableBeginCell(table: *mut ImGuiTable, column_n: core::ffi::c_int);
 }
 extern "C" {
     pub fn igTableEndCell(table: *mut ImGuiTable);
 }
 extern "C" {
-    pub fn igTableGetCellBgRect(pOut: *mut ImRect, table: *const ImGuiTable, column_n: cty::c_int);
+    pub fn igTableGetCellBgRect(
+        pOut: *mut ImRect,
+        table: *const ImGuiTable,
+        column_n: core::ffi::c_int,
+    );
 }
 extern "C" {
     pub fn igTableGetColumnName_TablePtr(
         table: *const ImGuiTable,
-        column_n: cty::c_int,
-    ) -> *const cty::c_char;
+        column_n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igTableGetColumnResizeID(
         table: *mut ImGuiTable,
-        column_n: cty::c_int,
-        instance_no: cty::c_int,
+        column_n: core::ffi::c_int,
+        instance_no: core::ffi::c_int,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn igTableCalcMaxColumnWidth(table: *const ImGuiTable, column_n: cty::c_int) -> f32;
+    pub fn igTableCalcMaxColumnWidth(table: *const ImGuiTable, column_n: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igTableSetColumnWidthAutoSingle(table: *mut ImGuiTable, column_n: cty::c_int);
+    pub fn igTableSetColumnWidthAutoSingle(table: *mut ImGuiTable, column_n: core::ffi::c_int);
 }
 extern "C" {
     pub fn igTableSetColumnWidthAutoAll(table: *mut ImGuiTable);
@@ -11246,8 +11340,10 @@ extern "C" {
     pub fn igTableSettingsAddSettingsHandler();
 }
 extern "C" {
-    pub fn igTableSettingsCreate(id: ImGuiID, columns_count: cty::c_int)
-        -> *mut ImGuiTableSettings;
+    pub fn igTableSettingsCreate(
+        id: ImGuiID,
+        columns_count: core::ffi::c_int,
+    ) -> *mut ImGuiTableSettings;
 }
 extern "C" {
     pub fn igTableSettingsFindByID(id: ImGuiID) -> *mut ImGuiTableSettings;
@@ -11264,7 +11360,7 @@ extern "C" {
 extern "C" {
     pub fn igTabBarFindTabByOrder(
         tab_bar: *mut ImGuiTabBar,
-        order: cty::c_int,
+        order: core::ffi::c_int,
     ) -> *mut ImGuiTabItem;
 }
 extern "C" {
@@ -11276,13 +11372,16 @@ extern "C" {
     pub fn igTabBarGetCurrentTab(tab_bar: *mut ImGuiTabBar) -> *mut ImGuiTabItem;
 }
 extern "C" {
-    pub fn igTabBarGetTabOrder(tab_bar: *mut ImGuiTabBar, tab: *mut ImGuiTabItem) -> cty::c_int;
+    pub fn igTabBarGetTabOrder(
+        tab_bar: *mut ImGuiTabBar,
+        tab: *mut ImGuiTabItem,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igTabBarGetTabName(
         tab_bar: *mut ImGuiTabBar,
         tab: *mut ImGuiTabItem,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igTabBarAddTab(
@@ -11301,13 +11400,13 @@ extern "C" {
     pub fn igTabBarQueueFocus_TabItemPtr(tab_bar: *mut ImGuiTabBar, tab: *mut ImGuiTabItem);
 }
 extern "C" {
-    pub fn igTabBarQueueFocus_Str(tab_bar: *mut ImGuiTabBar, tab_name: *const cty::c_char);
+    pub fn igTabBarQueueFocus_Str(tab_bar: *mut ImGuiTabBar, tab_name: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igTabBarQueueReorder(
         tab_bar: *mut ImGuiTabBar,
         tab: *mut ImGuiTabItem,
-        offset: cty::c_int,
+        offset: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -11323,7 +11422,7 @@ extern "C" {
 extern "C" {
     pub fn igTabItemEx(
         tab_bar: *mut ImGuiTabBar,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
         docked_window: *mut ImGuiWindow,
@@ -11332,7 +11431,7 @@ extern "C" {
 extern "C" {
     pub fn igTabItemCalcSize_Str(
         pOut: *mut ImVec2,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         has_close_button_or_unsaved_marker: bool,
     );
 }
@@ -11353,7 +11452,7 @@ extern "C" {
         bb: ImRect,
         flags: ImGuiTabItemFlags,
         frame_padding: ImVec2,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         tab_id: ImGuiID,
         close_button_id: ImGuiID,
         is_contents_visible: bool,
@@ -11364,16 +11463,16 @@ extern "C" {
 extern "C" {
     pub fn igRenderText(
         pos: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_hash: bool,
     );
 }
 extern "C" {
     pub fn igRenderTextWrapped(
         pos: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
     );
 }
@@ -11381,8 +11480,8 @@ extern "C" {
     pub fn igRenderTextClipped(
         pos_min: ImVec2,
         pos_max: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
         align: ImVec2,
         clip_rect: *const ImRect,
@@ -11393,8 +11492,8 @@ extern "C" {
         draw_list: *mut ImDrawList,
         pos_min: ImVec2,
         pos_max: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
         align: ImVec2,
         clip_rect: *const ImRect,
@@ -11407,8 +11506,8 @@ extern "C" {
         pos_max: ImVec2,
         clip_max_x: f32,
         ellipsis_max_x: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
     );
 }
@@ -11441,9 +11540,9 @@ extern "C" {
 }
 extern "C" {
     pub fn igFindRenderedTextEnd(
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igRenderMouseCursor(
@@ -11509,15 +11608,22 @@ extern "C" {
     ) -> ImDrawFlags;
 }
 extern "C" {
-    pub fn igTextEx(text: *const cty::c_char, text_end: *const cty::c_char, flags: ImGuiTextFlags);
+    pub fn igTextEx(
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        flags: ImGuiTextFlags,
+    );
 }
 extern "C" {
-    pub fn igButtonEx(label: *const cty::c_char, size_arg: ImVec2, flags: ImGuiButtonFlags)
-        -> bool;
+    pub fn igButtonEx(
+        label: *const core::ffi::c_char,
+        size_arg: ImVec2,
+        flags: ImGuiButtonFlags,
+    ) -> bool;
 }
 extern "C" {
     pub fn igArrowButtonEx(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         dir: ImGuiDir,
         size_arg: ImVec2,
         flags: ImGuiButtonFlags,
@@ -11541,21 +11647,21 @@ extern "C" {
 extern "C" {
     pub fn igSeparatorTextEx(
         id: ImGuiID,
-        label: *const cty::c_char,
-        label_end: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        label_end: *const core::ffi::c_char,
         extra_width: f32,
     );
 }
 extern "C" {
     pub fn igCheckboxFlags_S64Ptr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: *mut ImS64,
         flags_value: ImS64,
     ) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_U64Ptr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: *mut ImU64,
         flags_value: ImU64,
     ) -> bool;
@@ -11587,7 +11693,7 @@ extern "C" {
     pub fn igGetWindowScrollbarID(window: *mut ImGuiWindow, axis: ImGuiAxis) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetWindowResizeCornerID(window: *mut ImGuiWindow, n: cty::c_int) -> ImGuiID;
+    pub fn igGetWindowResizeCornerID(window: *mut ImGuiWindow, n: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
     pub fn igGetWindowResizeBorderID(window: *mut ImGuiWindow, dir: ImGuiDir) -> ImGuiID;
@@ -11605,11 +11711,11 @@ extern "C" {
     pub fn igDragBehavior(
         id: ImGuiID,
         data_type: ImGuiDataType,
-        p_v: *mut cty::c_void,
+        p_v: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
@@ -11618,10 +11724,10 @@ extern "C" {
         bb: ImRect,
         id: ImGuiID,
         data_type: ImGuiDataType,
-        p_v: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_v: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
         out_grab_bb: *mut ImRect,
     ) -> bool;
@@ -11644,8 +11750,8 @@ extern "C" {
     pub fn igTreeNodeBehavior(
         id: ImGuiID,
         flags: ImGuiTreeNodeFlags,
-        label: *const cty::c_char,
-        label_end: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        label_end: *const core::ffi::c_char,
     ) -> bool;
 }
 extern "C" {
@@ -11665,59 +11771,59 @@ extern "C" {
 }
 extern "C" {
     pub fn igDataTypeFormatString(
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         data_type: ImGuiDataType,
-        p_data: *const cty::c_void,
-        format: *const cty::c_char,
-    ) -> cty::c_int;
+        p_data: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igDataTypeApplyOp(
         data_type: ImGuiDataType,
-        op: cty::c_int,
-        output: *mut cty::c_void,
-        arg_1: *const cty::c_void,
-        arg_2: *const cty::c_void,
+        op: core::ffi::c_int,
+        output: *mut core::ffi::c_void,
+        arg_1: *const core::ffi::c_void,
+        arg_2: *const core::ffi::c_void,
     );
 }
 extern "C" {
     pub fn igDataTypeApplyFromText(
-        buf: *const cty::c_char,
+        buf: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        format: *const cty::c_char,
-        p_data_when_empty: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        format: *const core::ffi::c_char,
+        p_data_when_empty: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igDataTypeCompare(
         data_type: ImGuiDataType,
-        arg_1: *const cty::c_void,
-        arg_2: *const cty::c_void,
-    ) -> cty::c_int;
+        arg_1: *const core::ffi::c_void,
+        arg_2: *const core::ffi::c_void,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igDataTypeClamp(
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
-    pub fn igDataTypeIsZero(data_type: ImGuiDataType, p_data: *const cty::c_void) -> bool;
+    pub fn igDataTypeIsZero(data_type: ImGuiDataType, p_data: *const core::ffi::c_void) -> bool;
 }
 extern "C" {
     pub fn igInputTextEx(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         size_arg: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
@@ -11727,9 +11833,9 @@ extern "C" {
     pub fn igTempInputText(
         bb: ImRect,
         id: ImGuiID,
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
@@ -11737,12 +11843,12 @@ extern "C" {
     pub fn igTempInputScalar(
         bb: ImRect,
         id: ImGuiID,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        format: *const cty::c_char,
-        p_clamp_min: *const cty::c_void,
-        p_clamp_max: *const cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        format: *const core::ffi::c_char,
+        p_clamp_min: *const core::ffi::c_void,
+        p_clamp_max: *const core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
@@ -11752,10 +11858,14 @@ extern "C" {
     pub fn igGetInputTextState(id: ImGuiID) -> *mut ImGuiInputTextState;
 }
 extern "C" {
-    pub fn igSetNextItemRefVal(data_type: ImGuiDataType, p_data: *mut cty::c_void);
+    pub fn igSetNextItemRefVal(data_type: ImGuiDataType, p_data: *mut core::ffi::c_void);
 }
 extern "C" {
-    pub fn igColorTooltip(text: *const cty::c_char, col: *const f32, flags: ImGuiColorEditFlags);
+    pub fn igColorTooltip(
+        text: *const core::ffi::c_char,
+        col: *const f32,
+        flags: ImGuiColorEditFlags,
+    );
 }
 extern "C" {
     pub fn igColorEditOptionsPopup(col: *const f32, flags: ImGuiColorEditFlags);
@@ -11766,24 +11876,24 @@ extern "C" {
 extern "C" {
     pub fn igPlotEx(
         plot_type: ImGuiPlotType,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         size_arg: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igShadeVertsLinearColorGradientKeepAlpha(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         gradient_p0: ImVec2,
         gradient_p1: ImVec2,
         col0: ImU32,
@@ -11793,8 +11903,8 @@ extern "C" {
 extern "C" {
     pub fn igShadeVertsLinearUV(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         a: ImVec2,
         b: ImVec2,
         uv_a: ImVec2,
@@ -11805,8 +11915,8 @@ extern "C" {
 extern "C" {
     pub fn igShadeVertsTransformPos(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         pivot_in: ImVec2,
         cos_a: f32,
         sin_a: f32,
@@ -11823,7 +11933,7 @@ extern "C" {
     pub fn igGcAwakeTransientWindowBuffers(window: *mut ImGuiWindow);
 }
 extern "C" {
-    pub fn igErrorLog(msg: *const cty::c_char) -> bool;
+    pub fn igErrorLog(msg: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
     pub fn igErrorRecoveryStoreState(state_out: *mut ImGuiErrorRecoveryState);
@@ -11849,8 +11959,8 @@ extern "C" {
 extern "C" {
     pub fn igDebugAllocHook(
         info: *mut ImGuiDebugAllocInfo,
-        frame_count: cty::c_int,
-        ptr: *mut cty::c_void,
+        frame_count: core::ffi::c_int,
+        ptr: *mut core::ffi::c_void,
         size: usize,
     );
 }
@@ -11865,8 +11975,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igDebugTextUnformattedWithLocateItem(
-        line_begin: *const cty::c_char,
-        line_end: *const cty::c_char,
+        line_begin: *const core::ffi::c_char,
+        line_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -11883,14 +11993,14 @@ extern "C" {
 }
 extern "C" {
     pub fn igDebugBreakButton(
-        label: *const cty::c_char,
-        description_of_location: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        description_of_location: *const core::ffi::c_char,
     ) -> bool;
 }
 extern "C" {
     pub fn igDebugBreakButtonTooltip(
         keyboard_only: bool,
-        description_of_location: *const cty::c_char,
+        description_of_location: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -11900,22 +12010,22 @@ extern "C" {
     pub fn igDebugHookIdInfo(
         id: ImGuiID,
         data_type: ImGuiDataType,
-        data_id: *const cty::c_void,
-        data_id_end: *const cty::c_void,
+        data_id: *const core::ffi::c_void,
+        data_id_end: *const core::ffi::c_void,
     );
 }
 extern "C" {
     pub fn igDebugNodeColumns(columns: *mut ImGuiOldColumns);
 }
 extern "C" {
-    pub fn igDebugNodeDockNode(node: *mut ImGuiDockNode, label: *const cty::c_char);
+    pub fn igDebugNodeDockNode(node: *mut ImGuiDockNode, label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugNodeDrawList(
         window: *mut ImGuiWindow,
         viewport: *mut ImGuiViewportP,
         draw_list: *const ImDrawList,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -11934,10 +12044,10 @@ extern "C" {
     pub fn igDebugNodeFontGlyph(font: *mut ImFont, glyph: *const ImFontGlyph);
 }
 extern "C" {
-    pub fn igDebugNodeStorage(storage: *mut ImGuiStorage, label: *const cty::c_char);
+    pub fn igDebugNodeStorage(storage: *mut ImGuiStorage, label: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igDebugNodeTabBar(tab_bar: *mut ImGuiTabBar, label: *const cty::c_char);
+    pub fn igDebugNodeTabBar(tab_bar: *mut ImGuiTabBar, label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugNodeTable(table: *mut ImGuiTable);
@@ -11955,18 +12065,21 @@ extern "C" {
     pub fn igDebugNodeMultiSelectState(state: *mut ImGuiMultiSelectState);
 }
 extern "C" {
-    pub fn igDebugNodeWindow(window: *mut ImGuiWindow, label: *const cty::c_char);
+    pub fn igDebugNodeWindow(window: *mut ImGuiWindow, label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugNodeWindowSettings(settings: *mut ImGuiWindowSettings);
 }
 extern "C" {
-    pub fn igDebugNodeWindowsList(windows: *mut ImVector_ImGuiWindowPtr, label: *const cty::c_char);
+    pub fn igDebugNodeWindowsList(
+        windows: *mut ImVector_ImGuiWindowPtr,
+        label: *const core::ffi::c_char,
+    );
 }
 extern "C" {
     pub fn igDebugNodeWindowsListByBeginStackParent(
         windows: *mut *mut ImGuiWindow,
-        windows_size: cty::c_int,
+        windows_size: core::ffi::c_int,
         parent_in_begin_stack: *mut ImGuiWindow,
     );
 }
@@ -11976,8 +12089,8 @@ extern "C" {
 extern "C" {
     pub fn igDebugNodePlatformMonitor(
         monitor: *mut ImGuiPlatformMonitor,
-        label: *const cty::c_char,
-        idx: cty::c_int,
+        label: *const core::ffi::c_char,
+        idx: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -12011,7 +12124,7 @@ extern "C" {
 extern "C" {
     pub fn igImFontAtlasBuildPackCustomRects(
         atlas: *mut ImFontAtlas,
-        stbrp_context_opaque: *mut cty::c_void,
+        stbrp_context_opaque: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -12020,47 +12133,51 @@ extern "C" {
 extern "C" {
     pub fn igImFontAtlasBuildRender8bppRectFromString(
         atlas: *mut ImFontAtlas,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        in_str: *const cty::c_char,
-        in_marker_char: cty::c_char,
-        in_marker_pixel_value: cty::c_uchar,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        in_str: *const core::ffi::c_char,
+        in_marker_char: core::ffi::c_char,
+        in_marker_pixel_value: core::ffi::c_uchar,
     );
 }
 extern "C" {
     pub fn igImFontAtlasBuildRender32bppRectFromString(
         atlas: *mut ImFontAtlas,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        in_str: *const cty::c_char,
-        in_marker_char: cty::c_char,
-        in_marker_pixel_value: cty::c_uint,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        in_str: *const core::ffi::c_char,
+        in_marker_char: core::ffi::c_char,
+        in_marker_pixel_value: core::ffi::c_uint,
     );
 }
 extern "C" {
     pub fn igImFontAtlasBuildMultiplyCalcLookupTable(
-        out_table: *mut cty::c_uchar,
+        out_table: *mut core::ffi::c_uchar,
         in_multiply_factor: f32,
     );
 }
 extern "C" {
     pub fn igImFontAtlasBuildMultiplyRectAlpha8(
-        table: *const cty::c_uchar,
-        pixels: *mut cty::c_uchar,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        stride: cty::c_int,
+        table: *const core::ffi::c_uchar,
+        pixels: *mut core::ffi::c_uchar,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
-    pub fn igLogText(fmt: *const cty::c_char, ...);
+    pub fn igLogText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_appendf(buffer: *mut ImGuiTextBuffer, fmt: *const cty::c_char, ...);
+    pub fn ImGuiTextBuffer_appendf(
+        buffer: *mut ImGuiTextBuffer,
+        fmt: *const core::ffi::c_char,
+        ...
+    );
 }

--- a/imgui-sys/src/docking_freetype_bindings.rs
+++ b/imgui-sys/src/docking_freetype_bindings.rs
@@ -82,14 +82,14 @@ where
         }
     }
 }
-pub type __int64_t = cty::c_longlong;
+pub type __int64_t = core::ffi::c_longlong;
 pub type __darwin_off_t = __int64_t;
 pub type fpos_t = __darwin_off_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct __sbuf {
-    pub _base: *mut cty::c_uchar,
-    pub _size: cty::c_int,
+    pub _base: *mut core::ffi::c_uchar,
+    pub _size: core::ffi::c_int,
 }
 impl Default for __sbuf {
     fn default() -> Self {
@@ -108,39 +108,45 @@ pub struct __sFILEX {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct __sFILE {
-    pub _p: *mut cty::c_uchar,
-    pub _r: cty::c_int,
-    pub _w: cty::c_int,
-    pub _flags: cty::c_short,
-    pub _file: cty::c_short,
+    pub _p: *mut core::ffi::c_uchar,
+    pub _r: core::ffi::c_int,
+    pub _w: core::ffi::c_int,
+    pub _flags: core::ffi::c_short,
+    pub _file: core::ffi::c_short,
     pub _bf: __sbuf,
-    pub _lbfsize: cty::c_int,
-    pub _cookie: *mut cty::c_void,
-    pub _close: ::core::option::Option<unsafe extern "C" fn(arg1: *mut cty::c_void) -> cty::c_int>,
+    pub _lbfsize: core::ffi::c_int,
+    pub _cookie: *mut core::ffi::c_void,
+    pub _close: ::core::option::Option<
+        unsafe extern "C" fn(arg1: *mut core::ffi::c_void) -> core::ffi::c_int,
+    >,
     pub _read: ::core::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cty::c_void,
-            arg2: *mut cty::c_char,
-            arg3: cty::c_int,
-        ) -> cty::c_int,
+            arg1: *mut core::ffi::c_void,
+            arg2: *mut core::ffi::c_char,
+            arg3: core::ffi::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub _seek: ::core::option::Option<
-        unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: fpos_t, arg3: cty::c_int) -> fpos_t,
+        unsafe extern "C" fn(
+            arg1: *mut core::ffi::c_void,
+            arg2: fpos_t,
+            arg3: core::ffi::c_int,
+        ) -> fpos_t,
     >,
     pub _write: ::core::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cty::c_void,
-            arg2: *const cty::c_char,
-            arg3: cty::c_int,
-        ) -> cty::c_int,
+            arg1: *mut core::ffi::c_void,
+            arg2: *const core::ffi::c_char,
+            arg3: core::ffi::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub _ub: __sbuf,
     pub _extra: *mut __sFILEX,
-    pub _ur: cty::c_int,
-    pub _ubuf: [cty::c_uchar; 3usize],
-    pub _nbuf: [cty::c_uchar; 1usize],
+    pub _ur: core::ffi::c_int,
+    pub _ubuf: [core::ffi::c_uchar; 3usize],
+    pub _nbuf: [core::ffi::c_uchar; 1usize],
     pub _lb: __sbuf,
-    pub _blksize: cty::c_int,
+    pub _blksize: core::ffi::c_int,
     pub _offset: fpos_t,
 }
 impl Default for __sFILE {
@@ -171,9 +177,9 @@ pub struct STB_TexteditState {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_const_charPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut *const cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut *const core::ffi::c_char,
 }
 impl Default for ImVector_const_charPtr {
     fn default() -> Self {
@@ -184,67 +190,67 @@ impl Default for ImVector_const_charPtr {
         }
     }
 }
-pub type ImGuiID = cty::c_uint;
-pub type ImS8 = cty::c_schar;
-pub type ImU8 = cty::c_uchar;
-pub type ImS16 = cty::c_short;
-pub type ImU16 = cty::c_ushort;
-pub type ImS32 = cty::c_int;
-pub type ImU32 = cty::c_uint;
-pub type ImS64 = cty::c_longlong;
-pub type ImU64 = cty::c_ulonglong;
-pub type ImGuiCol = cty::c_int;
-pub type ImGuiCond = cty::c_int;
-pub type ImGuiDataType = cty::c_int;
-pub type ImGuiMouseButton = cty::c_int;
-pub type ImGuiMouseCursor = cty::c_int;
-pub type ImGuiStyleVar = cty::c_int;
-pub type ImGuiTableBgTarget = cty::c_int;
-pub type ImDrawFlags = cty::c_int;
-pub type ImDrawListFlags = cty::c_int;
-pub type ImFontAtlasFlags = cty::c_int;
-pub type ImGuiBackendFlags = cty::c_int;
-pub type ImGuiButtonFlags = cty::c_int;
-pub type ImGuiChildFlags = cty::c_int;
-pub type ImGuiColorEditFlags = cty::c_int;
-pub type ImGuiConfigFlags = cty::c_int;
-pub type ImGuiComboFlags = cty::c_int;
-pub type ImGuiDockNodeFlags = cty::c_int;
-pub type ImGuiDragDropFlags = cty::c_int;
-pub type ImGuiFocusedFlags = cty::c_int;
-pub type ImGuiHoveredFlags = cty::c_int;
-pub type ImGuiInputFlags = cty::c_int;
-pub type ImGuiInputTextFlags = cty::c_int;
-pub type ImGuiItemFlags = cty::c_int;
-pub type ImGuiKeyChord = cty::c_int;
-pub type ImGuiPopupFlags = cty::c_int;
-pub type ImGuiMultiSelectFlags = cty::c_int;
-pub type ImGuiSelectableFlags = cty::c_int;
-pub type ImGuiSliderFlags = cty::c_int;
-pub type ImGuiTabBarFlags = cty::c_int;
-pub type ImGuiTabItemFlags = cty::c_int;
-pub type ImGuiTableFlags = cty::c_int;
-pub type ImGuiTableColumnFlags = cty::c_int;
-pub type ImGuiTableRowFlags = cty::c_int;
-pub type ImGuiTreeNodeFlags = cty::c_int;
-pub type ImGuiViewportFlags = cty::c_int;
-pub type ImGuiWindowFlags = cty::c_int;
-pub type ImTextureID = *mut cty::c_void;
-pub type ImDrawIdx = cty::c_ushort;
-pub type ImWchar32 = cty::c_uint;
-pub type ImWchar16 = cty::c_ushort;
+pub type ImGuiID = core::ffi::c_uint;
+pub type ImS8 = core::ffi::c_schar;
+pub type ImU8 = core::ffi::c_uchar;
+pub type ImS16 = core::ffi::c_short;
+pub type ImU16 = core::ffi::c_ushort;
+pub type ImS32 = core::ffi::c_int;
+pub type ImU32 = core::ffi::c_uint;
+pub type ImS64 = core::ffi::c_longlong;
+pub type ImU64 = core::ffi::c_ulonglong;
+pub type ImGuiCol = core::ffi::c_int;
+pub type ImGuiCond = core::ffi::c_int;
+pub type ImGuiDataType = core::ffi::c_int;
+pub type ImGuiMouseButton = core::ffi::c_int;
+pub type ImGuiMouseCursor = core::ffi::c_int;
+pub type ImGuiStyleVar = core::ffi::c_int;
+pub type ImGuiTableBgTarget = core::ffi::c_int;
+pub type ImDrawFlags = core::ffi::c_int;
+pub type ImDrawListFlags = core::ffi::c_int;
+pub type ImFontAtlasFlags = core::ffi::c_int;
+pub type ImGuiBackendFlags = core::ffi::c_int;
+pub type ImGuiButtonFlags = core::ffi::c_int;
+pub type ImGuiChildFlags = core::ffi::c_int;
+pub type ImGuiColorEditFlags = core::ffi::c_int;
+pub type ImGuiConfigFlags = core::ffi::c_int;
+pub type ImGuiComboFlags = core::ffi::c_int;
+pub type ImGuiDockNodeFlags = core::ffi::c_int;
+pub type ImGuiDragDropFlags = core::ffi::c_int;
+pub type ImGuiFocusedFlags = core::ffi::c_int;
+pub type ImGuiHoveredFlags = core::ffi::c_int;
+pub type ImGuiInputFlags = core::ffi::c_int;
+pub type ImGuiInputTextFlags = core::ffi::c_int;
+pub type ImGuiItemFlags = core::ffi::c_int;
+pub type ImGuiKeyChord = core::ffi::c_int;
+pub type ImGuiPopupFlags = core::ffi::c_int;
+pub type ImGuiMultiSelectFlags = core::ffi::c_int;
+pub type ImGuiSelectableFlags = core::ffi::c_int;
+pub type ImGuiSliderFlags = core::ffi::c_int;
+pub type ImGuiTabBarFlags = core::ffi::c_int;
+pub type ImGuiTabItemFlags = core::ffi::c_int;
+pub type ImGuiTableFlags = core::ffi::c_int;
+pub type ImGuiTableColumnFlags = core::ffi::c_int;
+pub type ImGuiTableRowFlags = core::ffi::c_int;
+pub type ImGuiTreeNodeFlags = core::ffi::c_int;
+pub type ImGuiViewportFlags = core::ffi::c_int;
+pub type ImGuiWindowFlags = core::ffi::c_int;
+pub type ImTextureID = *mut core::ffi::c_void;
+pub type ImDrawIdx = core::ffi::c_ushort;
+pub type ImWchar32 = core::ffi::c_uint;
+pub type ImWchar16 = core::ffi::c_ushort;
 pub type ImWchar = ImWchar32;
 pub type ImGuiSelectionUserData = ImS64;
 pub type ImGuiInputTextCallback = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> cty::c_int,
+    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> core::ffi::c_int,
 >;
 pub type ImGuiSizeCallback =
     ::core::option::Option<unsafe extern "C" fn(data: *mut ImGuiSizeCallbackData)>;
 pub type ImGuiMemAllocFunc = ::core::option::Option<
-    unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+    unsafe extern "C" fn(sz: usize, user_data: *mut core::ffi::c_void) -> *mut core::ffi::c_void,
 >;
 pub type ImGuiMemFreeFunc = ::core::option::Option<
-    unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+    unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -290,7 +296,7 @@ pub const ImGuiWindowFlags_Popup: ImGuiWindowFlags_ = 67108864;
 pub const ImGuiWindowFlags_Modal: ImGuiWindowFlags_ = 134217728;
 pub const ImGuiWindowFlags_ChildMenu: ImGuiWindowFlags_ = 268435456;
 pub const ImGuiWindowFlags_DockNodeHost: ImGuiWindowFlags_ = 536870912;
-pub type ImGuiWindowFlags_ = cty::c_uint;
+pub type ImGuiWindowFlags_ = core::ffi::c_uint;
 pub const ImGuiChildFlags_None: ImGuiChildFlags_ = 0;
 pub const ImGuiChildFlags_Borders: ImGuiChildFlags_ = 1;
 pub const ImGuiChildFlags_AlwaysUseWindowPadding: ImGuiChildFlags_ = 2;
@@ -301,7 +307,7 @@ pub const ImGuiChildFlags_AutoResizeY: ImGuiChildFlags_ = 32;
 pub const ImGuiChildFlags_AlwaysAutoResize: ImGuiChildFlags_ = 64;
 pub const ImGuiChildFlags_FrameStyle: ImGuiChildFlags_ = 128;
 pub const ImGuiChildFlags_NavFlattened: ImGuiChildFlags_ = 256;
-pub type ImGuiChildFlags_ = cty::c_uint;
+pub type ImGuiChildFlags_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_None: ImGuiItemFlags_ = 0;
 pub const ImGuiItemFlags_NoTabStop: ImGuiItemFlags_ = 1;
 pub const ImGuiItemFlags_NoNav: ImGuiItemFlags_ = 2;
@@ -309,7 +315,7 @@ pub const ImGuiItemFlags_NoNavDefaultFocus: ImGuiItemFlags_ = 4;
 pub const ImGuiItemFlags_ButtonRepeat: ImGuiItemFlags_ = 8;
 pub const ImGuiItemFlags_AutoClosePopups: ImGuiItemFlags_ = 16;
 pub const ImGuiItemFlags_AllowDuplicateId: ImGuiItemFlags_ = 32;
-pub type ImGuiItemFlags_ = cty::c_uint;
+pub type ImGuiItemFlags_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_None: ImGuiInputTextFlags_ = 0;
 pub const ImGuiInputTextFlags_CharsDecimal: ImGuiInputTextFlags_ = 1;
 pub const ImGuiInputTextFlags_CharsHexadecimal: ImGuiInputTextFlags_ = 2;
@@ -334,7 +340,7 @@ pub const ImGuiInputTextFlags_CallbackAlways: ImGuiInputTextFlags_ = 524288;
 pub const ImGuiInputTextFlags_CallbackCharFilter: ImGuiInputTextFlags_ = 1048576;
 pub const ImGuiInputTextFlags_CallbackResize: ImGuiInputTextFlags_ = 2097152;
 pub const ImGuiInputTextFlags_CallbackEdit: ImGuiInputTextFlags_ = 4194304;
-pub type ImGuiInputTextFlags_ = cty::c_uint;
+pub type ImGuiInputTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_None: ImGuiTreeNodeFlags_ = 0;
 pub const ImGuiTreeNodeFlags_Selected: ImGuiTreeNodeFlags_ = 1;
 pub const ImGuiTreeNodeFlags_Framed: ImGuiTreeNodeFlags_ = 2;
@@ -353,7 +359,7 @@ pub const ImGuiTreeNodeFlags_SpanTextWidth: ImGuiTreeNodeFlags_ = 8192;
 pub const ImGuiTreeNodeFlags_SpanAllColumns: ImGuiTreeNodeFlags_ = 16384;
 pub const ImGuiTreeNodeFlags_NavLeftJumpsBackHere: ImGuiTreeNodeFlags_ = 32768;
 pub const ImGuiTreeNodeFlags_CollapsingHeader: ImGuiTreeNodeFlags_ = 26;
-pub type ImGuiTreeNodeFlags_ = cty::c_uint;
+pub type ImGuiTreeNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiPopupFlags_None: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonLeft: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonRight: ImGuiPopupFlags_ = 1;
@@ -366,7 +372,7 @@ pub const ImGuiPopupFlags_NoOpenOverItems: ImGuiPopupFlags_ = 256;
 pub const ImGuiPopupFlags_AnyPopupId: ImGuiPopupFlags_ = 1024;
 pub const ImGuiPopupFlags_AnyPopupLevel: ImGuiPopupFlags_ = 2048;
 pub const ImGuiPopupFlags_AnyPopup: ImGuiPopupFlags_ = 3072;
-pub type ImGuiPopupFlags_ = cty::c_uint;
+pub type ImGuiPopupFlags_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_None: ImGuiSelectableFlags_ = 0;
 pub const ImGuiSelectableFlags_NoAutoClosePopups: ImGuiSelectableFlags_ = 1;
 pub const ImGuiSelectableFlags_SpanAllColumns: ImGuiSelectableFlags_ = 2;
@@ -374,7 +380,7 @@ pub const ImGuiSelectableFlags_AllowDoubleClick: ImGuiSelectableFlags_ = 4;
 pub const ImGuiSelectableFlags_Disabled: ImGuiSelectableFlags_ = 8;
 pub const ImGuiSelectableFlags_AllowOverlap: ImGuiSelectableFlags_ = 16;
 pub const ImGuiSelectableFlags_Highlight: ImGuiSelectableFlags_ = 32;
-pub type ImGuiSelectableFlags_ = cty::c_uint;
+pub type ImGuiSelectableFlags_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_None: ImGuiComboFlags_ = 0;
 pub const ImGuiComboFlags_PopupAlignLeft: ImGuiComboFlags_ = 1;
 pub const ImGuiComboFlags_HeightSmall: ImGuiComboFlags_ = 2;
@@ -385,7 +391,7 @@ pub const ImGuiComboFlags_NoArrowButton: ImGuiComboFlags_ = 32;
 pub const ImGuiComboFlags_NoPreview: ImGuiComboFlags_ = 64;
 pub const ImGuiComboFlags_WidthFitPreview: ImGuiComboFlags_ = 128;
 pub const ImGuiComboFlags_HeightMask_: ImGuiComboFlags_ = 30;
-pub type ImGuiComboFlags_ = cty::c_uint;
+pub type ImGuiComboFlags_ = core::ffi::c_uint;
 pub const ImGuiTabBarFlags_None: ImGuiTabBarFlags_ = 0;
 pub const ImGuiTabBarFlags_Reorderable: ImGuiTabBarFlags_ = 1;
 pub const ImGuiTabBarFlags_AutoSelectNewTabs: ImGuiTabBarFlags_ = 2;
@@ -398,7 +404,7 @@ pub const ImGuiTabBarFlags_FittingPolicyResizeDown: ImGuiTabBarFlags_ = 128;
 pub const ImGuiTabBarFlags_FittingPolicyScroll: ImGuiTabBarFlags_ = 256;
 pub const ImGuiTabBarFlags_FittingPolicyMask_: ImGuiTabBarFlags_ = 384;
 pub const ImGuiTabBarFlags_FittingPolicyDefault_: ImGuiTabBarFlags_ = 128;
-pub type ImGuiTabBarFlags_ = cty::c_uint;
+pub type ImGuiTabBarFlags_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_None: ImGuiTabItemFlags_ = 0;
 pub const ImGuiTabItemFlags_UnsavedDocument: ImGuiTabItemFlags_ = 1;
 pub const ImGuiTabItemFlags_SetSelected: ImGuiTabItemFlags_ = 2;
@@ -409,7 +415,7 @@ pub const ImGuiTabItemFlags_NoReorder: ImGuiTabItemFlags_ = 32;
 pub const ImGuiTabItemFlags_Leading: ImGuiTabItemFlags_ = 64;
 pub const ImGuiTabItemFlags_Trailing: ImGuiTabItemFlags_ = 128;
 pub const ImGuiTabItemFlags_NoAssumedClosure: ImGuiTabItemFlags_ = 256;
-pub type ImGuiTabItemFlags_ = cty::c_uint;
+pub type ImGuiTabItemFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusedFlags_None: ImGuiFocusedFlags_ = 0;
 pub const ImGuiFocusedFlags_ChildWindows: ImGuiFocusedFlags_ = 1;
 pub const ImGuiFocusedFlags_RootWindow: ImGuiFocusedFlags_ = 2;
@@ -417,7 +423,7 @@ pub const ImGuiFocusedFlags_AnyWindow: ImGuiFocusedFlags_ = 4;
 pub const ImGuiFocusedFlags_NoPopupHierarchy: ImGuiFocusedFlags_ = 8;
 pub const ImGuiFocusedFlags_DockHierarchy: ImGuiFocusedFlags_ = 16;
 pub const ImGuiFocusedFlags_RootAndChildWindows: ImGuiFocusedFlags_ = 3;
-pub type ImGuiFocusedFlags_ = cty::c_uint;
+pub type ImGuiFocusedFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_None: ImGuiHoveredFlags_ = 0;
 pub const ImGuiHoveredFlags_ChildWindows: ImGuiHoveredFlags_ = 1;
 pub const ImGuiHoveredFlags_RootWindow: ImGuiHoveredFlags_ = 2;
@@ -439,7 +445,7 @@ pub const ImGuiHoveredFlags_DelayNone: ImGuiHoveredFlags_ = 16384;
 pub const ImGuiHoveredFlags_DelayShort: ImGuiHoveredFlags_ = 32768;
 pub const ImGuiHoveredFlags_DelayNormal: ImGuiHoveredFlags_ = 65536;
 pub const ImGuiHoveredFlags_NoSharedDelay: ImGuiHoveredFlags_ = 131072;
-pub type ImGuiHoveredFlags_ = cty::c_uint;
+pub type ImGuiHoveredFlags_ = core::ffi::c_uint;
 pub const ImGuiDockNodeFlags_None: ImGuiDockNodeFlags_ = 0;
 pub const ImGuiDockNodeFlags_KeepAliveOnly: ImGuiDockNodeFlags_ = 1;
 pub const ImGuiDockNodeFlags_NoDockingOverCentralNode: ImGuiDockNodeFlags_ = 4;
@@ -448,7 +454,7 @@ pub const ImGuiDockNodeFlags_NoDockingSplit: ImGuiDockNodeFlags_ = 16;
 pub const ImGuiDockNodeFlags_NoResize: ImGuiDockNodeFlags_ = 32;
 pub const ImGuiDockNodeFlags_AutoHideTabBar: ImGuiDockNodeFlags_ = 64;
 pub const ImGuiDockNodeFlags_NoUndocking: ImGuiDockNodeFlags_ = 128;
-pub type ImGuiDockNodeFlags_ = cty::c_uint;
+pub type ImGuiDockNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiDragDropFlags_None: ImGuiDragDropFlags_ = 0;
 pub const ImGuiDragDropFlags_SourceNoPreviewTooltip: ImGuiDragDropFlags_ = 1;
 pub const ImGuiDragDropFlags_SourceNoDisableHover: ImGuiDragDropFlags_ = 2;
@@ -462,7 +468,7 @@ pub const ImGuiDragDropFlags_AcceptBeforeDelivery: ImGuiDragDropFlags_ = 1024;
 pub const ImGuiDragDropFlags_AcceptNoDrawDefaultRect: ImGuiDragDropFlags_ = 2048;
 pub const ImGuiDragDropFlags_AcceptNoPreviewTooltip: ImGuiDragDropFlags_ = 4096;
 pub const ImGuiDragDropFlags_AcceptPeekOnly: ImGuiDragDropFlags_ = 3072;
-pub type ImGuiDragDropFlags_ = cty::c_uint;
+pub type ImGuiDragDropFlags_ = core::ffi::c_uint;
 pub const ImGuiDataType_S8: ImGuiDataType_ = 0;
 pub const ImGuiDataType_U8: ImGuiDataType_ = 1;
 pub const ImGuiDataType_S16: ImGuiDataType_ = 2;
@@ -475,18 +481,18 @@ pub const ImGuiDataType_Float: ImGuiDataType_ = 8;
 pub const ImGuiDataType_Double: ImGuiDataType_ = 9;
 pub const ImGuiDataType_Bool: ImGuiDataType_ = 10;
 pub const ImGuiDataType_COUNT: ImGuiDataType_ = 11;
-pub type ImGuiDataType_ = cty::c_uint;
+pub type ImGuiDataType_ = core::ffi::c_uint;
 pub const ImGuiDir_None: ImGuiDir = -1;
 pub const ImGuiDir_Left: ImGuiDir = 0;
 pub const ImGuiDir_Right: ImGuiDir = 1;
 pub const ImGuiDir_Up: ImGuiDir = 2;
 pub const ImGuiDir_Down: ImGuiDir = 3;
 pub const ImGuiDir_COUNT: ImGuiDir = 4;
-pub type ImGuiDir = cty::c_int;
+pub type ImGuiDir = core::ffi::c_int;
 pub const ImGuiSortDirection_None: ImGuiSortDirection = 0;
 pub const ImGuiSortDirection_Ascending: ImGuiSortDirection = 1;
 pub const ImGuiSortDirection_Descending: ImGuiSortDirection = 2;
-pub type ImGuiSortDirection = cty::c_uint;
+pub type ImGuiSortDirection = core::ffi::c_uint;
 pub const ImGuiKey_None: ImGuiKey = 0;
 pub const ImGuiKey_Tab: ImGuiKey = 512;
 pub const ImGuiKey_LeftArrow: ImGuiKey = 513;
@@ -654,7 +660,7 @@ pub const ImGuiKey_NamedKey_END: ImGuiKey = 666;
 pub const ImGuiKey_NamedKey_COUNT: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_SIZE: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_OFFSET: ImGuiKey = 512;
-pub type ImGuiKey = cty::c_uint;
+pub type ImGuiKey = core::ffi::c_uint;
 pub const ImGuiInputFlags_None: ImGuiInputFlags_ = 0;
 pub const ImGuiInputFlags_Repeat: ImGuiInputFlags_ = 1;
 pub const ImGuiInputFlags_RouteActive: ImGuiInputFlags_ = 1024;
@@ -666,7 +672,7 @@ pub const ImGuiInputFlags_RouteOverActive: ImGuiInputFlags_ = 32768;
 pub const ImGuiInputFlags_RouteUnlessBgFocused: ImGuiInputFlags_ = 65536;
 pub const ImGuiInputFlags_RouteFromRootWindow: ImGuiInputFlags_ = 131072;
 pub const ImGuiInputFlags_Tooltip: ImGuiInputFlags_ = 262144;
-pub type ImGuiInputFlags_ = cty::c_uint;
+pub type ImGuiInputFlags_ = core::ffi::c_uint;
 pub const ImGuiConfigFlags_None: ImGuiConfigFlags_ = 0;
 pub const ImGuiConfigFlags_NavEnableKeyboard: ImGuiConfigFlags_ = 1;
 pub const ImGuiConfigFlags_NavEnableGamepad: ImGuiConfigFlags_ = 2;
@@ -681,7 +687,7 @@ pub const ImGuiConfigFlags_DpiEnableScaleViewports: ImGuiConfigFlags_ = 16384;
 pub const ImGuiConfigFlags_DpiEnableScaleFonts: ImGuiConfigFlags_ = 32768;
 pub const ImGuiConfigFlags_IsSRGB: ImGuiConfigFlags_ = 1048576;
 pub const ImGuiConfigFlags_IsTouchScreen: ImGuiConfigFlags_ = 2097152;
-pub type ImGuiConfigFlags_ = cty::c_uint;
+pub type ImGuiConfigFlags_ = core::ffi::c_uint;
 pub const ImGuiBackendFlags_None: ImGuiBackendFlags_ = 0;
 pub const ImGuiBackendFlags_HasGamepad: ImGuiBackendFlags_ = 1;
 pub const ImGuiBackendFlags_HasMouseCursors: ImGuiBackendFlags_ = 2;
@@ -690,7 +696,7 @@ pub const ImGuiBackendFlags_RendererHasVtxOffset: ImGuiBackendFlags_ = 8;
 pub const ImGuiBackendFlags_PlatformHasViewports: ImGuiBackendFlags_ = 1024;
 pub const ImGuiBackendFlags_HasMouseHoveredViewport: ImGuiBackendFlags_ = 2048;
 pub const ImGuiBackendFlags_RendererHasViewports: ImGuiBackendFlags_ = 4096;
-pub type ImGuiBackendFlags_ = cty::c_uint;
+pub type ImGuiBackendFlags_ = core::ffi::c_uint;
 pub const ImGuiCol_Text: ImGuiCol_ = 0;
 pub const ImGuiCol_TextDisabled: ImGuiCol_ = 1;
 pub const ImGuiCol_WindowBg: ImGuiCol_ = 2;
@@ -750,7 +756,7 @@ pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 55;
 pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 56;
 pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 57;
 pub const ImGuiCol_COUNT: ImGuiCol_ = 58;
-pub type ImGuiCol_ = cty::c_uint;
+pub type ImGuiCol_ = core::ffi::c_uint;
 pub const ImGuiStyleVar_Alpha: ImGuiStyleVar_ = 0;
 pub const ImGuiStyleVar_DisabledAlpha: ImGuiStyleVar_ = 1;
 pub const ImGuiStyleVar_WindowPadding: ImGuiStyleVar_ = 2;
@@ -786,13 +792,13 @@ pub const ImGuiStyleVar_SeparatorTextAlign: ImGuiStyleVar_ = 31;
 pub const ImGuiStyleVar_SeparatorTextPadding: ImGuiStyleVar_ = 32;
 pub const ImGuiStyleVar_DockingSeparatorSize: ImGuiStyleVar_ = 33;
 pub const ImGuiStyleVar_COUNT: ImGuiStyleVar_ = 34;
-pub type ImGuiStyleVar_ = cty::c_uint;
+pub type ImGuiStyleVar_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_None: ImGuiButtonFlags_ = 0;
 pub const ImGuiButtonFlags_MouseButtonLeft: ImGuiButtonFlags_ = 1;
 pub const ImGuiButtonFlags_MouseButtonRight: ImGuiButtonFlags_ = 2;
 pub const ImGuiButtonFlags_MouseButtonMiddle: ImGuiButtonFlags_ = 4;
 pub const ImGuiButtonFlags_MouseButtonMask_: ImGuiButtonFlags_ = 7;
-pub type ImGuiButtonFlags_ = cty::c_uint;
+pub type ImGuiButtonFlags_ = core::ffi::c_uint;
 pub const ImGuiColorEditFlags_None: ImGuiColorEditFlags_ = 0;
 pub const ImGuiColorEditFlags_NoAlpha: ImGuiColorEditFlags_ = 2;
 pub const ImGuiColorEditFlags_NoPicker: ImGuiColorEditFlags_ = 4;
@@ -822,7 +828,7 @@ pub const ImGuiColorEditFlags_DisplayMask_: ImGuiColorEditFlags_ = 7340032;
 pub const ImGuiColorEditFlags_DataTypeMask_: ImGuiColorEditFlags_ = 25165824;
 pub const ImGuiColorEditFlags_PickerMask_: ImGuiColorEditFlags_ = 100663296;
 pub const ImGuiColorEditFlags_InputMask_: ImGuiColorEditFlags_ = 402653184;
-pub type ImGuiColorEditFlags_ = cty::c_uint;
+pub type ImGuiColorEditFlags_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_None: ImGuiSliderFlags_ = 0;
 pub const ImGuiSliderFlags_Logarithmic: ImGuiSliderFlags_ = 32;
 pub const ImGuiSliderFlags_NoRoundToFormat: ImGuiSliderFlags_ = 64;
@@ -832,12 +838,12 @@ pub const ImGuiSliderFlags_ClampOnInput: ImGuiSliderFlags_ = 512;
 pub const ImGuiSliderFlags_ClampZeroRange: ImGuiSliderFlags_ = 1024;
 pub const ImGuiSliderFlags_AlwaysClamp: ImGuiSliderFlags_ = 1536;
 pub const ImGuiSliderFlags_InvalidMask_: ImGuiSliderFlags_ = 1879048207;
-pub type ImGuiSliderFlags_ = cty::c_uint;
+pub type ImGuiSliderFlags_ = core::ffi::c_uint;
 pub const ImGuiMouseButton_Left: ImGuiMouseButton_ = 0;
 pub const ImGuiMouseButton_Right: ImGuiMouseButton_ = 1;
 pub const ImGuiMouseButton_Middle: ImGuiMouseButton_ = 2;
 pub const ImGuiMouseButton_COUNT: ImGuiMouseButton_ = 5;
-pub type ImGuiMouseButton_ = cty::c_uint;
+pub type ImGuiMouseButton_ = core::ffi::c_uint;
 pub const ImGuiMouseCursor_None: ImGuiMouseCursor_ = -1;
 pub const ImGuiMouseCursor_Arrow: ImGuiMouseCursor_ = 0;
 pub const ImGuiMouseCursor_TextInput: ImGuiMouseCursor_ = 1;
@@ -849,18 +855,18 @@ pub const ImGuiMouseCursor_ResizeNWSE: ImGuiMouseCursor_ = 6;
 pub const ImGuiMouseCursor_Hand: ImGuiMouseCursor_ = 7;
 pub const ImGuiMouseCursor_NotAllowed: ImGuiMouseCursor_ = 8;
 pub const ImGuiMouseCursor_COUNT: ImGuiMouseCursor_ = 9;
-pub type ImGuiMouseCursor_ = cty::c_int;
+pub type ImGuiMouseCursor_ = core::ffi::c_int;
 pub const ImGuiMouseSource_Mouse: ImGuiMouseSource = 0;
 pub const ImGuiMouseSource_TouchScreen: ImGuiMouseSource = 1;
 pub const ImGuiMouseSource_Pen: ImGuiMouseSource = 2;
 pub const ImGuiMouseSource_COUNT: ImGuiMouseSource = 3;
-pub type ImGuiMouseSource = cty::c_uint;
+pub type ImGuiMouseSource = core::ffi::c_uint;
 pub const ImGuiCond_None: ImGuiCond_ = 0;
 pub const ImGuiCond_Always: ImGuiCond_ = 1;
 pub const ImGuiCond_Once: ImGuiCond_ = 2;
 pub const ImGuiCond_FirstUseEver: ImGuiCond_ = 4;
 pub const ImGuiCond_Appearing: ImGuiCond_ = 8;
-pub type ImGuiCond_ = cty::c_uint;
+pub type ImGuiCond_ = core::ffi::c_uint;
 pub const ImGuiTableFlags_None: ImGuiTableFlags_ = 0;
 pub const ImGuiTableFlags_Resizable: ImGuiTableFlags_ = 1;
 pub const ImGuiTableFlags_Reorderable: ImGuiTableFlags_ = 2;
@@ -898,7 +904,7 @@ pub const ImGuiTableFlags_SortMulti: ImGuiTableFlags_ = 67108864;
 pub const ImGuiTableFlags_SortTristate: ImGuiTableFlags_ = 134217728;
 pub const ImGuiTableFlags_HighlightHoveredColumn: ImGuiTableFlags_ = 268435456;
 pub const ImGuiTableFlags_SizingMask_: ImGuiTableFlags_ = 57344;
-pub type ImGuiTableFlags_ = cty::c_uint;
+pub type ImGuiTableFlags_ = core::ffi::c_uint;
 pub const ImGuiTableColumnFlags_None: ImGuiTableColumnFlags_ = 0;
 pub const ImGuiTableColumnFlags_Disabled: ImGuiTableColumnFlags_ = 1;
 pub const ImGuiTableColumnFlags_DefaultHide: ImGuiTableColumnFlags_ = 2;
@@ -927,20 +933,20 @@ pub const ImGuiTableColumnFlags_WidthMask_: ImGuiTableColumnFlags_ = 24;
 pub const ImGuiTableColumnFlags_IndentMask_: ImGuiTableColumnFlags_ = 196608;
 pub const ImGuiTableColumnFlags_StatusMask_: ImGuiTableColumnFlags_ = 251658240;
 pub const ImGuiTableColumnFlags_NoDirectResize_: ImGuiTableColumnFlags_ = 1073741824;
-pub type ImGuiTableColumnFlags_ = cty::c_uint;
+pub type ImGuiTableColumnFlags_ = core::ffi::c_uint;
 pub const ImGuiTableRowFlags_None: ImGuiTableRowFlags_ = 0;
 pub const ImGuiTableRowFlags_Headers: ImGuiTableRowFlags_ = 1;
-pub type ImGuiTableRowFlags_ = cty::c_uint;
+pub type ImGuiTableRowFlags_ = core::ffi::c_uint;
 pub const ImGuiTableBgTarget_None: ImGuiTableBgTarget_ = 0;
 pub const ImGuiTableBgTarget_RowBg0: ImGuiTableBgTarget_ = 1;
 pub const ImGuiTableBgTarget_RowBg1: ImGuiTableBgTarget_ = 2;
 pub const ImGuiTableBgTarget_CellBg: ImGuiTableBgTarget_ = 3;
-pub type ImGuiTableBgTarget_ = cty::c_uint;
+pub type ImGuiTableBgTarget_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTableSortSpecs {
     pub Specs: *const ImGuiTableColumnSortSpecs,
-    pub SpecsCount: cty::c_int,
+    pub SpecsCount: core::ffi::c_int,
     pub SpecsDirty: bool,
 }
 impl Default for ImGuiTableSortSpecs {
@@ -1047,8 +1053,8 @@ pub struct ImGuiKeyData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImWchar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImWchar,
 }
 impl Default for ImVector_ImWchar {
@@ -1068,9 +1074,9 @@ pub struct ImGuiIO {
     pub DisplaySize: ImVec2,
     pub DeltaTime: f32,
     pub IniSavingRate: f32,
-    pub IniFilename: *const cty::c_char,
-    pub LogFilename: *const cty::c_char,
-    pub UserData: *mut cty::c_void,
+    pub IniFilename: *const core::ffi::c_char,
+    pub LogFilename: *const core::ffi::c_char,
+    pub UserData: *mut core::ffi::c_void,
     pub Fonts: *mut ImFontAtlas,
     pub FontGlobalScale: f32,
     pub FontAllowUserScaling: bool,
@@ -1110,11 +1116,11 @@ pub struct ImGuiIO {
     pub ConfigDebugBeginReturnValueLoop: bool,
     pub ConfigDebugIgnoreFocusLoss: bool,
     pub ConfigDebugIniSettings: bool,
-    pub BackendPlatformName: *const cty::c_char,
-    pub BackendRendererName: *const cty::c_char,
-    pub BackendPlatformUserData: *mut cty::c_void,
-    pub BackendRendererUserData: *mut cty::c_void,
-    pub BackendLanguageUserData: *mut cty::c_void,
+    pub BackendPlatformName: *const core::ffi::c_char,
+    pub BackendRendererName: *const core::ffi::c_char,
+    pub BackendPlatformUserData: *mut core::ffi::c_void,
+    pub BackendRendererUserData: *mut core::ffi::c_void,
+    pub BackendLanguageUserData: *mut core::ffi::c_void,
     pub WantCaptureMouse: bool,
     pub WantCaptureKeyboard: bool,
     pub WantTextInput: bool,
@@ -1123,10 +1129,10 @@ pub struct ImGuiIO {
     pub NavActive: bool,
     pub NavVisible: bool,
     pub Framerate: f32,
-    pub MetricsRenderVertices: cty::c_int,
-    pub MetricsRenderIndices: cty::c_int,
-    pub MetricsRenderWindows: cty::c_int,
-    pub MetricsActiveWindows: cty::c_int,
+    pub MetricsRenderVertices: core::ffi::c_int,
+    pub MetricsRenderIndices: core::ffi::c_int,
+    pub MetricsRenderWindows: core::ffi::c_int,
+    pub MetricsActiveWindows: core::ffi::c_int,
     pub MouseDelta: ImVec2,
     pub Ctx: *mut ImGuiContext,
     pub MousePos: ImVec2,
@@ -1181,16 +1187,16 @@ pub struct ImGuiInputTextCallbackData {
     pub Ctx: *mut ImGuiContext,
     pub EventFlag: ImGuiInputTextFlags,
     pub Flags: ImGuiInputTextFlags,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub EventChar: ImWchar,
     pub EventKey: ImGuiKey,
-    pub Buf: *mut cty::c_char,
-    pub BufTextLen: cty::c_int,
-    pub BufSize: cty::c_int,
+    pub Buf: *mut core::ffi::c_char,
+    pub BufTextLen: core::ffi::c_int,
+    pub BufSize: core::ffi::c_int,
     pub BufDirty: bool,
-    pub CursorPos: cty::c_int,
-    pub SelectionStart: cty::c_int,
-    pub SelectionEnd: cty::c_int,
+    pub CursorPos: core::ffi::c_int,
+    pub SelectionStart: core::ffi::c_int,
+    pub SelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextCallbackData {
     fn default() -> Self {
@@ -1204,7 +1210,7 @@ impl Default for ImGuiInputTextCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiSizeCallbackData {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub Pos: ImVec2,
     pub CurrentSize: ImVec2,
     pub DesiredSize: ImVec2,
@@ -1234,12 +1240,12 @@ pub struct ImGuiWindowClass {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPayload {
-    pub Data: *mut cty::c_void,
-    pub DataSize: cty::c_int,
+    pub Data: *mut core::ffi::c_void,
+    pub DataSize: core::ffi::c_int,
     pub SourceId: ImGuiID,
     pub SourceParentId: ImGuiID,
-    pub DataFrameCount: cty::c_int,
-    pub DataType: [cty::c_char; 33usize],
+    pub DataFrameCount: core::ffi::c_int,
+    pub DataType: [core::ffi::c_char; 33usize],
     pub Preview: bool,
     pub Delivery: bool,
 }
@@ -1255,13 +1261,13 @@ impl Default for ImGuiPayload {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiOnceUponAFrame {
-    pub RefFrame: cty::c_int,
+    pub RefFrame: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextRange {
-    pub b: *const cty::c_char,
-    pub e: *const cty::c_char,
+    pub b: *const core::ffi::c_char,
+    pub e: *const core::ffi::c_char,
 }
 impl Default for ImGuiTextRange {
     fn default() -> Self {
@@ -1275,8 +1281,8 @@ impl Default for ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTextRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTextRange,
 }
 impl Default for ImVector_ImGuiTextRange {
@@ -1291,9 +1297,9 @@ impl Default for ImVector_ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextFilter {
-    pub InputBuf: [cty::c_char; 256usize],
+    pub InputBuf: [core::ffi::c_char; 256usize],
     pub Filters: ImVector_ImGuiTextRange,
-    pub CountGrep: cty::c_int,
+    pub CountGrep: core::ffi::c_int,
 }
 impl Default for ImGuiTextFilter {
     fn default() -> Self {
@@ -1307,9 +1313,9 @@ impl Default for ImGuiTextFilter {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_char,
 }
 impl Default for ImVector_char {
     fn default() -> Self {
@@ -1343,9 +1349,9 @@ pub struct ImGuiStoragePair {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStoragePair__bindgen_ty_1 {
-    pub val_i: cty::c_int,
+    pub val_i: core::ffi::c_int,
     pub val_f: f32,
-    pub val_p: *mut cty::c_void,
+    pub val_p: *mut core::ffi::c_void,
 }
 impl Default for ImGuiStoragePair__bindgen_ty_1 {
     fn default() -> Self {
@@ -1382,8 +1388,8 @@ impl ::core::fmt::Debug for ImGuiStoragePair {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStoragePair {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStoragePair,
 }
 impl Default for ImVector_ImGuiStoragePair {
@@ -1413,13 +1419,13 @@ impl Default for ImGuiStorage {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiListClipper {
     pub Ctx: *mut ImGuiContext,
-    pub DisplayStart: cty::c_int,
-    pub DisplayEnd: cty::c_int,
-    pub ItemsCount: cty::c_int,
+    pub DisplayStart: core::ffi::c_int,
+    pub DisplayEnd: core::ffi::c_int,
+    pub ItemsCount: core::ffi::c_int,
     pub ItemsHeight: f32,
     pub StartPosY: f32,
     pub StartSeekOffsetY: f64,
-    pub TempData: *mut cty::c_void,
+    pub TempData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiListClipper {
     fn default() -> Self {
@@ -1452,12 +1458,12 @@ pub const ImGuiMultiSelectFlags_ScopeRect: ImGuiMultiSelectFlags_ = 4096;
 pub const ImGuiMultiSelectFlags_SelectOnClick: ImGuiMultiSelectFlags_ = 8192;
 pub const ImGuiMultiSelectFlags_SelectOnClickRelease: ImGuiMultiSelectFlags_ = 16384;
 pub const ImGuiMultiSelectFlags_NavWrapX: ImGuiMultiSelectFlags_ = 65536;
-pub type ImGuiMultiSelectFlags_ = cty::c_uint;
+pub type ImGuiMultiSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSelectionRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSelectionRequest,
 }
 impl Default for ImVector_ImGuiSelectionRequest {
@@ -1477,7 +1483,7 @@ pub struct ImGuiMultiSelectIO {
     pub NavIdItem: ImGuiSelectionUserData,
     pub NavIdSelected: bool,
     pub RangeSrcReset: bool,
-    pub ItemsCount: cty::c_int,
+    pub ItemsCount: core::ffi::c_int,
 }
 impl Default for ImGuiMultiSelectIO {
     fn default() -> Self {
@@ -1491,7 +1497,7 @@ impl Default for ImGuiMultiSelectIO {
 pub const ImGuiSelectionRequestType_None: ImGuiSelectionRequestType = 0;
 pub const ImGuiSelectionRequestType_SetAll: ImGuiSelectionRequestType = 1;
 pub const ImGuiSelectionRequestType_SetRange: ImGuiSelectionRequestType = 2;
-pub type ImGuiSelectionRequestType = cty::c_uint;
+pub type ImGuiSelectionRequestType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionRequest {
@@ -1513,13 +1519,16 @@ impl Default for ImGuiSelectionRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionBasicStorage {
-    pub Size: cty::c_int,
+    pub Size: core::ffi::c_int,
     pub PreserveOrder: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterIndexToStorageId: ::core::option::Option<
-        unsafe extern "C" fn(self_: *mut ImGuiSelectionBasicStorage, idx: cty::c_int) -> ImGuiID,
+        unsafe extern "C" fn(
+            self_: *mut ImGuiSelectionBasicStorage,
+            idx: core::ffi::c_int,
+        ) -> ImGuiID,
     >,
-    pub _SelectionOrder: cty::c_int,
+    pub _SelectionOrder: core::ffi::c_int,
     pub _Storage: ImGuiStorage,
 }
 impl Default for ImGuiSelectionBasicStorage {
@@ -1534,11 +1543,11 @@ impl Default for ImGuiSelectionBasicStorage {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionExternalStorage {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterSetItemSelected: ::core::option::Option<
         unsafe extern "C" fn(
             self_: *mut ImGuiSelectionExternalStorage,
-            idx: cty::c_int,
+            idx: core::ffi::c_int,
             selected: bool,
         ),
     >,
@@ -1560,11 +1569,11 @@ pub type ImDrawCallback = ::core::option::Option<
 pub struct ImDrawCmd {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
-    pub IdxOffset: cty::c_uint,
-    pub ElemCount: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
+    pub IdxOffset: core::ffi::c_uint,
+    pub ElemCount: core::ffi::c_uint,
     pub UserCallback: ImDrawCallback,
-    pub UserCallbackData: *mut cty::c_void,
+    pub UserCallbackData: *mut core::ffi::c_void,
 }
 impl Default for ImDrawCmd {
     fn default() -> Self {
@@ -1587,7 +1596,7 @@ pub struct ImDrawVert {
 pub struct ImDrawCmdHeader {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
 }
 impl Default for ImDrawCmdHeader {
     fn default() -> Self {
@@ -1601,8 +1610,8 @@ impl Default for ImDrawCmdHeader {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawCmd {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawCmd,
 }
 impl Default for ImVector_ImDrawCmd {
@@ -1617,8 +1626,8 @@ impl Default for ImVector_ImDrawCmd {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawIdx {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawIdx,
 }
 impl Default for ImVector_ImDrawIdx {
@@ -1648,8 +1657,8 @@ impl Default for ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawChannel {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawChannel,
 }
 impl Default for ImVector_ImDrawChannel {
@@ -1664,8 +1673,8 @@ impl Default for ImVector_ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImDrawListSplitter {
-    pub _Current: cty::c_int,
-    pub _Count: cty::c_int,
+    pub _Current: core::ffi::c_int,
+    pub _Count: core::ffi::c_int,
     pub _Channels: ImVector_ImDrawChannel,
 }
 impl Default for ImDrawListSplitter {
@@ -1691,18 +1700,18 @@ pub const ImDrawFlags_RoundCornersRight: ImDrawFlags_ = 160;
 pub const ImDrawFlags_RoundCornersAll: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersDefault_: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersMask_: ImDrawFlags_ = 496;
-pub type ImDrawFlags_ = cty::c_uint;
+pub type ImDrawFlags_ = core::ffi::c_uint;
 pub const ImDrawListFlags_None: ImDrawListFlags_ = 0;
 pub const ImDrawListFlags_AntiAliasedLines: ImDrawListFlags_ = 1;
 pub const ImDrawListFlags_AntiAliasedLinesUseTex: ImDrawListFlags_ = 2;
 pub const ImDrawListFlags_AntiAliasedFill: ImDrawListFlags_ = 4;
 pub const ImDrawListFlags_AllowVtxOffset: ImDrawListFlags_ = 8;
-pub type ImDrawListFlags_ = cty::c_uint;
+pub type ImDrawListFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawVert {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawVert,
 }
 impl Default for ImVector_ImDrawVert {
@@ -1717,8 +1726,8 @@ impl Default for ImVector_ImDrawVert {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec2 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec2,
 }
 impl Default for ImVector_ImVec2 {
@@ -1733,8 +1742,8 @@ impl Default for ImVector_ImVec2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec4 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec4,
 }
 impl Default for ImVector_ImVec4 {
@@ -1749,8 +1758,8 @@ impl Default for ImVector_ImVec4 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImTextureID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImTextureID,
 }
 impl Default for ImVector_ImTextureID {
@@ -1769,7 +1778,7 @@ pub struct ImDrawList {
     pub IdxBuffer: ImVector_ImDrawIdx,
     pub VtxBuffer: ImVector_ImDrawVert,
     pub Flags: ImDrawListFlags,
-    pub _VtxCurrentIdx: cty::c_uint,
+    pub _VtxCurrentIdx: core::ffi::c_uint,
     pub _Data: *mut ImDrawListSharedData,
     pub _VtxWritePtr: *mut ImDrawVert,
     pub _IdxWritePtr: *mut ImDrawIdx,
@@ -1779,7 +1788,7 @@ pub struct ImDrawList {
     pub _ClipRectStack: ImVector_ImVec4,
     pub _TextureIdStack: ImVector_ImTextureID,
     pub _FringeScale: f32,
-    pub _OwnerName: *const cty::c_char,
+    pub _OwnerName: *const core::ffi::c_char,
 }
 impl Default for ImDrawList {
     fn default() -> Self {
@@ -1793,8 +1802,8 @@ impl Default for ImDrawList {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawListPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImDrawList,
 }
 impl Default for ImVector_ImDrawListPtr {
@@ -1810,9 +1819,9 @@ impl Default for ImVector_ImDrawListPtr {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImDrawData {
     pub Valid: bool,
-    pub CmdListsCount: cty::c_int,
-    pub TotalIdxCount: cty::c_int,
-    pub TotalVtxCount: cty::c_int,
+    pub CmdListsCount: core::ffi::c_int,
+    pub TotalIdxCount: core::ffi::c_int,
+    pub TotalVtxCount: core::ffi::c_int,
     pub CmdLists: ImVector_ImDrawListPtr,
     pub DisplayPos: ImVec2,
     pub DisplaySize: ImVec2,
@@ -1831,13 +1840,13 @@ impl Default for ImDrawData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontConfig {
-    pub FontData: *mut cty::c_void,
-    pub FontDataSize: cty::c_int,
+    pub FontData: *mut core::ffi::c_void,
+    pub FontDataSize: core::ffi::c_int,
     pub FontDataOwnedByAtlas: bool,
-    pub FontNo: cty::c_int,
+    pub FontNo: core::ffi::c_int,
     pub SizePixels: f32,
-    pub OversampleH: cty::c_int,
-    pub OversampleV: cty::c_int,
+    pub OversampleH: core::ffi::c_int,
+    pub OversampleV: core::ffi::c_int,
     pub PixelSnapH: bool,
     pub GlyphExtraSpacing: ImVec2,
     pub GlyphOffset: ImVec2,
@@ -1845,11 +1854,11 @@ pub struct ImFontConfig {
     pub GlyphMinAdvanceX: f32,
     pub GlyphMaxAdvanceX: f32,
     pub MergeMode: bool,
-    pub FontBuilderFlags: cty::c_uint,
+    pub FontBuilderFlags: core::ffi::c_uint,
     pub RasterizerMultiply: f32,
     pub RasterizerDensity: f32,
     pub EllipsisChar: ImWchar,
-    pub Name: [cty::c_char; 40usize],
+    pub Name: [core::ffi::c_char; 40usize],
     pub DstFont: *mut ImFont,
 }
 impl Default for ImFontConfig {
@@ -1878,33 +1887,33 @@ pub struct ImFontGlyph {
 }
 impl ImFontGlyph {
     #[inline]
-    pub fn Colored(&self) -> cty::c_uint {
+    pub fn Colored(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Colored(&mut self, val: cty::c_uint) {
+    pub fn set_Colored(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Visible(&self) -> cty::c_uint {
+    pub fn Visible(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Visible(&mut self, val: cty::c_uint) {
+    pub fn set_Visible(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(1usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Codepoint(&self) -> cty::c_uint {
+    pub fn Codepoint(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
     }
     #[inline]
-    pub fn set_Codepoint(&mut self, val: cty::c_uint) {
+    pub fn set_Codepoint(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(2usize, 30u8, val as u64)
@@ -1912,9 +1921,9 @@ impl ImFontGlyph {
     }
     #[inline]
     pub fn new_bitfield_1(
-        Colored: cty::c_uint,
-        Visible: cty::c_uint,
-        Codepoint: cty::c_uint,
+        Colored: core::ffi::c_uint,
+        Visible: core::ffi::c_uint,
+        Codepoint: core::ffi::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1935,8 +1944,8 @@ impl ImFontGlyph {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImU32 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImU32,
 }
 impl Default for ImVector_ImU32 {
@@ -1965,11 +1974,11 @@ impl Default for ImFontGlyphRangesBuilder {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontAtlasCustomRect {
-    pub Width: cty::c_ushort,
-    pub Height: cty::c_ushort,
-    pub X: cty::c_ushort,
-    pub Y: cty::c_ushort,
-    pub GlyphID: cty::c_uint,
+    pub Width: core::ffi::c_ushort,
+    pub Height: core::ffi::c_ushort,
+    pub X: core::ffi::c_ushort,
+    pub Y: core::ffi::c_ushort,
+    pub GlyphID: core::ffi::c_uint,
     pub GlyphAdvanceX: f32,
     pub GlyphOffset: ImVec2,
     pub Font: *mut ImFont,
@@ -1987,12 +1996,12 @@ pub const ImFontAtlasFlags_None: ImFontAtlasFlags_ = 0;
 pub const ImFontAtlasFlags_NoPowerOfTwoHeight: ImFontAtlasFlags_ = 1;
 pub const ImFontAtlasFlags_NoMouseCursors: ImFontAtlasFlags_ = 2;
 pub const ImFontAtlasFlags_NoBakedLines: ImFontAtlasFlags_ = 4;
-pub type ImFontAtlasFlags_ = cty::c_uint;
+pub type ImFontAtlasFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImFont,
 }
 impl Default for ImVector_ImFontPtr {
@@ -2007,8 +2016,8 @@ impl Default for ImVector_ImFontPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontAtlasCustomRect {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontAtlasCustomRect,
 }
 impl Default for ImVector_ImFontAtlasCustomRect {
@@ -2023,8 +2032,8 @@ impl Default for ImVector_ImFontAtlasCustomRect {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontConfig {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontConfig,
 }
 impl Default for ImVector_ImFontConfig {
@@ -2041,16 +2050,16 @@ impl Default for ImVector_ImFontConfig {
 pub struct ImFontAtlas {
     pub Flags: ImFontAtlasFlags,
     pub TexID: ImTextureID,
-    pub TexDesiredWidth: cty::c_int,
-    pub TexGlyphPadding: cty::c_int,
+    pub TexDesiredWidth: core::ffi::c_int,
+    pub TexGlyphPadding: core::ffi::c_int,
     pub Locked: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub TexReady: bool,
     pub TexPixelsUseColors: bool,
-    pub TexPixelsAlpha8: *mut cty::c_uchar,
-    pub TexPixelsRGBA32: *mut cty::c_uint,
-    pub TexWidth: cty::c_int,
-    pub TexHeight: cty::c_int,
+    pub TexPixelsAlpha8: *mut core::ffi::c_uchar,
+    pub TexPixelsRGBA32: *mut core::ffi::c_uint,
+    pub TexWidth: core::ffi::c_int,
+    pub TexHeight: core::ffi::c_int,
     pub TexUvScale: ImVec2,
     pub TexUvWhitePixel: ImVec2,
     pub Fonts: ImVector_ImFontPtr,
@@ -2058,9 +2067,9 @@ pub struct ImFontAtlas {
     pub ConfigData: ImVector_ImFontConfig,
     pub TexUvLines: [ImVec4; 64usize],
     pub FontBuilderIO: *const ImFontBuilderIO,
-    pub FontBuilderFlags: cty::c_uint,
-    pub PackIdMouseCursors: cty::c_int,
-    pub PackIdLines: cty::c_int,
+    pub FontBuilderFlags: core::ffi::c_uint,
+    pub PackIdMouseCursors: core::ffi::c_int,
+    pub PackIdLines: core::ffi::c_int,
 }
 impl Default for ImFontAtlas {
     fn default() -> Self {
@@ -2074,8 +2083,8 @@ impl Default for ImFontAtlas {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_float {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut f32,
 }
 impl Default for ImVector_float {
@@ -2090,8 +2099,8 @@ impl Default for ImVector_float {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontGlyph {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontGlyph,
 }
 impl Default for ImVector_ImFontGlyph {
@@ -2114,17 +2123,17 @@ pub struct ImFont {
     pub FallbackGlyph: *const ImFontGlyph,
     pub ContainerAtlas: *mut ImFontAtlas,
     pub ConfigData: *const ImFontConfig,
-    pub ConfigDataCount: cty::c_short,
+    pub ConfigDataCount: core::ffi::c_short,
     pub FallbackChar: ImWchar,
     pub EllipsisChar: ImWchar,
-    pub EllipsisCharCount: cty::c_short,
+    pub EllipsisCharCount: core::ffi::c_short,
     pub EllipsisWidth: f32,
     pub EllipsisCharStep: f32,
     pub DirtyLookupTables: bool,
     pub Scale: f32,
     pub Ascent: f32,
     pub Descent: f32,
-    pub MetricsTotalSurface: cty::c_int,
+    pub MetricsTotalSurface: core::ffi::c_int,
     pub Used4kPagesMap: [ImU8; 34usize],
 }
 impl Default for ImFont {
@@ -2151,7 +2160,7 @@ pub const ImGuiViewportFlags_TopMost: ImGuiViewportFlags_ = 1024;
 pub const ImGuiViewportFlags_CanHostOtherWindows: ImGuiViewportFlags_ = 2048;
 pub const ImGuiViewportFlags_IsMinimized: ImGuiViewportFlags_ = 4096;
 pub const ImGuiViewportFlags_IsFocused: ImGuiViewportFlags_ = 8192;
-pub type ImGuiViewportFlags_ = cty::c_uint;
+pub type ImGuiViewportFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiViewport {
@@ -2164,10 +2173,10 @@ pub struct ImGuiViewport {
     pub DpiScale: f32,
     pub ParentViewportId: ImGuiID,
     pub DrawData: *mut ImDrawData,
-    pub RendererUserData: *mut cty::c_void,
-    pub PlatformUserData: *mut cty::c_void,
-    pub PlatformHandle: *mut cty::c_void,
-    pub PlatformHandleRaw: *mut cty::c_void,
+    pub RendererUserData: *mut core::ffi::c_void,
+    pub PlatformUserData: *mut core::ffi::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
+    pub PlatformHandleRaw: *mut core::ffi::c_void,
     pub PlatformWindowCreated: bool,
     pub PlatformRequestMove: bool,
     pub PlatformRequestResize: bool,
@@ -2185,8 +2194,8 @@ impl Default for ImGuiViewport {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPlatformMonitor {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPlatformMonitor,
 }
 impl Default for ImVector_ImGuiPlatformMonitor {
@@ -2201,8 +2210,8 @@ impl Default for ImVector_ImGuiPlatformMonitor {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiViewportPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiViewport,
 }
 impl Default for ImVector_ImGuiViewportPtr {
@@ -2217,16 +2226,17 @@ impl Default for ImVector_ImGuiViewportPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPlatformIO {
-    pub Platform_GetClipboardTextFn:
-        ::core::option::Option<unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const cty::c_char>,
+    pub Platform_GetClipboardTextFn: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const core::ffi::c_char,
+    >,
     pub Platform_SetClipboardTextFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const cty::c_char),
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const core::ffi::c_char),
     >,
-    pub Platform_ClipboardUserData: *mut cty::c_void,
+    pub Platform_ClipboardUserData: *mut core::ffi::c_void,
     pub Platform_OpenInShellFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const cty::c_char) -> bool,
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const core::ffi::c_char) -> bool,
     >,
-    pub Platform_OpenInShellUserData: *mut cty::c_void,
+    pub Platform_OpenInShellUserData: *mut core::ffi::c_void,
     pub Platform_SetImeDataFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
@@ -2234,7 +2244,7 @@ pub struct ImGuiPlatformIO {
             data: *mut ImGuiPlatformImeData,
         ),
     >,
-    pub Platform_ImeUserData: *mut cty::c_void,
+    pub Platform_ImeUserData: *mut core::ffi::c_void,
     pub Platform_LocaleDecimalPoint: ImWchar,
     pub Platform_CreateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Platform_DestroyWindow:
@@ -2255,16 +2265,16 @@ pub struct ImGuiPlatformIO {
     pub Platform_GetWindowMinimized:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> bool>,
     pub Platform_SetWindowTitle: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, str_: *const cty::c_char),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, str_: *const core::ffi::c_char),
     >,
     pub Platform_SetWindowAlpha:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, alpha: f32)>,
     pub Platform_UpdateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Platform_RenderWindow: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Platform_SwapBuffers: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Platform_GetWindowDpiScale:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> f32>,
@@ -2276,9 +2286,9 @@ pub struct ImGuiPlatformIO {
         unsafe extern "C" fn(
             vp: *mut ImGuiViewport,
             vk_inst: ImU64,
-            vk_allocators: *const cty::c_void,
+            vk_allocators: *const core::ffi::c_void,
             out_vk_surface: *mut ImU64,
-        ) -> cty::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub Renderer_CreateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Renderer_DestroyWindow:
@@ -2286,10 +2296,10 @@ pub struct ImGuiPlatformIO {
     pub Renderer_SetWindowSize:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, size: ImVec2)>,
     pub Renderer_RenderWindow: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Renderer_SwapBuffers: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Monitors: ImVector_ImGuiPlatformMonitor,
     pub Viewports: ImVector_ImGuiViewportPtr,
@@ -2311,7 +2321,7 @@ pub struct ImGuiPlatformMonitor {
     pub WorkPos: ImVec2,
     pub WorkSize: ImVec2,
     pub DpiScale: f32,
-    pub PlatformHandle: *mut cty::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
 }
 impl Default for ImGuiPlatformMonitor {
     fn default() -> Self {
@@ -2329,23 +2339,23 @@ pub struct ImGuiPlatformImeData {
     pub InputPos: ImVec2,
     pub InputLineHeight: f32,
 }
-pub type ImGuiDataAuthority = cty::c_int;
-pub type ImGuiLayoutType = cty::c_int;
-pub type ImGuiActivateFlags = cty::c_int;
-pub type ImGuiDebugLogFlags = cty::c_int;
-pub type ImGuiFocusRequestFlags = cty::c_int;
-pub type ImGuiItemStatusFlags = cty::c_int;
-pub type ImGuiOldColumnFlags = cty::c_int;
-pub type ImGuiNavHighlightFlags = cty::c_int;
-pub type ImGuiNavMoveFlags = cty::c_int;
-pub type ImGuiNextItemDataFlags = cty::c_int;
-pub type ImGuiNextWindowDataFlags = cty::c_int;
-pub type ImGuiScrollFlags = cty::c_int;
-pub type ImGuiSeparatorFlags = cty::c_int;
-pub type ImGuiTextFlags = cty::c_int;
-pub type ImGuiTooltipFlags = cty::c_int;
-pub type ImGuiTypingSelectFlags = cty::c_int;
-pub type ImGuiWindowRefreshFlags = cty::c_int;
+pub type ImGuiDataAuthority = core::ffi::c_int;
+pub type ImGuiLayoutType = core::ffi::c_int;
+pub type ImGuiActivateFlags = core::ffi::c_int;
+pub type ImGuiDebugLogFlags = core::ffi::c_int;
+pub type ImGuiFocusRequestFlags = core::ffi::c_int;
+pub type ImGuiItemStatusFlags = core::ffi::c_int;
+pub type ImGuiOldColumnFlags = core::ffi::c_int;
+pub type ImGuiNavHighlightFlags = core::ffi::c_int;
+pub type ImGuiNavMoveFlags = core::ffi::c_int;
+pub type ImGuiNextItemDataFlags = core::ffi::c_int;
+pub type ImGuiNextWindowDataFlags = core::ffi::c_int;
+pub type ImGuiScrollFlags = core::ffi::c_int;
+pub type ImGuiSeparatorFlags = core::ffi::c_int;
+pub type ImGuiTextFlags = core::ffi::c_int;
+pub type ImGuiTooltipFlags = core::ffi::c_int;
+pub type ImGuiTypingSelectFlags = core::ffi::c_int;
+pub type ImGuiWindowRefreshFlags = core::ffi::c_int;
 pub type ImFileHandle = *mut FILE;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -2355,8 +2365,8 @@ pub struct ImVec1 {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVec2ih {
-    pub x: cty::c_short,
-    pub y: cty::c_short,
+    pub x: core::ffi::c_short,
+    pub y: core::ffi::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -2379,13 +2389,13 @@ impl Default for ImBitVector {
         }
     }
 }
-pub type ImPoolIdx = cty::c_int;
+pub type ImPoolIdx = core::ffi::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_int {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_int,
 }
 impl Default for ImVector_int {
     fn default() -> Self {
@@ -2400,7 +2410,7 @@ impl Default for ImVector_int {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextIndex {
     pub LineOffsets: ImVector_int,
-    pub EndOffset: cty::c_int,
+    pub EndOffset: core::ffi::c_int,
 }
 impl Default for ImGuiTextIndex {
     fn default() -> Self {
@@ -2468,9 +2478,9 @@ pub struct ImGuiDataTypeStorage {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDataTypeInfo {
     pub Size: usize,
-    pub Name: *const cty::c_char,
-    pub PrintFmt: *const cty::c_char,
-    pub ScanFmt: *const cty::c_char,
+    pub Name: *const core::ffi::c_char,
+    pub PrintFmt: *const core::ffi::c_char,
+    pub ScanFmt: *const core::ffi::c_char,
 }
 impl Default for ImGuiDataTypeInfo {
     fn default() -> Self {
@@ -2484,7 +2494,7 @@ impl Default for ImGuiDataTypeInfo {
 pub const ImGuiDataType_String: ImGuiDataTypePrivate_ = 12;
 pub const ImGuiDataType_Pointer: ImGuiDataTypePrivate_ = 13;
 pub const ImGuiDataType_ID: ImGuiDataTypePrivate_ = 14;
-pub type ImGuiDataTypePrivate_ = cty::c_uint;
+pub type ImGuiDataTypePrivate_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_Disabled: ImGuiItemFlagsPrivate_ = 1024;
 pub const ImGuiItemFlags_ReadOnly: ImGuiItemFlagsPrivate_ = 2048;
 pub const ImGuiItemFlags_MixedValue: ImGuiItemFlagsPrivate_ = 4096;
@@ -2494,7 +2504,7 @@ pub const ImGuiItemFlags_Inputable: ImGuiItemFlagsPrivate_ = 1048576;
 pub const ImGuiItemFlags_HasSelectionUserData: ImGuiItemFlagsPrivate_ = 2097152;
 pub const ImGuiItemFlags_IsMultiSelect: ImGuiItemFlagsPrivate_ = 4194304;
 pub const ImGuiItemFlags_Default_: ImGuiItemFlagsPrivate_ = 16;
-pub type ImGuiItemFlagsPrivate_ = cty::c_uint;
+pub type ImGuiItemFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiItemStatusFlags_None: ImGuiItemStatusFlags_ = 0;
 pub const ImGuiItemStatusFlags_HoveredRect: ImGuiItemStatusFlags_ = 1;
 pub const ImGuiItemStatusFlags_HasDisplayRect: ImGuiItemStatusFlags_ = 2;
@@ -2507,16 +2517,16 @@ pub const ImGuiItemStatusFlags_HoveredWindow: ImGuiItemStatusFlags_ = 128;
 pub const ImGuiItemStatusFlags_Visible: ImGuiItemStatusFlags_ = 256;
 pub const ImGuiItemStatusFlags_HasClipRect: ImGuiItemStatusFlags_ = 512;
 pub const ImGuiItemStatusFlags_HasShortcut: ImGuiItemStatusFlags_ = 1024;
-pub type ImGuiItemStatusFlags_ = cty::c_uint;
+pub type ImGuiItemStatusFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_DelayMask_: ImGuiHoveredFlagsPrivate_ = 245760;
 pub const ImGuiHoveredFlags_AllowedMaskForIsWindowHovered: ImGuiHoveredFlagsPrivate_ = 12479;
 pub const ImGuiHoveredFlags_AllowedMaskForIsItemHovered: ImGuiHoveredFlagsPrivate_ = 262048;
-pub type ImGuiHoveredFlagsPrivate_ = cty::c_uint;
+pub type ImGuiHoveredFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_Multiline: ImGuiInputTextFlagsPrivate_ = 67108864;
 pub const ImGuiInputTextFlags_NoMarkEdited: ImGuiInputTextFlagsPrivate_ = 134217728;
 pub const ImGuiInputTextFlags_MergedItem: ImGuiInputTextFlagsPrivate_ = 268435456;
 pub const ImGuiInputTextFlags_LocalizeDecimalPoint: ImGuiInputTextFlagsPrivate_ = 536870912;
-pub type ImGuiInputTextFlagsPrivate_ = cty::c_uint;
+pub type ImGuiInputTextFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_PressedOnClick: ImGuiButtonFlagsPrivate_ = 16;
 pub const ImGuiButtonFlags_PressedOnClickRelease: ImGuiButtonFlagsPrivate_ = 32;
 pub const ImGuiButtonFlags_PressedOnClickReleaseAnywhere: ImGuiButtonFlagsPrivate_ = 64;
@@ -2536,12 +2546,12 @@ pub const ImGuiButtonFlags_NoSetKeyOwner: ImGuiButtonFlagsPrivate_ = 1048576;
 pub const ImGuiButtonFlags_NoTestKeyOwner: ImGuiButtonFlagsPrivate_ = 2097152;
 pub const ImGuiButtonFlags_PressedOnMask_: ImGuiButtonFlagsPrivate_ = 1008;
 pub const ImGuiButtonFlags_PressedOnDefault_: ImGuiButtonFlagsPrivate_ = 32;
-pub type ImGuiButtonFlagsPrivate_ = cty::c_uint;
+pub type ImGuiButtonFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_CustomPreview: ImGuiComboFlagsPrivate_ = 1048576;
-pub type ImGuiComboFlagsPrivate_ = cty::c_uint;
+pub type ImGuiComboFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_Vertical: ImGuiSliderFlagsPrivate_ = 1048576;
 pub const ImGuiSliderFlags_ReadOnly: ImGuiSliderFlagsPrivate_ = 2097152;
-pub type ImGuiSliderFlagsPrivate_ = cty::c_uint;
+pub type ImGuiSliderFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_NoHoldingActiveID: ImGuiSelectableFlagsPrivate_ = 1048576;
 pub const ImGuiSelectableFlags_SelectOnNav: ImGuiSelectableFlagsPrivate_ = 2097152;
 pub const ImGuiSelectableFlags_SelectOnClick: ImGuiSelectableFlagsPrivate_ = 4194304;
@@ -2550,42 +2560,42 @@ pub const ImGuiSelectableFlags_SpanAvailWidth: ImGuiSelectableFlagsPrivate_ = 16
 pub const ImGuiSelectableFlags_SetNavIdOnHover: ImGuiSelectableFlagsPrivate_ = 33554432;
 pub const ImGuiSelectableFlags_NoPadWithHalfSpacing: ImGuiSelectableFlagsPrivate_ = 67108864;
 pub const ImGuiSelectableFlags_NoSetKeyOwner: ImGuiSelectableFlagsPrivate_ = 134217728;
-pub type ImGuiSelectableFlagsPrivate_ = cty::c_uint;
+pub type ImGuiSelectableFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_ClipLabelForTrailingButton: ImGuiTreeNodeFlagsPrivate_ = 268435456;
 pub const ImGuiTreeNodeFlags_UpsideDownArrow: ImGuiTreeNodeFlagsPrivate_ = 536870912;
 pub const ImGuiTreeNodeFlags_OpenOnMask_: ImGuiTreeNodeFlagsPrivate_ = 192;
-pub type ImGuiTreeNodeFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTreeNodeFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSeparatorFlags_None: ImGuiSeparatorFlags_ = 0;
 pub const ImGuiSeparatorFlags_Horizontal: ImGuiSeparatorFlags_ = 1;
 pub const ImGuiSeparatorFlags_Vertical: ImGuiSeparatorFlags_ = 2;
 pub const ImGuiSeparatorFlags_SpanAllColumns: ImGuiSeparatorFlags_ = 4;
-pub type ImGuiSeparatorFlags_ = cty::c_uint;
+pub type ImGuiSeparatorFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusRequestFlags_None: ImGuiFocusRequestFlags_ = 0;
 pub const ImGuiFocusRequestFlags_RestoreFocusedChild: ImGuiFocusRequestFlags_ = 1;
 pub const ImGuiFocusRequestFlags_UnlessBelowModal: ImGuiFocusRequestFlags_ = 2;
-pub type ImGuiFocusRequestFlags_ = cty::c_uint;
+pub type ImGuiFocusRequestFlags_ = core::ffi::c_uint;
 pub const ImGuiTextFlags_None: ImGuiTextFlags_ = 0;
 pub const ImGuiTextFlags_NoWidthForLargeClippedText: ImGuiTextFlags_ = 1;
-pub type ImGuiTextFlags_ = cty::c_uint;
+pub type ImGuiTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTooltipFlags_None: ImGuiTooltipFlags_ = 0;
 pub const ImGuiTooltipFlags_OverridePrevious: ImGuiTooltipFlags_ = 2;
-pub type ImGuiTooltipFlags_ = cty::c_uint;
+pub type ImGuiTooltipFlags_ = core::ffi::c_uint;
 pub const ImGuiLayoutType_Horizontal: ImGuiLayoutType_ = 0;
 pub const ImGuiLayoutType_Vertical: ImGuiLayoutType_ = 1;
-pub type ImGuiLayoutType_ = cty::c_uint;
+pub type ImGuiLayoutType_ = core::ffi::c_uint;
 pub const ImGuiLogType_None: ImGuiLogType = 0;
 pub const ImGuiLogType_TTY: ImGuiLogType = 1;
 pub const ImGuiLogType_File: ImGuiLogType = 2;
 pub const ImGuiLogType_Buffer: ImGuiLogType = 3;
 pub const ImGuiLogType_Clipboard: ImGuiLogType = 4;
-pub type ImGuiLogType = cty::c_uint;
+pub type ImGuiLogType = core::ffi::c_uint;
 pub const ImGuiAxis_None: ImGuiAxis = -1;
 pub const ImGuiAxis_X: ImGuiAxis = 0;
 pub const ImGuiAxis_Y: ImGuiAxis = 1;
-pub type ImGuiAxis = cty::c_int;
+pub type ImGuiAxis = core::ffi::c_int;
 pub const ImGuiPlotType_Lines: ImGuiPlotType = 0;
 pub const ImGuiPlotType_Histogram: ImGuiPlotType = 1;
-pub type ImGuiPlotType = cty::c_uint;
+pub type ImGuiPlotType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiColorMod {
@@ -2601,7 +2611,7 @@ pub struct ImGuiStyleMod {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStyleMod__bindgen_ty_1 {
-    pub BackupInt: [cty::c_int; 2usize],
+    pub BackupInt: [core::ffi::c_int; 2usize],
     pub BackupFloat: [f32; 2usize],
 }
 impl Default for ImGuiStyleMod__bindgen_ty_1 {
@@ -2697,11 +2707,11 @@ pub struct ImGuiInputTextState {
     pub Ctx: *mut ImGuiContext,
     pub Stb: *mut ImStbTexteditState,
     pub ID: ImGuiID,
-    pub CurLenA: cty::c_int,
+    pub CurLenA: core::ffi::c_int,
     pub TextA: ImVector_char,
     pub InitialTextA: ImVector_char,
     pub CallbackTextBackup: ImVector_char,
-    pub BufCapacityA: cty::c_int,
+    pub BufCapacityA: core::ffi::c_int,
     pub Scroll: ImVec2,
     pub CursorAnim: f32,
     pub CursorFollow: bool,
@@ -2709,8 +2719,8 @@ pub struct ImGuiInputTextState {
     pub Edited: bool,
     pub Flags: ImGuiInputTextFlags,
     pub ReloadUserBuf: bool,
-    pub ReloadSelectionStart: cty::c_int,
-    pub ReloadSelectionEnd: cty::c_int,
+    pub ReloadSelectionStart: core::ffi::c_int,
+    pub ReloadSelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextState {
     fn default() -> Self {
@@ -2725,7 +2735,7 @@ pub const ImGuiWindowRefreshFlags_None: ImGuiWindowRefreshFlags_ = 0;
 pub const ImGuiWindowRefreshFlags_TryToAvoidRefresh: ImGuiWindowRefreshFlags_ = 1;
 pub const ImGuiWindowRefreshFlags_RefreshOnHover: ImGuiWindowRefreshFlags_ = 2;
 pub const ImGuiWindowRefreshFlags_RefreshOnFocus: ImGuiWindowRefreshFlags_ = 4;
-pub type ImGuiWindowRefreshFlags_ = cty::c_uint;
+pub type ImGuiWindowRefreshFlags_ = core::ffi::c_uint;
 pub const ImGuiNextWindowDataFlags_None: ImGuiNextWindowDataFlags_ = 0;
 pub const ImGuiNextWindowDataFlags_HasPos: ImGuiNextWindowDataFlags_ = 1;
 pub const ImGuiNextWindowDataFlags_HasSize: ImGuiNextWindowDataFlags_ = 2;
@@ -2740,7 +2750,7 @@ pub const ImGuiNextWindowDataFlags_HasRefreshPolicy: ImGuiNextWindowDataFlags_ =
 pub const ImGuiNextWindowDataFlags_HasViewport: ImGuiNextWindowDataFlags_ = 1024;
 pub const ImGuiNextWindowDataFlags_HasDock: ImGuiNextWindowDataFlags_ = 2048;
 pub const ImGuiNextWindowDataFlags_HasWindowClass: ImGuiNextWindowDataFlags_ = 4096;
-pub type ImGuiNextWindowDataFlags_ = cty::c_uint;
+pub type ImGuiNextWindowDataFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiNextWindowData {
@@ -2759,7 +2769,7 @@ pub struct ImGuiNextWindowData {
     pub CollapsedVal: bool,
     pub SizeConstraintRect: ImRect,
     pub SizeCallback: ImGuiSizeCallback,
-    pub SizeCallbackUserData: *mut cty::c_void,
+    pub SizeCallbackUserData: *mut core::ffi::c_void,
     pub BgAlphaVal: f32,
     pub ViewportId: ImGuiID,
     pub DockId: ImGuiID,
@@ -2782,7 +2792,7 @@ pub const ImGuiNextItemDataFlags_HasOpen: ImGuiNextItemDataFlags_ = 2;
 pub const ImGuiNextItemDataFlags_HasShortcut: ImGuiNextItemDataFlags_ = 4;
 pub const ImGuiNextItemDataFlags_HasRefVal: ImGuiNextItemDataFlags_ = 8;
 pub const ImGuiNextItemDataFlags_HasStorageID: ImGuiNextItemDataFlags_ = 16;
-pub type ImGuiNextItemDataFlags_ = cty::c_uint;
+pub type ImGuiNextItemDataFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiNextItemData {
@@ -2821,17 +2831,17 @@ pub struct ImGuiTreeNodeStackData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiErrorRecoveryState {
-    pub SizeOfWindowStack: cty::c_short,
-    pub SizeOfIDStack: cty::c_short,
-    pub SizeOfTreeStack: cty::c_short,
-    pub SizeOfColorStack: cty::c_short,
-    pub SizeOfStyleVarStack: cty::c_short,
-    pub SizeOfFontStack: cty::c_short,
-    pub SizeOfFocusScopeStack: cty::c_short,
-    pub SizeOfGroupStack: cty::c_short,
-    pub SizeOfItemFlagsStack: cty::c_short,
-    pub SizeOfBeginPopupStack: cty::c_short,
-    pub SizeOfDisabledStack: cty::c_short,
+    pub SizeOfWindowStack: core::ffi::c_short,
+    pub SizeOfIDStack: core::ffi::c_short,
+    pub SizeOfTreeStack: core::ffi::c_short,
+    pub SizeOfColorStack: core::ffi::c_short,
+    pub SizeOfStyleVarStack: core::ffi::c_short,
+    pub SizeOfFontStack: core::ffi::c_short,
+    pub SizeOfFocusScopeStack: core::ffi::c_short,
+    pub SizeOfGroupStack: core::ffi::c_short,
+    pub SizeOfItemFlagsStack: core::ffi::c_short,
+    pub SizeOfBeginPopupStack: core::ffi::c_short,
+    pub SizeOfDisabledStack: core::ffi::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -2853,15 +2863,15 @@ impl Default for ImGuiWindowStackData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiShrinkWidthItem {
-    pub Index: cty::c_int,
+    pub Index: core::ffi::c_int,
     pub Width: f32,
     pub InitialWidth: f32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPtrOrIndex {
-    pub Ptr: *mut cty::c_void,
-    pub Index: cty::c_int,
+    pub Ptr: *mut core::ffi::c_void,
+    pub Index: core::ffi::c_int,
 }
 impl Default for ImGuiPtrOrIndex {
     fn default() -> Self {
@@ -2875,15 +2885,15 @@ impl Default for ImGuiPtrOrIndex {
 pub const ImGuiPopupPositionPolicy_Default: ImGuiPopupPositionPolicy = 0;
 pub const ImGuiPopupPositionPolicy_ComboBox: ImGuiPopupPositionPolicy = 1;
 pub const ImGuiPopupPositionPolicy_Tooltip: ImGuiPopupPositionPolicy = 2;
-pub type ImGuiPopupPositionPolicy = cty::c_uint;
+pub type ImGuiPopupPositionPolicy = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiPopupData {
     pub PopupId: ImGuiID,
     pub Window: *mut ImGuiWindow,
     pub RestoreNavWindow: *mut ImGuiWindow,
-    pub ParentNavLayer: cty::c_int,
-    pub OpenFrameCount: cty::c_int,
+    pub ParentNavLayer: core::ffi::c_int,
+    pub OpenFrameCount: core::ffi::c_int,
     pub OpenParentId: ImGuiID,
     pub OpenPopupPos: ImVec2,
     pub OpenMousePos: ImVec2,
@@ -2912,13 +2922,13 @@ pub const ImGuiInputEventType_Key: ImGuiInputEventType = 5;
 pub const ImGuiInputEventType_Text: ImGuiInputEventType = 6;
 pub const ImGuiInputEventType_Focus: ImGuiInputEventType = 7;
 pub const ImGuiInputEventType_COUNT: ImGuiInputEventType = 8;
-pub type ImGuiInputEventType = cty::c_uint;
+pub type ImGuiInputEventType = core::ffi::c_uint;
 pub const ImGuiInputSource_None: ImGuiInputSource = 0;
 pub const ImGuiInputSource_Mouse: ImGuiInputSource = 1;
 pub const ImGuiInputSource_Keyboard: ImGuiInputSource = 2;
 pub const ImGuiInputSource_Gamepad: ImGuiInputSource = 3;
 pub const ImGuiInputSource_COUNT: ImGuiInputSource = 4;
-pub type ImGuiInputSource = cty::c_uint;
+pub type ImGuiInputSource = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiInputEventMousePos {
@@ -2954,7 +2964,7 @@ impl Default for ImGuiInputEventMouseWheel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiInputEventMouseButton {
-    pub Button: cty::c_int,
+    pub Button: core::ffi::c_int,
     pub Down: bool,
     pub MouseSource: ImGuiMouseSource,
 }
@@ -2991,7 +3001,7 @@ impl Default for ImGuiInputEventKey {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiInputEventText {
-    pub Char: cty::c_uint,
+    pub Char: core::ffi::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -3060,8 +3070,8 @@ pub struct ImGuiKeyRoutingData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiKeyRoutingData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiKeyRoutingData,
 }
 impl Default for ImVector_ImGuiKeyRoutingData {
@@ -3121,12 +3131,12 @@ pub const ImGuiInputFlags_SupportedByShortcut: ImGuiInputFlagsPrivate_ = 261375;
 pub const ImGuiInputFlags_SupportedBySetNextItemShortcut: ImGuiInputFlagsPrivate_ = 523519;
 pub const ImGuiInputFlags_SupportedBySetKeyOwner: ImGuiInputFlagsPrivate_ = 3145728;
 pub const ImGuiInputFlags_SupportedBySetItemKeyOwner: ImGuiInputFlagsPrivate_ = 15728640;
-pub type ImGuiInputFlagsPrivate_ = cty::c_uint;
+pub type ImGuiInputFlagsPrivate_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiListClipperRange {
-    pub Min: cty::c_int,
-    pub Max: cty::c_int,
+    pub Min: core::ffi::c_int,
+    pub Max: core::ffi::c_int,
     pub PosToIndexConvert: bool,
     pub PosToIndexOffsetMin: ImS8,
     pub PosToIndexOffsetMax: ImS8,
@@ -3134,8 +3144,8 @@ pub struct ImGuiListClipperRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiListClipperRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiListClipperRange,
 }
 impl Default for ImVector_ImGuiListClipperRange {
@@ -3152,8 +3162,8 @@ impl Default for ImVector_ImGuiListClipperRange {
 pub struct ImGuiListClipperData {
     pub ListClipper: *mut ImGuiListClipper,
     pub LossynessOffset: f32,
-    pub StepNo: cty::c_int,
-    pub ItemsFrozen: cty::c_int,
+    pub StepNo: core::ffi::c_int,
+    pub ItemsFrozen: core::ffi::c_int,
     pub Ranges: ImVector_ImGuiListClipperRange,
 }
 impl Default for ImGuiListClipperData {
@@ -3171,7 +3181,7 @@ pub const ImGuiActivateFlags_PreferTweak: ImGuiActivateFlags_ = 2;
 pub const ImGuiActivateFlags_TryToPreserveState: ImGuiActivateFlags_ = 4;
 pub const ImGuiActivateFlags_FromTabbing: ImGuiActivateFlags_ = 8;
 pub const ImGuiActivateFlags_FromShortcut: ImGuiActivateFlags_ = 16;
-pub type ImGuiActivateFlags_ = cty::c_uint;
+pub type ImGuiActivateFlags_ = core::ffi::c_uint;
 pub const ImGuiScrollFlags_None: ImGuiScrollFlags_ = 0;
 pub const ImGuiScrollFlags_KeepVisibleEdgeX: ImGuiScrollFlags_ = 1;
 pub const ImGuiScrollFlags_KeepVisibleEdgeY: ImGuiScrollFlags_ = 2;
@@ -3182,12 +3192,12 @@ pub const ImGuiScrollFlags_AlwaysCenterY: ImGuiScrollFlags_ = 32;
 pub const ImGuiScrollFlags_NoScrollParent: ImGuiScrollFlags_ = 64;
 pub const ImGuiScrollFlags_MaskX_: ImGuiScrollFlags_ = 21;
 pub const ImGuiScrollFlags_MaskY_: ImGuiScrollFlags_ = 42;
-pub type ImGuiScrollFlags_ = cty::c_uint;
+pub type ImGuiScrollFlags_ = core::ffi::c_uint;
 pub const ImGuiNavHighlightFlags_None: ImGuiNavHighlightFlags_ = 0;
 pub const ImGuiNavHighlightFlags_Compact: ImGuiNavHighlightFlags_ = 2;
 pub const ImGuiNavHighlightFlags_AlwaysDraw: ImGuiNavHighlightFlags_ = 4;
 pub const ImGuiNavHighlightFlags_NoRounding: ImGuiNavHighlightFlags_ = 8;
-pub type ImGuiNavHighlightFlags_ = cty::c_uint;
+pub type ImGuiNavHighlightFlags_ = core::ffi::c_uint;
 pub const ImGuiNavMoveFlags_None: ImGuiNavMoveFlags_ = 0;
 pub const ImGuiNavMoveFlags_LoopX: ImGuiNavMoveFlags_ = 1;
 pub const ImGuiNavMoveFlags_LoopY: ImGuiNavMoveFlags_ = 2;
@@ -3206,11 +3216,11 @@ pub const ImGuiNavMoveFlags_Activate: ImGuiNavMoveFlags_ = 4096;
 pub const ImGuiNavMoveFlags_NoSelect: ImGuiNavMoveFlags_ = 8192;
 pub const ImGuiNavMoveFlags_NoSetNavHighlight: ImGuiNavMoveFlags_ = 16384;
 pub const ImGuiNavMoveFlags_NoClearActiveId: ImGuiNavMoveFlags_ = 32768;
-pub type ImGuiNavMoveFlags_ = cty::c_uint;
+pub type ImGuiNavMoveFlags_ = core::ffi::c_uint;
 pub const ImGuiNavLayer_Main: ImGuiNavLayer = 0;
 pub const ImGuiNavLayer_Menu: ImGuiNavLayer = 1;
 pub const ImGuiNavLayer_COUNT: ImGuiNavLayer = 2;
-pub type ImGuiNavLayer = cty::c_uint;
+pub type ImGuiNavLayer = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiNavItemData {
@@ -3242,13 +3252,13 @@ pub struct ImGuiFocusScopeData {
 pub const ImGuiTypingSelectFlags_None: ImGuiTypingSelectFlags_ = 0;
 pub const ImGuiTypingSelectFlags_AllowBackspace: ImGuiTypingSelectFlags_ = 1;
 pub const ImGuiTypingSelectFlags_AllowSingleCharMode: ImGuiTypingSelectFlags_ = 2;
-pub type ImGuiTypingSelectFlags_ = cty::c_uint;
+pub type ImGuiTypingSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTypingSelectRequest {
     pub Flags: ImGuiTypingSelectFlags,
-    pub SearchBufferLen: cty::c_int,
-    pub SearchBuffer: *const cty::c_char,
+    pub SearchBufferLen: core::ffi::c_int,
+    pub SearchBuffer: *const core::ffi::c_char,
     pub SelectRequest: bool,
     pub SingleCharMode: bool,
     pub SingleCharSize: ImS8,
@@ -3266,9 +3276,9 @@ impl Default for ImGuiTypingSelectRequest {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTypingSelectState {
     pub Request: ImGuiTypingSelectRequest,
-    pub SearchBuffer: [cty::c_char; 64usize],
+    pub SearchBuffer: [core::ffi::c_char; 64usize],
     pub FocusScope: ImGuiID,
-    pub LastRequestFrame: cty::c_int,
+    pub LastRequestFrame: core::ffi::c_int,
     pub LastRequestTime: f32,
     pub SingleCharModeLock: bool,
 }
@@ -3287,7 +3297,7 @@ pub const ImGuiOldColumnFlags_NoResize: ImGuiOldColumnFlags_ = 2;
 pub const ImGuiOldColumnFlags_NoPreserveWidths: ImGuiOldColumnFlags_ = 4;
 pub const ImGuiOldColumnFlags_NoForceWithinWindow: ImGuiOldColumnFlags_ = 8;
 pub const ImGuiOldColumnFlags_GrowParentContentsSize: ImGuiOldColumnFlags_ = 16;
-pub type ImGuiOldColumnFlags_ = cty::c_uint;
+pub type ImGuiOldColumnFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiOldColumnData {
@@ -3299,8 +3309,8 @@ pub struct ImGuiOldColumnData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiOldColumnData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiOldColumnData,
 }
 impl Default for ImVector_ImGuiOldColumnData {
@@ -3319,8 +3329,8 @@ pub struct ImGuiOldColumns {
     pub Flags: ImGuiOldColumnFlags,
     pub IsFirstFrame: bool,
     pub IsBeingResized: bool,
-    pub Current: cty::c_int,
-    pub Count: cty::c_int,
+    pub Current: core::ffi::c_int,
+    pub Count: core::ffi::c_int,
     pub OffMinX: f32,
     pub OffMaxX: f32,
     pub LineMinY: f32,
@@ -3427,8 +3437,8 @@ impl Default for ImGuiMultiSelectTempData {
 pub struct ImGuiMultiSelectState {
     pub Window: *mut ImGuiWindow,
     pub ID: ImGuiID,
-    pub LastFrameActive: cty::c_int,
-    pub LastSelectionSize: cty::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastSelectionSize: core::ffi::c_int,
     pub RangeSelected: ImS8,
     pub NavIdSelected: ImS8,
     pub RangeSrcItem: ImGuiSelectionUserData,
@@ -3461,21 +3471,21 @@ pub const ImGuiDockNodeFlags_SharedFlagsInheritMask_: ImGuiDockNodeFlagsPrivate_
 pub const ImGuiDockNodeFlags_NoResizeFlagsMask_: ImGuiDockNodeFlagsPrivate_ = 196640;
 pub const ImGuiDockNodeFlags_LocalFlagsTransferMask_: ImGuiDockNodeFlagsPrivate_ = 260208;
 pub const ImGuiDockNodeFlags_SavedFlagsMask_: ImGuiDockNodeFlagsPrivate_ = 261152;
-pub type ImGuiDockNodeFlagsPrivate_ = cty::c_int;
+pub type ImGuiDockNodeFlagsPrivate_ = core::ffi::c_int;
 pub const ImGuiDataAuthority_Auto: ImGuiDataAuthority_ = 0;
 pub const ImGuiDataAuthority_DockNode: ImGuiDataAuthority_ = 1;
 pub const ImGuiDataAuthority_Window: ImGuiDataAuthority_ = 2;
-pub type ImGuiDataAuthority_ = cty::c_uint;
+pub type ImGuiDataAuthority_ = core::ffi::c_uint;
 pub const ImGuiDockNodeState_Unknown: ImGuiDockNodeState = 0;
 pub const ImGuiDockNodeState_HostWindowHiddenBecauseSingleWindow: ImGuiDockNodeState = 1;
 pub const ImGuiDockNodeState_HostWindowHiddenBecauseWindowsAreResizing: ImGuiDockNodeState = 2;
 pub const ImGuiDockNodeState_HostWindowVisible: ImGuiDockNodeState = 3;
-pub type ImGuiDockNodeState = cty::c_uint;
+pub type ImGuiDockNodeState = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiWindowPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiWindow,
 }
 impl Default for ImVector_ImGuiWindowPtr {
@@ -3510,10 +3520,10 @@ pub struct ImGuiDockNode {
     pub VisibleWindow: *mut ImGuiWindow,
     pub CentralNode: *mut ImGuiDockNode,
     pub OnlyNodeWithWindows: *mut ImGuiDockNode,
-    pub CountNodeWithWindows: cty::c_int,
-    pub LastFrameAlive: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub LastFrameFocused: cty::c_int,
+    pub CountNodeWithWindows: core::ffi::c_int,
+    pub LastFrameAlive: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFrameFocused: core::ffi::c_int,
     pub LastFocusedNodeId: ImGuiID,
     pub SelectedTabId: ImGuiID,
     pub WantCloseTabId: ImGuiID,
@@ -3774,7 +3784,7 @@ pub const ImGuiWindowDockStyleCol_TabDimmed: ImGuiWindowDockStyleCol = 5;
 pub const ImGuiWindowDockStyleCol_TabDimmedSelected: ImGuiWindowDockStyleCol = 6;
 pub const ImGuiWindowDockStyleCol_TabDimmedSelectedOverline: ImGuiWindowDockStyleCol = 7;
 pub const ImGuiWindowDockStyleCol_COUNT: ImGuiWindowDockStyleCol = 8;
-pub type ImGuiWindowDockStyleCol = cty::c_uint;
+pub type ImGuiWindowDockStyleCol = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiWindowDockStyle {
@@ -3783,8 +3793,8 @@ pub struct ImGuiWindowDockStyle {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiDockRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiDockRequest,
 }
 impl Default for ImVector_ImGuiDockRequest {
@@ -3799,8 +3809,8 @@ impl Default for ImVector_ImGuiDockRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiDockNodeSettings {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiDockNodeSettings,
 }
 impl Default for ImVector_ImGuiDockNodeSettings {
@@ -3834,17 +3844,17 @@ impl Default for ImGuiDockContext {
 pub struct ImGuiViewportP {
     pub _ImGuiViewport: ImGuiViewport,
     pub Window: *mut ImGuiWindow,
-    pub Idx: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub LastFocusedStampCount: cty::c_int,
+    pub Idx: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFocusedStampCount: core::ffi::c_int,
     pub LastNameHash: ImGuiID,
     pub LastPos: ImVec2,
     pub LastSize: ImVec2,
     pub Alpha: f32,
     pub LastAlpha: f32,
     pub LastFocusedHadNavWindow: bool,
-    pub PlatformMonitor: cty::c_short,
-    pub BgFgDrawListsLastFrame: [cty::c_int; 2usize],
+    pub PlatformMonitor: core::ffi::c_short,
+    pub BgFgDrawListsLastFrame: [core::ffi::c_int; 2usize],
     pub BgFgDrawLists: [*mut ImDrawList; 2usize],
     pub DrawDataP: ImDrawData,
     pub DrawDataBuilder: ImDrawDataBuilder,
@@ -3875,7 +3885,7 @@ pub struct ImGuiWindowSettings {
     pub ViewportId: ImGuiID,
     pub DockId: ImGuiID,
     pub ClassId: ImGuiID,
-    pub DockOrder: cty::c_short,
+    pub DockOrder: core::ffi::c_short,
     pub Collapsed: bool,
     pub IsChild: bool,
     pub WantApply: bool,
@@ -3884,7 +3894,7 @@ pub struct ImGuiWindowSettings {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSettingsHandler {
-    pub TypeName: *const cty::c_char,
+    pub TypeName: *const core::ffi::c_char,
     pub TypeHash: ImGuiID,
     pub ClearAllFn: ::core::option::Option<
         unsafe extern "C" fn(ctx: *mut ImGuiContext, handler: *mut ImGuiSettingsHandler),
@@ -3896,15 +3906,15 @@ pub struct ImGuiSettingsHandler {
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
             handler: *mut ImGuiSettingsHandler,
-            name: *const cty::c_char,
-        ) -> *mut cty::c_void,
+            name: *const core::ffi::c_char,
+        ) -> *mut core::ffi::c_void,
     >,
     pub ReadLineFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
             handler: *mut ImGuiSettingsHandler,
-            entry: *mut cty::c_void,
-            line: *const cty::c_char,
+            entry: *mut core::ffi::c_void,
+            line: *const core::ffi::c_char,
         ),
     >,
     pub ApplyAllFn: ::core::option::Option<
@@ -3917,7 +3927,7 @@ pub struct ImGuiSettingsHandler {
             out_buf: *mut ImGuiTextBuffer,
         ),
     >,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiSettingsHandler {
     fn default() -> Self {
@@ -3942,12 +3952,12 @@ pub const ImGuiLocKey_DockingHideTabBar: ImGuiLocKey = 10;
 pub const ImGuiLocKey_DockingHoldShiftToDock: ImGuiLocKey = 11;
 pub const ImGuiLocKey_DockingDragToUndockOrMoveNode: ImGuiLocKey = 12;
 pub const ImGuiLocKey_COUNT: ImGuiLocKey = 13;
-pub type ImGuiLocKey = cty::c_uint;
+pub type ImGuiLocKey = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiLocEntry {
     pub Key: ImGuiLocKey,
-    pub Text: *const cty::c_char,
+    pub Text: *const core::ffi::c_char,
 }
 impl Default for ImGuiLocEntry {
     fn default() -> Self {
@@ -3961,8 +3971,8 @@ impl Default for ImGuiLocEntry {
 pub type ImGuiErrorCallback = ::core::option::Option<
     unsafe extern "C" fn(
         ctx: *mut ImGuiContext,
-        user_data: *mut cty::c_void,
-        msg: *const cty::c_char,
+        user_data: *mut core::ffi::c_void,
+        msg: *const core::ffi::c_char,
     ),
 >;
 pub const ImGuiDebugLogFlags_None: ImGuiDebugLogFlags_ = 0;
@@ -3980,19 +3990,19 @@ pub const ImGuiDebugLogFlags_EventViewport: ImGuiDebugLogFlags_ = 1024;
 pub const ImGuiDebugLogFlags_EventMask_: ImGuiDebugLogFlags_ = 2047;
 pub const ImGuiDebugLogFlags_OutputToTTY: ImGuiDebugLogFlags_ = 1048576;
 pub const ImGuiDebugLogFlags_OutputToTestEngine: ImGuiDebugLogFlags_ = 2097152;
-pub type ImGuiDebugLogFlags_ = cty::c_uint;
+pub type ImGuiDebugLogFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDebugAllocEntry {
-    pub FrameCount: cty::c_int,
+    pub FrameCount: core::ffi::c_int,
     pub AllocCount: ImS16,
     pub FreeCount: ImS16,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDebugAllocInfo {
-    pub TotalAllocCount: cty::c_int,
-    pub TotalFreeCount: cty::c_int,
+    pub TotalAllocCount: core::ffi::c_int,
+    pub TotalFreeCount: core::ffi::c_int,
     pub LastEntriesIdx: ImS16,
     pub LastEntriesBuf: [ImGuiDebugAllocEntry; 6usize],
 }
@@ -4009,9 +4019,9 @@ pub struct ImGuiMetricsConfig {
     pub ShowTextEncodingViewer: bool,
     pub ShowAtlasTintedWithTextColor: bool,
     pub ShowDockingNodes: bool,
-    pub ShowWindowsRectsType: cty::c_int,
-    pub ShowTablesRectsType: cty::c_int,
-    pub HighlightMonitorIdx: cty::c_int,
+    pub ShowWindowsRectsType: core::ffi::c_int,
+    pub ShowTablesRectsType: core::ffi::c_int,
+    pub HighlightMonitorIdx: core::ffi::c_int,
     pub HighlightViewportID: ImGuiID,
 }
 #[repr(C)]
@@ -4022,7 +4032,7 @@ pub struct ImGuiStackLevelInfo {
     pub QuerySuccess: bool,
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub Desc: [cty::c_char; 57usize],
+    pub Desc: [core::ffi::c_char; 57usize],
 }
 impl Default for ImGuiStackLevelInfo {
     fn default() -> Self {
@@ -4058,8 +4068,8 @@ impl ImGuiStackLevelInfo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStackLevelInfo {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStackLevelInfo,
 }
 impl Default for ImVector_ImGuiStackLevelInfo {
@@ -4074,8 +4084,8 @@ impl Default for ImVector_ImGuiStackLevelInfo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiIDStackTool {
-    pub LastActiveFrame: cty::c_int,
-    pub StackLevel: cty::c_int,
+    pub LastActiveFrame: core::ffi::c_int,
+    pub StackLevel: core::ffi::c_int,
     pub QueryId: ImGuiID,
     pub Results: ImVector_ImGuiStackLevelInfo,
     pub CopyToClipboardOnCtrlC: bool,
@@ -4101,7 +4111,7 @@ pub const ImGuiContextHookType_RenderPre: ImGuiContextHookType = 4;
 pub const ImGuiContextHookType_RenderPost: ImGuiContextHookType = 5;
 pub const ImGuiContextHookType_Shutdown: ImGuiContextHookType = 6;
 pub const ImGuiContextHookType_PendingRemoval_: ImGuiContextHookType = 7;
-pub type ImGuiContextHookType = cty::c_uint;
+pub type ImGuiContextHookType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiContextHook {
@@ -4109,7 +4119,7 @@ pub struct ImGuiContextHook {
     pub Type: ImGuiContextHookType,
     pub Owner: ImGuiID,
     pub Callback: ImGuiContextHookCallback,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiContextHook {
     fn default() -> Self {
@@ -4123,8 +4133,8 @@ impl Default for ImGuiContextHook {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiInputEvent {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiInputEvent,
 }
 impl Default for ImVector_ImGuiInputEvent {
@@ -4139,8 +4149,8 @@ impl Default for ImVector_ImGuiInputEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiWindowStackData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiWindowStackData,
 }
 impl Default for ImVector_ImGuiWindowStackData {
@@ -4155,8 +4165,8 @@ impl Default for ImVector_ImGuiWindowStackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiColorMod {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiColorMod,
 }
 impl Default for ImVector_ImGuiColorMod {
@@ -4171,8 +4181,8 @@ impl Default for ImVector_ImGuiColorMod {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStyleMod {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStyleMod,
 }
 impl Default for ImVector_ImGuiStyleMod {
@@ -4187,8 +4197,8 @@ impl Default for ImVector_ImGuiStyleMod {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiFocusScopeData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiFocusScopeData,
 }
 impl Default for ImVector_ImGuiFocusScopeData {
@@ -4203,8 +4213,8 @@ impl Default for ImVector_ImGuiFocusScopeData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiItemFlags {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiItemFlags,
 }
 impl Default for ImVector_ImGuiItemFlags {
@@ -4219,8 +4229,8 @@ impl Default for ImVector_ImGuiItemFlags {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiGroupData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiGroupData,
 }
 impl Default for ImVector_ImGuiGroupData {
@@ -4235,8 +4245,8 @@ impl Default for ImVector_ImGuiGroupData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPopupData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPopupData,
 }
 impl Default for ImVector_ImGuiPopupData {
@@ -4251,8 +4261,8 @@ impl Default for ImVector_ImGuiPopupData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTreeNodeStackData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTreeNodeStackData,
 }
 impl Default for ImVector_ImGuiTreeNodeStackData {
@@ -4267,8 +4277,8 @@ impl Default for ImVector_ImGuiTreeNodeStackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiViewportPPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiViewportP,
 }
 impl Default for ImVector_ImGuiViewportPPtr {
@@ -4283,9 +4293,9 @@ impl Default for ImVector_ImGuiViewportPPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_unsigned_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_uchar,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_uchar,
 }
 impl Default for ImVector_unsigned_char {
     fn default() -> Self {
@@ -4299,8 +4309,8 @@ impl Default for ImVector_unsigned_char {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiListClipperData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiListClipperData,
 }
 impl Default for ImVector_ImGuiListClipperData {
@@ -4315,8 +4325,8 @@ impl Default for ImVector_ImGuiListClipperData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableTempData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableTempData,
 }
 impl Default for ImVector_ImGuiTableTempData {
@@ -4331,8 +4341,8 @@ impl Default for ImVector_ImGuiTableTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTable {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTable,
 }
 impl Default for ImVector_ImGuiTable {
@@ -4364,8 +4374,8 @@ impl Default for ImPool_ImGuiTable {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTabBar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTabBar,
 }
 impl Default for ImVector_ImGuiTabBar {
@@ -4397,8 +4407,8 @@ impl Default for ImPool_ImGuiTabBar {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPtrOrIndex {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPtrOrIndex,
 }
 impl Default for ImVector_ImGuiPtrOrIndex {
@@ -4413,8 +4423,8 @@ impl Default for ImVector_ImGuiPtrOrIndex {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiShrinkWidthItem {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiShrinkWidthItem,
 }
 impl Default for ImVector_ImGuiShrinkWidthItem {
@@ -4429,8 +4439,8 @@ impl Default for ImVector_ImGuiShrinkWidthItem {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiMultiSelectTempData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiMultiSelectTempData,
 }
 impl Default for ImVector_ImGuiMultiSelectTempData {
@@ -4445,8 +4455,8 @@ impl Default for ImVector_ImGuiMultiSelectTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiMultiSelectState {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiMultiSelectState,
 }
 impl Default for ImVector_ImGuiMultiSelectState {
@@ -4478,8 +4488,8 @@ impl Default for ImPool_ImGuiMultiSelectState {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiID,
 }
 impl Default for ImVector_ImGuiID {
@@ -4494,8 +4504,8 @@ impl Default for ImVector_ImGuiID {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSettingsHandler {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSettingsHandler,
 }
 impl Default for ImVector_ImGuiSettingsHandler {
@@ -4538,8 +4548,8 @@ impl Default for ImChunkStream_ImGuiTableSettings {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiContextHook {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiContextHook,
 }
 impl Default for ImVector_ImGuiContextHook {
@@ -4568,17 +4578,17 @@ pub struct ImGuiContext {
     pub CurrentDpiScale: f32,
     pub DrawListSharedData: ImDrawListSharedData,
     pub Time: f64,
-    pub FrameCount: cty::c_int,
-    pub FrameCountEnded: cty::c_int,
-    pub FrameCountPlatformEnded: cty::c_int,
-    pub FrameCountRendered: cty::c_int,
+    pub FrameCount: core::ffi::c_int,
+    pub FrameCountEnded: core::ffi::c_int,
+    pub FrameCountPlatformEnded: core::ffi::c_int,
+    pub FrameCountRendered: core::ffi::c_int,
     pub WithinFrameScope: bool,
     pub WithinFrameScopeWithImplicitWindow: bool,
     pub WithinEndChild: bool,
     pub GcCompactAll: bool,
     pub TestEngineHookItems: bool,
-    pub TestEngine: *mut cty::c_void,
-    pub ContextName: [cty::c_char; 16usize],
+    pub TestEngine: *mut core::ffi::c_void,
+    pub ContextName: [core::ffi::c_char; 16usize],
     pub InputEventsQueue: ImVector_ImGuiInputEvent,
     pub InputEventsTrail: ImVector_ImGuiInputEvent,
     pub InputEventsNextMouseSource: ImGuiMouseSource,
@@ -4588,7 +4598,7 @@ pub struct ImGuiContext {
     pub WindowsTempSortBuffer: ImVector_ImGuiWindowPtr,
     pub CurrentWindowStack: ImVector_ImGuiWindowStackData,
     pub WindowsById: ImGuiStorage,
-    pub WindowsActiveCount: cty::c_int,
+    pub WindowsActiveCount: core::ffi::c_int,
     pub WindowsHoverPadding: ImVec2,
     pub DebugBreakInWindow: ImGuiID,
     pub CurrentWindow: *mut ImGuiWindow,
@@ -4598,8 +4608,8 @@ pub struct ImGuiContext {
     pub MovingWindow: *mut ImGuiWindow,
     pub WheelingWindow: *mut ImGuiWindow,
     pub WheelingWindowRefMousePos: ImVec2,
-    pub WheelingWindowStartFrame: cty::c_int,
-    pub WheelingWindowScrolledFrame: cty::c_int,
+    pub WheelingWindowStartFrame: core::ffi::c_int,
+    pub WheelingWindowScrolledFrame: core::ffi::c_int,
     pub WheelingWindowReleaseTimer: f32,
     pub WheelingWindowWheelRemainder: ImVec2,
     pub WheelingAxisAvg: ImVec2,
@@ -4607,7 +4617,7 @@ pub struct ImGuiContext {
     pub DebugHookIdInfo: ImGuiID,
     pub HoveredId: ImGuiID,
     pub HoveredIdPreviousFrame: ImGuiID,
-    pub HoveredIdPreviousFrameItemCount: cty::c_int,
+    pub HoveredIdPreviousFrameItemCount: core::ffi::c_int,
     pub HoveredIdTimer: f32,
     pub HoveredIdNotActiveTimer: f32,
     pub HoveredIdAllowOverlap: bool,
@@ -4667,9 +4677,9 @@ pub struct ImGuiContext {
     pub PlatformLastFocusedViewportId: ImGuiID,
     pub FallbackMonitor: ImGuiPlatformMonitor,
     pub PlatformMonitorsFullWorkRect: ImRect,
-    pub ViewportCreatedCount: cty::c_int,
-    pub PlatformWindowsCreatedCount: cty::c_int,
-    pub ViewportFocusedStampCount: cty::c_int,
+    pub ViewportCreatedCount: core::ffi::c_int,
+    pub PlatformWindowsCreatedCount: core::ffi::c_int,
+    pub ViewportFocusedStampCount: core::ffi::c_int,
     pub NavWindow: *mut ImGuiWindow,
     pub NavId: ImGuiID,
     pub NavFocusScopeId: ImGuiID,
@@ -4704,9 +4714,9 @@ pub struct ImGuiContext {
     pub NavMoveClipDir: ImGuiDir,
     pub NavScoringRect: ImRect,
     pub NavScoringNoClipRect: ImRect,
-    pub NavScoringDebugCount: cty::c_int,
-    pub NavTabbingDir: cty::c_int,
-    pub NavTabbingCounter: cty::c_int,
+    pub NavScoringDebugCount: core::ffi::c_int,
+    pub NavTabbingDir: core::ffi::c_int,
+    pub NavTabbingCounter: core::ffi::c_int,
     pub NavMoveResultLocal: ImGuiNavItemData,
     pub NavMoveResultLocalVisible: ImGuiNavItemData,
     pub NavMoveResultOther: ImGuiNavItemData,
@@ -4733,8 +4743,8 @@ pub struct ImGuiContext {
     pub DragDropWithinSource: bool,
     pub DragDropWithinTarget: bool,
     pub DragDropSourceFlags: ImGuiDragDropFlags,
-    pub DragDropSourceFrameCount: cty::c_int,
-    pub DragDropMouseButton: cty::c_int,
+    pub DragDropSourceFrameCount: core::ffi::c_int,
+    pub DragDropMouseButton: core::ffi::c_int,
     pub DragDropPayload: ImGuiPayload,
     pub DragDropTargetRect: ImRect,
     pub DragDropTargetClipRect: ImRect,
@@ -4743,15 +4753,15 @@ pub struct ImGuiContext {
     pub DragDropAcceptIdCurrRectSurface: f32,
     pub DragDropAcceptIdCurr: ImGuiID,
     pub DragDropAcceptIdPrev: ImGuiID,
-    pub DragDropAcceptFrameCount: cty::c_int,
+    pub DragDropAcceptFrameCount: core::ffi::c_int,
     pub DragDropHoldJustPressedId: ImGuiID,
     pub DragDropPayloadBufHeap: ImVector_unsigned_char,
-    pub DragDropPayloadBufLocal: [cty::c_uchar; 16usize],
-    pub ClipperTempDataStacked: cty::c_int,
+    pub DragDropPayloadBufLocal: [core::ffi::c_uchar; 16usize],
+    pub ClipperTempDataStacked: core::ffi::c_int,
     pub ClipperTempData: ImVector_ImGuiListClipperData,
     pub CurrentTable: *mut ImGuiTable,
     pub DebugBreakInTable: ImGuiID,
-    pub TablesTempDataStacked: cty::c_int,
+    pub TablesTempDataStacked: core::ffi::c_int,
     pub TablesTempData: ImVector_ImGuiTableTempData,
     pub Tables: ImPool_ImGuiTable,
     pub TablesLastTimeActive: ImVector_float,
@@ -4762,7 +4772,7 @@ pub struct ImGuiContext {
     pub ShrinkWidthBuffer: ImVector_ImGuiShrinkWidthItem,
     pub BoxSelectState: ImGuiBoxSelectState,
     pub CurrentMultiSelect: *mut ImGuiMultiSelectTempData,
-    pub MultiSelectTempDataStacked: cty::c_int,
+    pub MultiSelectTempDataStacked: core::ffi::c_int,
     pub MultiSelectTempData: ImVector_ImGuiMultiSelectTempData,
     pub MultiSelectStorage: ImPool_ImGuiMultiSelectState,
     pub HoverItemDelayId: ImGuiID,
@@ -4779,8 +4789,8 @@ pub struct ImGuiContext {
     pub InputTextPasswordFont: ImFont,
     pub TempInputId: ImGuiID,
     pub DataTypeZeroValue: ImGuiDataTypeStorage,
-    pub BeginMenuDepth: cty::c_int,
-    pub BeginComboDepth: cty::c_int,
+    pub BeginMenuDepth: core::ffi::c_int,
+    pub BeginComboDepth: core::ffi::c_int,
     pub ColorEditOptions: ImGuiColorEditFlags,
     pub ColorEditCurrentID: ImGuiID,
     pub ColorEditSavedID: ImGuiID,
@@ -4791,7 +4801,7 @@ pub struct ImGuiContext {
     pub ComboPreviewData: ImGuiComboPreviewData,
     pub WindowResizeBorderExpectedRect: ImRect,
     pub WindowResizeRelativeMode: bool,
-    pub ScrollbarSeekMode: cty::c_short,
+    pub ScrollbarSeekMode: core::ffi::c_short,
     pub ScrollbarClickDeltaToGrabCenter: f32,
     pub SliderGrabClickOffset: f32,
     pub SliderCurrentAccum: f32,
@@ -4800,9 +4810,9 @@ pub struct ImGuiContext {
     pub DragCurrentAccum: f32,
     pub DragSpeedDefaultRatio: f32,
     pub DisabledAlphaBackup: f32,
-    pub DisabledStackSize: cty::c_short,
-    pub LockMarkEdited: cty::c_short,
-    pub TooltipOverrideCount: cty::c_short,
+    pub DisabledStackSize: core::ffi::c_short,
+    pub LockMarkEdited: core::ffi::c_short,
+    pub TooltipOverrideCount: core::ffi::c_short,
     pub TooltipPreviousWindow: *mut ImGuiWindow,
     pub ClipboardHandlerData: ImVector_char,
     pub MenusIdSubmittedThisFrame: ImVector_ImGuiID,
@@ -4826,30 +4836,30 @@ pub struct ImGuiContext {
     pub SettingsTables: ImChunkStream_ImGuiTableSettings,
     pub Hooks: ImVector_ImGuiContextHook,
     pub HookIdNext: ImGuiID,
-    pub LocalizationTable: [*const cty::c_char; 13usize],
+    pub LocalizationTable: [*const core::ffi::c_char; 13usize],
     pub LogEnabled: bool,
     pub LogType: ImGuiLogType,
     pub LogFile: ImFileHandle,
     pub LogBuffer: ImGuiTextBuffer,
-    pub LogNextPrefix: *const cty::c_char,
-    pub LogNextSuffix: *const cty::c_char,
+    pub LogNextPrefix: *const core::ffi::c_char,
+    pub LogNextSuffix: *const core::ffi::c_char,
     pub LogLinePosY: f32,
     pub LogLineFirstItem: bool,
-    pub LogDepthRef: cty::c_int,
-    pub LogDepthToExpand: cty::c_int,
-    pub LogDepthToExpandDefault: cty::c_int,
+    pub LogDepthRef: core::ffi::c_int,
+    pub LogDepthToExpand: core::ffi::c_int,
+    pub LogDepthToExpandDefault: core::ffi::c_int,
     pub ErrorCallback: ImGuiErrorCallback,
-    pub ErrorCallbackUserData: *mut cty::c_void,
+    pub ErrorCallbackUserData: *mut core::ffi::c_void,
     pub ErrorTooltipLockedPos: ImVec2,
     pub ErrorFirst: bool,
-    pub ErrorCountCurrentFrame: cty::c_int,
+    pub ErrorCountCurrentFrame: core::ffi::c_int,
     pub StackSizesInNewFrame: ImGuiErrorRecoveryState,
     pub StackSizesInBeginForCurrentWindow: *mut ImGuiErrorRecoveryState,
-    pub DebugDrawIdConflictsCount: cty::c_int,
+    pub DebugDrawIdConflictsCount: core::ffi::c_int,
     pub DebugLogFlags: ImGuiDebugLogFlags,
     pub DebugLogBuf: ImGuiTextBuffer,
     pub DebugLogIndex: ImGuiTextIndex,
-    pub DebugLogSkippedErrors: cty::c_int,
+    pub DebugLogSkippedErrors: core::ffi::c_int,
     pub DebugLogAutoDisableFlags: ImGuiDebugLogFlags,
     pub DebugLogAutoDisableFrames: ImU8,
     pub DebugLocateFrames: ImU8,
@@ -4866,14 +4876,14 @@ pub struct ImGuiContext {
     pub DebugAllocInfo: ImGuiDebugAllocInfo,
     pub DebugHoveredDockNode: *mut ImGuiDockNode,
     pub FramerateSecPerFrame: [f32; 60usize],
-    pub FramerateSecPerFrameIdx: cty::c_int,
-    pub FramerateSecPerFrameCount: cty::c_int,
+    pub FramerateSecPerFrameIdx: core::ffi::c_int,
+    pub FramerateSecPerFrameCount: core::ffi::c_int,
     pub FramerateSecPerFrameAccum: f32,
-    pub WantCaptureMouseNextFrame: cty::c_int,
-    pub WantCaptureKeyboardNextFrame: cty::c_int,
-    pub WantTextInputNextFrame: cty::c_int,
+    pub WantCaptureMouseNextFrame: core::ffi::c_int,
+    pub WantCaptureKeyboardNextFrame: core::ffi::c_int,
+    pub WantTextInputNextFrame: core::ffi::c_int,
     pub TempBuffer: ImVector_char,
-    pub TempKeychordName: [cty::c_char; 64usize],
+    pub TempKeychordName: [core::ffi::c_char; 64usize],
 }
 impl Default for ImGuiContext {
     fn default() -> Self {
@@ -4886,18 +4896,20 @@ impl Default for ImGuiContext {
 }
 impl ImGuiContext {
     #[inline]
-    pub fn ActiveIdMouseButton(&self) -> cty::c_int {
+    pub fn ActiveIdMouseButton(&self) -> core::ffi::c_int {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
     }
     #[inline]
-    pub fn set_ActiveIdMouseButton(&mut self, val: cty::c_int) {
+    pub fn set_ActiveIdMouseButton(&mut self, val: core::ffi::c_int) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 8u8, val as u64)
         }
     }
     #[inline]
-    pub fn new_bitfield_1(ActiveIdMouseButton: cty::c_int) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+    pub fn new_bitfield_1(
+        ActiveIdMouseButton: core::ffi::c_int,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 8u8, {
             let ActiveIdMouseButton: u32 = unsafe { ::core::mem::transmute(ActiveIdMouseButton) };
@@ -4925,20 +4937,20 @@ pub struct ImGuiWindowTempData {
     pub GroupOffset: ImVec1,
     pub CursorStartPosLossyness: ImVec2,
     pub NavLayerCurrent: ImGuiNavLayer,
-    pub NavLayersActiveMask: cty::c_short,
-    pub NavLayersActiveMaskNext: cty::c_short,
+    pub NavLayersActiveMask: core::ffi::c_short,
+    pub NavLayersActiveMaskNext: core::ffi::c_short,
     pub NavIsScrollPushableX: bool,
     pub NavHideHighlightOneFrame: bool,
     pub NavWindowHasScrollY: bool,
     pub MenuBarAppending: bool,
     pub MenuBarOffset: ImVec2,
     pub MenuColumns: ImGuiMenuColumns,
-    pub TreeDepth: cty::c_int,
+    pub TreeDepth: core::ffi::c_int,
     pub TreeHasStackDataDepthMask: ImU32,
     pub ChildWindows: ImVector_ImGuiWindowPtr,
     pub StateStorage: *mut ImGuiStorage,
     pub CurrentColumns: *mut ImGuiOldColumns,
-    pub CurrentTableIdx: cty::c_int,
+    pub CurrentTableIdx: core::ffi::c_int,
     pub LayoutType: ImGuiLayoutType,
     pub ParentLayoutType: ImGuiLayoutType,
     pub ModalDimBgColor: ImU32,
@@ -4959,8 +4971,8 @@ impl Default for ImGuiWindowTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiOldColumns {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiOldColumns,
 }
 impl Default for ImVector_ImGuiOldColumns {
@@ -4976,7 +4988,7 @@ impl Default for ImVector_ImGuiOldColumns {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiWindow {
     pub Ctx: *mut ImGuiContext,
-    pub Name: *mut cty::c_char,
+    pub Name: *mut core::ffi::c_char,
     pub ID: ImGuiID,
     pub Flags: ImGuiWindowFlags,
     pub FlagsPreviousFrame: ImGuiWindowFlags,
@@ -4985,7 +4997,7 @@ pub struct ImGuiWindow {
     pub Viewport: *mut ImGuiViewportP,
     pub ViewportId: ImGuiID,
     pub ViewportPos: ImVec2,
-    pub ViewportAllowPlatformMonitorExtend: cty::c_int,
+    pub ViewportAllowPlatformMonitorExtend: core::ffi::c_int,
     pub Pos: ImVec2,
     pub Size: ImVec2,
     pub SizeFull: ImVec2,
@@ -5003,7 +5015,7 @@ pub struct ImGuiWindow {
     pub DecoOuterSizeY2: f32,
     pub DecoInnerSizeX1: f32,
     pub DecoInnerSizeY1: f32,
-    pub NameBufLen: cty::c_int,
+    pub NameBufLen: core::ffi::c_int,
     pub MoveId: ImGuiID,
     pub TabId: ImGuiID,
     pub ChildId: ImGuiID,
@@ -5029,13 +5041,13 @@ pub struct ImGuiWindow {
     pub IsFallbackWindow: bool,
     pub IsExplicitChild: bool,
     pub HasCloseButton: bool,
-    pub ResizeBorderHovered: cty::c_schar,
-    pub ResizeBorderHeld: cty::c_schar,
-    pub BeginCount: cty::c_short,
-    pub BeginCountPreviousFrame: cty::c_short,
-    pub BeginOrderWithinParent: cty::c_short,
-    pub BeginOrderWithinContext: cty::c_short,
-    pub FocusOrder: cty::c_short,
+    pub ResizeBorderHovered: core::ffi::c_schar,
+    pub ResizeBorderHeld: core::ffi::c_schar,
+    pub BeginCount: core::ffi::c_short,
+    pub BeginCountPreviousFrame: core::ffi::c_short,
+    pub BeginOrderWithinParent: core::ffi::c_short,
+    pub BeginOrderWithinContext: core::ffi::c_short,
+    pub FocusOrder: core::ffi::c_short,
     pub AutoFitFramesX: ImS8,
     pub AutoFitFramesY: ImS8,
     pub AutoFitOnlyGrows: bool,
@@ -5059,15 +5071,15 @@ pub struct ImGuiWindow {
     pub ContentRegionRect: ImRect,
     pub HitTestHoleSize: ImVec2ih,
     pub HitTestHoleOffset: ImVec2ih,
-    pub LastFrameActive: cty::c_int,
-    pub LastFrameJustFocused: cty::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFrameJustFocused: core::ffi::c_int,
     pub LastTimeActive: f32,
     pub ItemWidthDefault: f32,
     pub StateStorage: ImGuiStorage,
     pub ColumnsStorage: ImVector_ImGuiOldColumns,
     pub FontWindowScale: f32,
     pub FontDpiScale: f32,
-    pub SettingsOffset: cty::c_int,
+    pub SettingsOffset: core::ffi::c_int,
     pub DrawList: *mut ImDrawList,
     pub DrawListInst: ImDrawList,
     pub ParentWindow: *mut ImGuiWindow,
@@ -5083,12 +5095,12 @@ pub struct ImGuiWindow {
     pub NavRectRel: [ImRect; 2usize],
     pub NavPreferredScoringPosRel: [ImVec2; 2usize],
     pub NavRootFocusScopeId: ImGuiID,
-    pub MemoryDrawListIdxCapacity: cty::c_int,
-    pub MemoryDrawListVtxCapacity: cty::c_int,
+    pub MemoryDrawListIdxCapacity: core::ffi::c_int,
+    pub MemoryDrawListVtxCapacity: core::ffi::c_int,
     pub MemoryCompacted: bool,
     pub _bitfield_align_2: [u8; 0],
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub DockOrder: cty::c_short,
+    pub DockOrder: core::ffi::c_short,
     pub DockStyle: ImGuiWindowDockStyle,
     pub DockNode: *mut ImGuiDockNode,
     pub DockNodeAsHost: *mut ImGuiDockNode,
@@ -5254,20 +5266,20 @@ impl ImGuiWindow {
 pub const ImGuiTabBarFlags_DockNode: ImGuiTabBarFlagsPrivate_ = 1048576;
 pub const ImGuiTabBarFlags_IsFocused: ImGuiTabBarFlagsPrivate_ = 2097152;
 pub const ImGuiTabBarFlags_SaveSettings: ImGuiTabBarFlagsPrivate_ = 4194304;
-pub type ImGuiTabBarFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTabBarFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_SectionMask_: ImGuiTabItemFlagsPrivate_ = 192;
 pub const ImGuiTabItemFlags_NoCloseButton: ImGuiTabItemFlagsPrivate_ = 1048576;
 pub const ImGuiTabItemFlags_Button: ImGuiTabItemFlagsPrivate_ = 2097152;
 pub const ImGuiTabItemFlags_Unsorted: ImGuiTabItemFlagsPrivate_ = 4194304;
-pub type ImGuiTabItemFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTabItemFlagsPrivate_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTabItem {
     pub ID: ImGuiID,
     pub Flags: ImGuiTabItemFlags,
     pub Window: *mut ImGuiWindow,
-    pub LastFrameVisible: cty::c_int,
-    pub LastFrameSelected: cty::c_int,
+    pub LastFrameVisible: core::ffi::c_int,
+    pub LastFrameSelected: core::ffi::c_int,
     pub Offset: f32,
     pub Width: f32,
     pub ContentWidth: f32,
@@ -5289,8 +5301,8 @@ impl Default for ImGuiTabItem {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTabItem {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTabItem,
 }
 impl Default for ImVector_ImGuiTabItem {
@@ -5312,8 +5324,8 @@ pub struct ImGuiTabBar {
     pub SelectedTabId: ImGuiID,
     pub NextSelectedTabId: ImGuiID,
     pub VisibleTabId: ImGuiID,
-    pub CurrFrameVisible: cty::c_int,
-    pub PrevFrameVisible: cty::c_int,
+    pub CurrFrameVisible: core::ffi::c_int,
+    pub PrevFrameVisible: core::ffi::c_int,
     pub BarRect: ImRect,
     pub CurrTabsContentsHeight: f32,
     pub PrevTabsContentsHeight: f32,
@@ -5475,8 +5487,8 @@ pub struct ImGuiTableInstanceData {
     pub LastOuterHeight: f32,
     pub LastTopHeadersRowHeight: f32,
     pub LastFrozenHeight: f32,
-    pub HoveredRowLast: cty::c_int,
-    pub HoveredRowNext: cty::c_int,
+    pub HoveredRowLast: core::ffi::c_int,
+    pub HoveredRowNext: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -5526,8 +5538,8 @@ impl Default for ImSpan_ImGuiTableCellData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableInstanceData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableInstanceData,
 }
 impl Default for ImVector_ImGuiTableInstanceData {
@@ -5542,8 +5554,8 @@ impl Default for ImVector_ImGuiTableInstanceData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableColumnSortSpecs {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableColumnSortSpecs,
 }
 impl Default for ImVector_ImGuiTableColumnSortSpecs {
@@ -5560,7 +5572,7 @@ impl Default for ImVector_ImGuiTableColumnSortSpecs {
 pub struct ImGuiTable {
     pub ID: ImGuiID,
     pub Flags: ImGuiTableFlags,
-    pub RawData: *mut cty::c_void,
+    pub RawData: *mut core::ffi::c_void,
     pub TempData: *mut ImGuiTableTempData,
     pub Columns: ImSpan_ImGuiTableColumn,
     pub DisplayOrderToIndex: ImSpan_ImGuiTableColumnIdx,
@@ -5569,11 +5581,11 @@ pub struct ImGuiTable {
     pub EnabledMaskByIndex: ImBitArrayPtr,
     pub VisibleMaskByIndex: ImBitArrayPtr,
     pub SettingsLoadedFlags: ImGuiTableFlags,
-    pub SettingsOffset: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub ColumnsCount: cty::c_int,
-    pub CurrentRow: cty::c_int,
-    pub CurrentColumn: cty::c_int,
+    pub SettingsOffset: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub ColumnsCount: core::ffi::c_int,
+    pub CurrentRow: core::ffi::c_int,
+    pub CurrentColumn: core::ffi::c_int,
     pub InstanceCurrent: ImS16,
     pub InstanceInteracted: ImS16,
     pub RowPosY1: f32,
@@ -5584,7 +5596,7 @@ pub struct ImGuiTable {
     pub RowIndentOffsetX: f32,
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub RowBgColorCounter: cty::c_int,
+    pub RowBgColorCounter: core::ffi::c_int,
     pub RowBgColor: [ImU32; 2usize],
     pub BorderColorStrong: ImU32,
     pub BorderColorLight: ImU32,
@@ -5723,8 +5735,8 @@ impl ImGuiTable {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableHeaderData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableHeaderData,
 }
 impl Default for ImVector_ImGuiTableHeaderData {
@@ -5739,7 +5751,7 @@ impl Default for ImVector_ImGuiTableHeaderData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTableTempData {
-    pub TableIndex: cty::c_int,
+    pub TableIndex: core::ffi::c_int,
     pub LastTimeActive: f32,
     pub AngledHeadersExtraWidth: f32,
     pub AngledHeadersRequests: ImVector_ImGuiTableHeaderData,
@@ -5752,7 +5764,7 @@ pub struct ImGuiTableTempData {
     pub HostBackupCursorMaxPos: ImVec2,
     pub HostBackupColumnsOffset: ImVec1,
     pub HostBackupItemWidth: f32,
-    pub HostBackupItemWidthStackSize: cty::c_int,
+    pub HostBackupItemWidthStackSize: core::ffi::c_int,
 }
 impl Default for ImGuiTableTempData {
     fn default() -> Self {
@@ -5857,7 +5869,7 @@ pub const ImGuiFreeTypeBuilderFlags_Oblique: ImGuiFreeTypeBuilderFlags = 64;
 pub const ImGuiFreeTypeBuilderFlags_Monochrome: ImGuiFreeTypeBuilderFlags = 128;
 pub const ImGuiFreeTypeBuilderFlags_LoadColor: ImGuiFreeTypeBuilderFlags = 256;
 pub const ImGuiFreeTypeBuilderFlags_Bitmap: ImGuiFreeTypeBuilderFlags = 512;
-pub type ImGuiFreeTypeBuilderFlags = cty::c_uint;
+pub type ImGuiFreeTypeBuilderFlags = core::ffi::c_uint;
 extern "C" {
     pub fn ImVec2_ImVec2_Nil() -> *mut ImVec2;
 }
@@ -5928,16 +5940,16 @@ extern "C" {
     pub fn igShowStyleEditor(ref_: *mut ImGuiStyle);
 }
 extern "C" {
-    pub fn igShowStyleSelector(label: *const cty::c_char) -> bool;
+    pub fn igShowStyleSelector(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igShowFontSelector(label: *const cty::c_char);
+    pub fn igShowFontSelector(label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igShowUserGuide();
 }
 extern "C" {
-    pub fn igGetVersion() -> *const cty::c_char;
+    pub fn igGetVersion() -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igStyleColorsDark(dst: *mut ImGuiStyle);
@@ -5949,14 +5961,18 @@ extern "C" {
     pub fn igStyleColorsClassic(dst: *mut ImGuiStyle);
 }
 extern "C" {
-    pub fn igBegin(name: *const cty::c_char, p_open: *mut bool, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBegin(
+        name: *const core::ffi::c_char,
+        p_open: *mut bool,
+        flags: ImGuiWindowFlags,
+    ) -> bool;
 }
 extern "C" {
     pub fn igEnd();
 }
 extern "C" {
     pub fn igBeginChild_Str(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         child_flags: ImGuiChildFlags,
         window_flags: ImGuiWindowFlags,
@@ -6017,7 +6033,7 @@ extern "C" {
         size_min: ImVec2,
         size_max: ImVec2,
         custom_callback: ImGuiSizeCallback,
-        custom_callback_data: *mut cty::c_void,
+        custom_callback_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -6054,16 +6070,20 @@ extern "C" {
     pub fn igSetWindowFontScale(scale: f32);
 }
 extern "C" {
-    pub fn igSetWindowPos_Str(name: *const cty::c_char, pos: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowPos_Str(name: *const core::ffi::c_char, pos: ImVec2, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igSetWindowSize_Str(name: *const cty::c_char, size: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowSize_Str(name: *const core::ffi::c_char, size: ImVec2, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igSetWindowCollapsed_Str(name: *const cty::c_char, collapsed: bool, cond: ImGuiCond);
+    pub fn igSetWindowCollapsed_Str(
+        name: *const core::ffi::c_char,
+        collapsed: bool,
+        cond: ImGuiCond,
+    );
 }
 extern "C" {
-    pub fn igSetWindowFocus_Str(name: *const cty::c_char);
+    pub fn igSetWindowFocus_Str(name: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igGetScrollX() -> f32;
@@ -6108,7 +6128,7 @@ extern "C" {
     pub fn igPushStyleColor_Vec4(idx: ImGuiCol, col: ImVec4);
 }
 extern "C" {
-    pub fn igPopStyleColor(count: cty::c_int);
+    pub fn igPopStyleColor(count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushStyleVar_Float(idx: ImGuiStyleVar, val: f32);
@@ -6123,7 +6143,7 @@ extern "C" {
     pub fn igPushStyleVarY(idx: ImGuiStyleVar, val_y: f32);
 }
 extern "C" {
-    pub fn igPopStyleVar(count: cty::c_int);
+    pub fn igPopStyleVar(count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushItemFlag(option: ImGuiItemFlags, enabled: bool);
@@ -6243,113 +6263,116 @@ extern "C" {
     pub fn igGetFrameHeightWithSpacing() -> f32;
 }
 extern "C" {
-    pub fn igPushID_Str(str_id: *const cty::c_char);
+    pub fn igPushID_Str(str_id: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igPushID_StrStr(str_id_begin: *const cty::c_char, str_id_end: *const cty::c_char);
+    pub fn igPushID_StrStr(
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
+    );
 }
 extern "C" {
-    pub fn igPushID_Ptr(ptr_id: *const cty::c_void);
+    pub fn igPushID_Ptr(ptr_id: *const core::ffi::c_void);
 }
 extern "C" {
-    pub fn igPushID_Int(int_id: cty::c_int);
+    pub fn igPushID_Int(int_id: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPopID();
 }
 extern "C" {
-    pub fn igGetID_Str(str_id: *const cty::c_char) -> ImGuiID;
+    pub fn igGetID_Str(str_id: *const core::ffi::c_char) -> ImGuiID;
 }
 extern "C" {
     pub fn igGetID_StrStr(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetID_Ptr(ptr_id: *const cty::c_void) -> ImGuiID;
+    pub fn igGetID_Ptr(ptr_id: *const core::ffi::c_void) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetID_Int(int_id: cty::c_int) -> ImGuiID;
+    pub fn igGetID_Int(int_id: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
-    pub fn igTextUnformatted(text: *const cty::c_char, text_end: *const cty::c_char);
+    pub fn igTextUnformatted(text: *const core::ffi::c_char, text_end: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igText(fmt: *const cty::c_char, ...);
+    pub fn igText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextColored(col: ImVec4, fmt: *const cty::c_char, ...);
+    pub fn igTextColored(col: ImVec4, fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextDisabled(fmt: *const cty::c_char, ...);
+    pub fn igTextDisabled(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextWrapped(fmt: *const cty::c_char, ...);
+    pub fn igTextWrapped(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igLabelText(label: *const cty::c_char, fmt: *const cty::c_char, ...);
+    pub fn igLabelText(label: *const core::ffi::c_char, fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igBulletText(fmt: *const cty::c_char, ...);
+    pub fn igBulletText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igSeparatorText(label: *const cty::c_char);
+    pub fn igSeparatorText(label: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igButton(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igButton(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 extern "C" {
-    pub fn igSmallButton(label: *const cty::c_char) -> bool;
+    pub fn igSmallButton(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
     pub fn igInvisibleButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         flags: ImGuiButtonFlags,
     ) -> bool;
 }
 extern "C" {
-    pub fn igArrowButton(str_id: *const cty::c_char, dir: ImGuiDir) -> bool;
+    pub fn igArrowButton(str_id: *const core::ffi::c_char, dir: ImGuiDir) -> bool;
 }
 extern "C" {
-    pub fn igCheckbox(label: *const cty::c_char, v: *mut bool) -> bool;
+    pub fn igCheckbox(label: *const core::ffi::c_char, v: *mut bool) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_IntPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_int,
-        flags_value: cty::c_int,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_int,
+        flags_value: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_UintPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_uint,
-        flags_value: cty::c_uint,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_uint,
+        flags_value: core::ffi::c_uint,
     ) -> bool;
 }
 extern "C" {
-    pub fn igRadioButton_Bool(label: *const cty::c_char, active: bool) -> bool;
+    pub fn igRadioButton_Bool(label: *const core::ffi::c_char, active: bool) -> bool;
 }
 extern "C" {
     pub fn igRadioButton_IntPtr(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_button: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_button: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
-    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const cty::c_char);
+    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igBullet();
 }
 extern "C" {
-    pub fn igTextLink(label: *const cty::c_char) -> bool;
+    pub fn igTextLink(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igTextLinkOpenURL(label: *const cty::c_char, url: *const cty::c_char);
+    pub fn igTextLinkOpenURL(label: *const core::ffi::c_char, url: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igImage(
@@ -6363,7 +6386,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igImageButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         user_texture_id: ImTextureID,
         image_size: ImVec2,
         uv0: ImVec2,
@@ -6374,8 +6397,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginCombo(
-        label: *const cty::c_char,
-        preview_value: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        preview_value: *const core::ffi::c_char,
         flags: ImGuiComboFlags,
     ) -> bool;
 }
@@ -6384,475 +6407,475 @@ extern "C" {
 }
 extern "C" {
     pub fn igCombo_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCombo_Str(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items_separated_by_zeros: *const cty::c_char,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items_separated_by_zeros: *const core::ffi::c_char,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCombo_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloatRange2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_current_min: *mut f32,
         v_current_max: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragIntRange2(
-        label: *const cty::c_char,
-        v_current_min: *mut cty::c_int,
-        v_current_max: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v_current_min: *mut core::ffi::c_int,
+        v_current_max: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderAngle(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_rad: *mut f32,
         v_degrees_min: f32,
         v_degrees_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderInt(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputText(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputTextMultiline(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         size: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputTextWithHint(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         step: f32,
         step_fast: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        step: cty::c_int,
-        step_fast: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        step: core::ffi::c_int,
+        step_fast: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputDouble(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f64,
         step: f64,
         step_fast: f64,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorEdit3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorEdit4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorPicker3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorPicker4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
         ref_col: *const f32,
@@ -6860,7 +6883,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igColorButton(
-        desc_id: *const cty::c_char,
+        desc_id: *const core::ffi::c_char,
         col: ImVec4,
         flags: ImGuiColorEditFlags,
         size: ImVec2,
@@ -6870,38 +6893,46 @@ extern "C" {
     pub fn igSetColorEditOptions(flags: ImGuiColorEditFlags);
 }
 extern "C" {
-    pub fn igTreeNode_Str(label: *const cty::c_char) -> bool;
+    pub fn igTreeNode_Str(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igTreeNode_StrStr(str_id: *const cty::c_char, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_StrStr(
+        str_id: *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 extern "C" {
-    pub fn igTreeNode_Ptr(ptr_id: *const cty::c_void, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_Ptr(
+        ptr_id: *const core::ffi::c_void,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 extern "C" {
-    pub fn igTreeNodeEx_Str(label: *const cty::c_char, flags: ImGuiTreeNodeFlags) -> bool;
+    pub fn igTreeNodeEx_Str(label: *const core::ffi::c_char, flags: ImGuiTreeNodeFlags) -> bool;
 }
 extern "C" {
     pub fn igTreeNodeEx_StrStr(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 extern "C" {
     pub fn igTreeNodeEx_Ptr(
-        ptr_id: *const cty::c_void,
+        ptr_id: *const core::ffi::c_void,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 extern "C" {
-    pub fn igTreePush_Str(str_id: *const cty::c_char);
+    pub fn igTreePush_Str(str_id: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igTreePush_Ptr(ptr_id: *const cty::c_void);
+    pub fn igTreePush_Ptr(ptr_id: *const core::ffi::c_void);
 }
 extern "C" {
     pub fn igTreePop();
@@ -6911,13 +6942,13 @@ extern "C" {
 }
 extern "C" {
     pub fn igCollapsingHeader_TreeNodeFlags(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igCollapsingHeader_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_visible: *mut bool,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
@@ -6930,7 +6961,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igSelectable_Bool(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         selected: bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -6938,7 +6969,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igSelectable_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_selected: *mut bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -6947,8 +6978,8 @@ extern "C" {
 extern "C" {
     pub fn igBeginMultiSelect(
         flags: ImGuiMultiSelectFlags,
-        selection_size: cty::c_int,
-        items_count: cty::c_int,
+        selection_size: core::ffi::c_int,
+        items_count: core::ffi::c_int,
     ) -> *mut ImGuiMultiSelectIO;
 }
 extern "C" {
@@ -6961,58 +6992,58 @@ extern "C" {
     pub fn igIsItemToggledSelection() -> bool;
 }
 extern "C" {
-    pub fn igBeginListBox(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igBeginListBox(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 extern "C" {
     pub fn igEndListBox();
 }
 extern "C" {
     pub fn igListBox_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igListBox_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igPlotLines_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn igPlotLines_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -7020,43 +7051,47 @@ extern "C" {
 }
 extern "C" {
     pub fn igPlotHistogram_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn igPlotHistogram_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
     );
 }
 extern "C" {
-    pub fn igValue_Bool(prefix: *const cty::c_char, b: bool);
+    pub fn igValue_Bool(prefix: *const core::ffi::c_char, b: bool);
 }
 extern "C" {
-    pub fn igValue_Int(prefix: *const cty::c_char, v: cty::c_int);
+    pub fn igValue_Int(prefix: *const core::ffi::c_char, v: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igValue_Uint(prefix: *const cty::c_char, v: cty::c_uint);
+    pub fn igValue_Uint(prefix: *const core::ffi::c_char, v: core::ffi::c_uint);
 }
 extern "C" {
-    pub fn igValue_Float(prefix: *const cty::c_char, v: f32, float_format: *const cty::c_char);
+    pub fn igValue_Float(
+        prefix: *const core::ffi::c_char,
+        v: f32,
+        float_format: *const core::ffi::c_char,
+    );
 }
 extern "C" {
     pub fn igBeginMenuBar() -> bool;
@@ -7071,23 +7106,23 @@ extern "C" {
     pub fn igEndMainMenuBar();
 }
 extern "C" {
-    pub fn igBeginMenu(label: *const cty::c_char, enabled: bool) -> bool;
+    pub fn igBeginMenu(label: *const core::ffi::c_char, enabled: bool) -> bool;
 }
 extern "C" {
     pub fn igEndMenu();
 }
 extern "C" {
     pub fn igMenuItem_Bool(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
 }
 extern "C" {
     pub fn igMenuItem_BoolPtr(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         p_selected: *mut bool,
         enabled: bool,
     ) -> bool;
@@ -7099,20 +7134,20 @@ extern "C" {
     pub fn igEndTooltip();
 }
 extern "C" {
-    pub fn igSetTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetTooltip(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
     pub fn igBeginItemTooltip() -> bool;
 }
 extern "C" {
-    pub fn igSetItemTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetItemTooltip(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igBeginPopup(str_id: *const cty::c_char, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBeginPopup(str_id: *const core::ffi::c_char, flags: ImGuiWindowFlags) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupModal(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiWindowFlags,
     ) -> bool;
@@ -7121,42 +7156,42 @@ extern "C" {
     pub fn igEndPopup();
 }
 extern "C" {
-    pub fn igOpenPopup_Str(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopup_Str(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
     pub fn igOpenPopup_ID(id: ImGuiID, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
-    pub fn igOpenPopupOnItemClick(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopupOnItemClick(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
     pub fn igCloseCurrentPopup();
 }
 extern "C" {
     pub fn igBeginPopupContextItem(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupContextWindow(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupContextVoid(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
-    pub fn igIsPopupOpen_Str(str_id: *const cty::c_char, flags: ImGuiPopupFlags) -> bool;
+    pub fn igIsPopupOpen_Str(str_id: *const core::ffi::c_char, flags: ImGuiPopupFlags) -> bool;
 }
 extern "C" {
     pub fn igBeginTable(
-        str_id: *const cty::c_char,
-        columns: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        columns: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -7172,21 +7207,21 @@ extern "C" {
     pub fn igTableNextColumn() -> bool;
 }
 extern "C" {
-    pub fn igTableSetColumnIndex(column_n: cty::c_int) -> bool;
+    pub fn igTableSetColumnIndex(column_n: core::ffi::c_int) -> bool;
 }
 extern "C" {
     pub fn igTableSetupColumn(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTableColumnFlags,
         init_width_or_weight: f32,
         user_id: ImGuiID,
     );
 }
 extern "C" {
-    pub fn igTableSetupScrollFreeze(cols: cty::c_int, rows: cty::c_int);
+    pub fn igTableSetupScrollFreeze(cols: core::ffi::c_int, rows: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igTableHeader(label: *const cty::c_char);
+    pub fn igTableHeader(label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igTableHeadersRow();
@@ -7198,62 +7233,62 @@ extern "C" {
     pub fn igTableGetSortSpecs() -> *mut ImGuiTableSortSpecs;
 }
 extern "C" {
-    pub fn igTableGetColumnCount() -> cty::c_int;
+    pub fn igTableGetColumnCount() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetColumnIndex() -> cty::c_int;
+    pub fn igTableGetColumnIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetRowIndex() -> cty::c_int;
+    pub fn igTableGetRowIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetColumnName_Int(column_n: cty::c_int) -> *const cty::c_char;
+    pub fn igTableGetColumnName_Int(column_n: core::ffi::c_int) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igTableGetColumnFlags(column_n: cty::c_int) -> ImGuiTableColumnFlags;
+    pub fn igTableGetColumnFlags(column_n: core::ffi::c_int) -> ImGuiTableColumnFlags;
 }
 extern "C" {
-    pub fn igTableSetColumnEnabled(column_n: cty::c_int, v: bool);
+    pub fn igTableSetColumnEnabled(column_n: core::ffi::c_int, v: bool);
 }
 extern "C" {
-    pub fn igTableGetHoveredColumn() -> cty::c_int;
+    pub fn igTableGetHoveredColumn() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: cty::c_int);
+    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igColumns(count: cty::c_int, id: *const cty::c_char, borders: bool);
+    pub fn igColumns(count: core::ffi::c_int, id: *const core::ffi::c_char, borders: bool);
 }
 extern "C" {
     pub fn igNextColumn();
 }
 extern "C" {
-    pub fn igGetColumnIndex() -> cty::c_int;
+    pub fn igGetColumnIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igGetColumnWidth(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnWidth(column_index: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igSetColumnWidth(column_index: cty::c_int, width: f32);
+    pub fn igSetColumnWidth(column_index: core::ffi::c_int, width: f32);
 }
 extern "C" {
-    pub fn igGetColumnOffset(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnOffset(column_index: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igSetColumnOffset(column_index: cty::c_int, offset_x: f32);
+    pub fn igSetColumnOffset(column_index: core::ffi::c_int, offset_x: f32);
 }
 extern "C" {
-    pub fn igGetColumnsCount() -> cty::c_int;
+    pub fn igGetColumnsCount() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igBeginTabBar(str_id: *const cty::c_char, flags: ImGuiTabBarFlags) -> bool;
+    pub fn igBeginTabBar(str_id: *const core::ffi::c_char, flags: ImGuiTabBarFlags) -> bool;
 }
 extern "C" {
     pub fn igEndTabBar();
 }
 extern "C" {
     pub fn igBeginTabItem(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
     ) -> bool;
@@ -7262,10 +7297,10 @@ extern "C" {
     pub fn igEndTabItem();
 }
 extern "C" {
-    pub fn igTabItemButton(label: *const cty::c_char, flags: ImGuiTabItemFlags) -> bool;
+    pub fn igTabItemButton(label: *const core::ffi::c_char, flags: ImGuiTabItemFlags) -> bool;
 }
 extern "C" {
-    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const cty::c_char);
+    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDockSpace(
@@ -7296,13 +7331,13 @@ extern "C" {
     pub fn igIsWindowDocked() -> bool;
 }
 extern "C" {
-    pub fn igLogToTTY(auto_open_depth: cty::c_int);
+    pub fn igLogToTTY(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igLogToFile(auto_open_depth: cty::c_int, filename: *const cty::c_char);
+    pub fn igLogToFile(auto_open_depth: core::ffi::c_int, filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLogToClipboard(auto_open_depth: cty::c_int);
+    pub fn igLogToClipboard(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
     pub fn igLogFinish();
@@ -7315,8 +7350,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igSetDragDropPayload(
-        type_: *const cty::c_char,
-        data: *const cty::c_void,
+        type_: *const core::ffi::c_char,
+        data: *const core::ffi::c_void,
         sz: usize,
         cond: ImGuiCond,
     ) -> bool;
@@ -7329,7 +7364,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igAcceptDragDropPayload(
-        type_: *const cty::c_char,
+        type_: *const core::ffi::c_char,
         flags: ImGuiDragDropFlags,
     ) -> *const ImGuiPayload;
 }
@@ -7359,7 +7394,7 @@ extern "C" {
     pub fn igSetItemDefaultFocus();
 }
 extern "C" {
-    pub fn igSetKeyboardFocusHere(offset: cty::c_int);
+    pub fn igSetKeyboardFocusHere(offset: core::ffi::c_int);
 }
 extern "C" {
     pub fn igSetNextItemAllowOverlap();
@@ -7434,13 +7469,13 @@ extern "C" {
     pub fn igGetTime() -> f64;
 }
 extern "C" {
-    pub fn igGetFrameCount() -> cty::c_int;
+    pub fn igGetFrameCount() -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igGetDrawListSharedData() -> *mut ImDrawListSharedData;
 }
 extern "C" {
-    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const cty::c_char;
+    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetStateStorage(storage: *mut ImGuiStorage);
@@ -7451,8 +7486,8 @@ extern "C" {
 extern "C" {
     pub fn igCalcTextSize(
         pOut: *mut ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_double_hash: bool,
         wrap_width: f32,
     );
@@ -7496,10 +7531,10 @@ extern "C" {
     pub fn igIsKeyChordPressed_Nil(key_chord: ImGuiKeyChord) -> bool;
 }
 extern "C" {
-    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> cty::c_int;
+    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igGetKeyName(key: ImGuiKey) -> *const cty::c_char;
+    pub fn igGetKeyName(key: ImGuiKey) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetNextFrameWantCaptureKeyboard(want_capture_keyboard: bool);
@@ -7526,7 +7561,7 @@ extern "C" {
     pub fn igIsMouseDoubleClicked_Nil(button: ImGuiMouseButton) -> bool;
 }
 extern "C" {
-    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> cty::c_int;
+    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igIsMouseHoveringRect(r_min: ImVec2, r_max: ImVec2, clip: bool) -> bool;
@@ -7562,25 +7597,25 @@ extern "C" {
     pub fn igSetNextFrameWantCaptureMouse(want_capture_mouse: bool);
 }
 extern "C" {
-    pub fn igGetClipboardText() -> *const cty::c_char;
+    pub fn igGetClipboardText() -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igSetClipboardText(text: *const cty::c_char);
+    pub fn igSetClipboardText(text: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLoadIniSettingsFromDisk(ini_filename: *const cty::c_char);
+    pub fn igLoadIniSettingsFromDisk(ini_filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLoadIniSettingsFromMemory(ini_data: *const cty::c_char, ini_size: usize);
+    pub fn igLoadIniSettingsFromMemory(ini_data: *const core::ffi::c_char, ini_size: usize);
 }
 extern "C" {
-    pub fn igSaveIniSettingsToDisk(ini_filename: *const cty::c_char);
+    pub fn igSaveIniSettingsToDisk(ini_filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const cty::c_char;
+    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igDebugTextEncoding(text: *const cty::c_char);
+    pub fn igDebugTextEncoding(text: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugFlashStyleColor(idx: ImGuiCol);
@@ -7590,7 +7625,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igDebugCheckVersionAndDataLayout(
-        version_str: *const cty::c_char,
+        version_str: *const core::ffi::c_char,
         sz_io: usize,
         sz_style: usize,
         sz_vec2: usize,
@@ -7600,35 +7635,35 @@ extern "C" {
     ) -> bool;
 }
 extern "C" {
-    pub fn igDebugLog(fmt: *const cty::c_char, ...);
+    pub fn igDebugLog(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
     pub fn igSetAllocatorFunctions(
         alloc_func: ImGuiMemAllocFunc,
         free_func: ImGuiMemFreeFunc,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
     pub fn igGetAllocatorFunctions(
         p_alloc_func: *mut ImGuiMemAllocFunc,
         p_free_func: *mut ImGuiMemFreeFunc,
-        p_user_data: *mut *mut cty::c_void,
+        p_user_data: *mut *mut core::ffi::c_void,
     );
 }
 extern "C" {
-    pub fn igMemAlloc(size: usize) -> *mut cty::c_void;
+    pub fn igMemAlloc(size: usize) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn igMemFree(ptr: *mut cty::c_void);
+    pub fn igMemFree(ptr: *mut core::ffi::c_void);
 }
 extern "C" {
     pub fn igUpdatePlatformWindows();
 }
 extern "C" {
     pub fn igRenderPlatformWindowsDefault(
-        platform_render_arg: *mut cty::c_void,
-        renderer_render_arg: *mut cty::c_void,
+        platform_render_arg: *mut core::ffi::c_void,
+        renderer_render_arg: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -7638,7 +7673,9 @@ extern "C" {
     pub fn igFindViewportByID(id: ImGuiID) -> *mut ImGuiViewport;
 }
 extern "C" {
-    pub fn igFindViewportByPlatformHandle(platform_handle: *mut cty::c_void) -> *mut ImGuiViewport;
+    pub fn igFindViewportByPlatformHandle(
+        platform_handle: *mut core::ffi::c_void,
+    ) -> *mut ImGuiViewport;
 }
 extern "C" {
     pub fn ImGuiTableSortSpecs_ImGuiTableSortSpecs() -> *mut ImGuiTableSortSpecs;
@@ -7671,7 +7708,7 @@ extern "C" {
     pub fn ImGuiIO_AddMousePosEvent(self_: *mut ImGuiIO, x: f32, y: f32);
 }
 extern "C" {
-    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: cty::c_int, down: bool);
+    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: core::ffi::c_int, down: bool);
 }
 extern "C" {
     pub fn ImGuiIO_AddMouseWheelEvent(self_: *mut ImGuiIO, wheel_x: f32, wheel_y: f32);
@@ -7686,21 +7723,21 @@ extern "C" {
     pub fn ImGuiIO_AddFocusEvent(self_: *mut ImGuiIO, focused: bool);
 }
 extern "C" {
-    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: cty::c_uint);
+    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: core::ffi::c_uint);
 }
 extern "C" {
     pub fn ImGuiIO_AddInputCharacterUTF16(self_: *mut ImGuiIO, c: ImWchar16);
 }
 extern "C" {
-    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const cty::c_char);
+    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn ImGuiIO_SetKeyEventNativeData(
         self_: *mut ImGuiIO,
         key: ImGuiKey,
-        native_keycode: cty::c_int,
-        native_scancode: cty::c_int,
-        native_legacy_index: cty::c_int,
+        native_keycode: core::ffi::c_int,
+        native_scancode: core::ffi::c_int,
+        native_legacy_index: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -7730,16 +7767,16 @@ extern "C" {
 extern "C" {
     pub fn ImGuiInputTextCallbackData_DeleteChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        bytes_count: cty::c_int,
+        pos: core::ffi::c_int,
+        bytes_count: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImGuiInputTextCallbackData_InsertChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        pos: core::ffi::c_int,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -7767,7 +7804,10 @@ extern "C" {
     pub fn ImGuiPayload_Clear(self_: *mut ImGuiPayload);
 }
 extern "C" {
-    pub fn ImGuiPayload_IsDataType(self_: *mut ImGuiPayload, type_: *const cty::c_char) -> bool;
+    pub fn ImGuiPayload_IsDataType(
+        self_: *mut ImGuiPayload,
+        type_: *const core::ffi::c_char,
+    ) -> bool;
 }
 extern "C" {
     pub fn ImGuiPayload_IsPreview(self_: *mut ImGuiPayload) -> bool;
@@ -7783,7 +7823,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiTextFilter_ImGuiTextFilter(
-        default_filter: *const cty::c_char,
+        default_filter: *const core::ffi::c_char,
     ) -> *mut ImGuiTextFilter;
 }
 extern "C" {
@@ -7792,15 +7832,15 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_Draw(
         self_: *mut ImGuiTextFilter,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         width: f32,
     ) -> bool;
 }
 extern "C" {
     pub fn ImGuiTextFilter_PassFilter(
         self_: *mut ImGuiTextFilter,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     ) -> bool;
 }
 extern "C" {
@@ -7820,8 +7860,8 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiTextRange_ImGuiTextRange_Str(
-        _b: *const cty::c_char,
-        _e: *const cty::c_char,
+        _b: *const core::ffi::c_char,
+        _e: *const core::ffi::c_char,
     ) -> *mut ImGuiTextRange;
 }
 extern "C" {
@@ -7830,7 +7870,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextRange_split(
         self_: *mut ImGuiTextRange,
-        separator: cty::c_char,
+        separator: core::ffi::c_char,
         out: *mut ImVector_ImGuiTextRange,
     );
 }
@@ -7841,13 +7881,13 @@ extern "C" {
     pub fn ImGuiTextBuffer_destroy(self_: *mut ImGuiTextBuffer);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> cty::c_int;
+    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiTextBuffer_empty(self_: *mut ImGuiTextBuffer) -> bool;
@@ -7856,22 +7896,22 @@ extern "C" {
     pub fn ImGuiTextBuffer_clear(self_: *mut ImGuiTextBuffer);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: cty::c_int);
+    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiTextBuffer_append(
         self_: *mut ImGuiTextBuffer,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Int(
         _key: ImGuiID,
-        _val: cty::c_int,
+        _val: core::ffi::c_int,
     ) -> *mut ImGuiStoragePair;
 }
 extern "C" {
@@ -7886,7 +7926,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Ptr(
         _key: ImGuiID,
-        _val: *mut cty::c_void,
+        _val: *mut core::ffi::c_void,
     ) -> *mut ImGuiStoragePair;
 }
 extern "C" {
@@ -7896,11 +7936,11 @@ extern "C" {
     pub fn ImGuiStorage_GetInt(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: cty::c_int);
+    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiStorage_GetBool(self_: *mut ImGuiStorage, key: ImGuiID, default_val: bool) -> bool;
@@ -7915,17 +7955,24 @@ extern "C" {
     pub fn ImGuiStorage_SetFloat(self_: *mut ImGuiStorage, key: ImGuiID, val: f32);
 }
 extern "C" {
-    pub fn ImGuiStorage_GetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID) -> *mut cty::c_void;
+    pub fn ImGuiStorage_GetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+    ) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn ImGuiStorage_SetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID, val: *mut cty::c_void);
+    pub fn ImGuiStorage_SetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+        val: *mut core::ffi::c_void,
+    );
 }
 extern "C" {
     pub fn ImGuiStorage_GetIntRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> *mut cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> *mut core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiStorage_GetBoolRef(
@@ -7945,14 +7992,14 @@ extern "C" {
     pub fn ImGuiStorage_GetVoidPtrRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: *mut cty::c_void,
-    ) -> *mut *mut cty::c_void;
+        default_val: *mut core::ffi::c_void,
+    ) -> *mut *mut core::ffi::c_void;
 }
 extern "C" {
     pub fn ImGuiStorage_BuildSortByKey(self_: *mut ImGuiStorage);
 }
 extern "C" {
-    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: cty::c_int);
+    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiListClipper_ImGuiListClipper() -> *mut ImGuiListClipper;
@@ -7963,7 +8010,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_Begin(
         self_: *mut ImGuiListClipper,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         items_height: f32,
     );
 }
@@ -7976,18 +8023,21 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemByIndex(
         self_: *mut ImGuiListClipper,
-        item_index: cty::c_int,
+        item_index: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemsByIndex(
         self_: *mut ImGuiListClipper,
-        item_begin: cty::c_int,
-        item_end: cty::c_int,
+        item_begin: core::ffi::c_int,
+        item_end: core::ffi::c_int,
     );
 }
 extern "C" {
-    pub fn ImGuiListClipper_SeekCursorForItem(self_: *mut ImGuiListClipper, item_index: cty::c_int);
+    pub fn ImGuiListClipper_SeekCursorForItem(
+        self_: *mut ImGuiListClipper,
+        item_index: core::ffi::c_int,
+    );
 }
 extern "C" {
     pub fn ImColor_ImColor_Nil() -> *mut ImColor;
@@ -8003,10 +8053,10 @@ extern "C" {
 }
 extern "C" {
     pub fn ImColor_ImColor_Int(
-        r: cty::c_int,
-        g: cty::c_int,
-        b: cty::c_int,
-        a: cty::c_int,
+        r: core::ffi::c_int,
+        g: core::ffi::c_int,
+        b: core::ffi::c_int,
+        a: core::ffi::c_int,
     ) -> *mut ImColor;
 }
 extern "C" {
@@ -8055,14 +8105,14 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetNextSelectedItem(
         self_: *mut ImGuiSelectionBasicStorage,
-        opaque_it: *mut *mut cty::c_void,
+        opaque_it: *mut *mut core::ffi::c_void,
         out_id: *mut ImGuiID,
     ) -> bool;
 }
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetStorageIdFromIndex(
         self_: *mut ImGuiSelectionBasicStorage,
-        idx: cty::c_int,
+        idx: core::ffi::c_int,
     ) -> ImGuiID;
 }
 extern "C" {
@@ -8103,7 +8153,7 @@ extern "C" {
     pub fn ImDrawListSplitter_Split(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        count: cty::c_int,
+        count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8113,7 +8163,7 @@ extern "C" {
     pub fn ImDrawListSplitter_SetCurrentChannel(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        channel_idx: cty::c_int,
+        channel_idx: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8235,7 +8285,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8245,7 +8295,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8254,7 +8304,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8264,7 +8314,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8274,7 +8324,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8285,7 +8335,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8293,8 +8343,8 @@ extern "C" {
         self_: *mut ImDrawList,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -8304,8 +8354,8 @@ extern "C" {
         font_size: f32,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip_rect: *const ImVec4,
     );
@@ -8319,7 +8369,7 @@ extern "C" {
         p4: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8330,14 +8380,14 @@ extern "C" {
         p3: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImDrawList_AddPolyline(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
         flags: ImDrawFlags,
         thickness: f32,
@@ -8347,7 +8397,7 @@ extern "C" {
     pub fn ImDrawList_AddConvexPolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -8355,7 +8405,7 @@ extern "C" {
     pub fn ImDrawList_AddConcavePolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -8428,7 +8478,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8436,8 +8486,8 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_of_12: cty::c_int,
-        a_max_of_12: cty::c_int,
+        a_min_of_12: core::ffi::c_int,
+        a_max_of_12: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8448,7 +8498,7 @@ extern "C" {
         rot: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8457,7 +8507,7 @@ extern "C" {
         p2: ImVec2,
         p3: ImVec2,
         p4: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8465,7 +8515,7 @@ extern "C" {
         self_: *mut ImDrawList,
         p2: ImVec2,
         p3: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8481,7 +8531,7 @@ extern "C" {
     pub fn ImDrawList_AddCallback(
         self_: *mut ImDrawList,
         callback: ImDrawCallback,
-        callback_data: *mut cty::c_void,
+        callback_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -8491,26 +8541,26 @@ extern "C" {
     pub fn ImDrawList_CloneOutput(self_: *mut ImDrawList) -> *mut ImDrawList;
 }
 extern "C" {
-    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: cty::c_int);
+    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImDrawList_ChannelsMerge(self_: *mut ImDrawList);
 }
 extern "C" {
-    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: cty::c_int);
+    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImDrawList_PrimReserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImDrawList_PrimUnreserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8577,16 +8627,16 @@ extern "C" {
     pub fn ImDrawList__CalcCircleAutoSegmentCount(
         self_: *mut ImDrawList,
         radius: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImDrawList__PathArcToFastEx(
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_sample: cty::c_int,
-        a_max_sample: cty::c_int,
-        a_step: cty::c_int,
+        a_min_sample: core::ffi::c_int,
+        a_max_sample: core::ffi::c_int,
+        a_step: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8596,7 +8646,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8644,8 +8694,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontGlyphRangesBuilder_AddText(
         self_: *mut ImFontGlyphRangesBuilder,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -8690,7 +8740,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromFileTTF(
         self_: *mut ImFontAtlas,
-        filename: *const cty::c_char,
+        filename: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -8699,8 +8749,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryTTF(
         self_: *mut ImFontAtlas,
-        font_data: *mut cty::c_void,
-        font_data_size: cty::c_int,
+        font_data: *mut core::ffi::c_void,
+        font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -8709,8 +8759,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedTTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data: *const cty::c_void,
-        compressed_font_data_size: cty::c_int,
+        compressed_font_data: *const core::ffi::c_void,
+        compressed_font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -8719,7 +8769,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data_base85: *const cty::c_char,
+        compressed_font_data_base85: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -8743,19 +8793,19 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsAlpha8(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsRGBA32(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 extern "C" {
@@ -8796,25 +8846,25 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectRegular(
         self_: *mut ImFontAtlas,
-        width: cty::c_int,
-        height: cty::c_int,
-    ) -> cty::c_int;
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectFontGlyph(
         self_: *mut ImFontAtlas,
         font: *mut ImFont,
         id: ImWchar,
-        width: cty::c_int,
-        height: cty::c_int,
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
         advance_x: f32,
         offset: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImFontAtlas_GetCustomRectByIndex(
         self_: *mut ImFontAtlas,
-        index: cty::c_int,
+        index: core::ffi::c_int,
     ) -> *mut ImFontAtlasCustomRect;
 }
 extern "C" {
@@ -8854,7 +8904,7 @@ extern "C" {
     pub fn ImFont_IsLoaded(self_: *mut ImFont) -> bool;
 }
 extern "C" {
-    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const cty::c_char;
+    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImFont_CalcTextSizeA(
@@ -8863,19 +8913,19 @@ extern "C" {
         size: f32,
         max_width: f32,
         wrap_width: f32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
-        remaining: *mut *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        remaining: *mut *const core::ffi::c_char,
     );
 }
 extern "C" {
     pub fn ImFont_CalcWordWrapPositionA(
         self_: *mut ImFont,
         scale: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImFont_RenderChar(
@@ -8895,8 +8945,8 @@ extern "C" {
         pos: ImVec2,
         col: ImU32,
         clip_rect: ImVec4,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip: bool,
     );
@@ -8908,7 +8958,7 @@ extern "C" {
     pub fn ImFont_ClearOutputData(self_: *mut ImFont);
 }
 extern "C" {
-    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: cty::c_int);
+    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImFont_AddGlyph(
@@ -8935,8 +8985,8 @@ extern "C" {
 extern "C" {
     pub fn ImFont_IsGlyphRangeUnused(
         self_: *mut ImFont,
-        c_begin: cty::c_uint,
-        c_last: cty::c_uint,
+        c_begin: core::ffi::c_uint,
+        c_last: core::ffi::c_uint,
     ) -> bool;
 }
 extern "C" {
@@ -8970,18 +9020,22 @@ extern "C" {
     pub fn ImGuiPlatformImeData_destroy(self_: *mut ImGuiPlatformImeData);
 }
 extern "C" {
-    pub fn igImHashData(data: *const cty::c_void, data_size: usize, seed: ImGuiID) -> ImGuiID;
+    pub fn igImHashData(data: *const core::ffi::c_void, data_size: usize, seed: ImGuiID)
+        -> ImGuiID;
 }
 extern "C" {
-    pub fn igImHashStr(data: *const cty::c_char, data_size: usize, seed: ImGuiID) -> ImGuiID;
+    pub fn igImHashStr(data: *const core::ffi::c_char, data_size: usize, seed: ImGuiID) -> ImGuiID;
 }
 extern "C" {
     pub fn igImQsort(
-        base: *mut cty::c_void,
+        base: *mut core::ffi::c_void,
         count: usize,
         size_of_element: usize,
         compare_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *const cty::c_void, arg2: *const cty::c_void) -> cty::c_int,
+            unsafe extern "C" fn(
+                arg1: *const core::ffi::c_void,
+                arg2: *const core::ffi::c_void,
+            ) -> core::ffi::c_int,
         >,
     );
 }
@@ -8989,193 +9043,202 @@ extern "C" {
     pub fn igImAlphaBlendColors(col_a: ImU32, col_b: ImU32) -> ImU32;
 }
 extern "C" {
-    pub fn igImIsPowerOfTwo_Int(v: cty::c_int) -> bool;
+    pub fn igImIsPowerOfTwo_Int(v: core::ffi::c_int) -> bool;
 }
 extern "C" {
     pub fn igImIsPowerOfTwo_U64(v: ImU64) -> bool;
 }
 extern "C" {
-    pub fn igImUpperPowerOfTwo(v: cty::c_int) -> cty::c_int;
+    pub fn igImUpperPowerOfTwo(v: core::ffi::c_int) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igImStricmp(str1: *const cty::c_char, str2: *const cty::c_char) -> cty::c_int;
+    pub fn igImStricmp(
+        str1: *const core::ffi::c_char,
+        str2: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImStrnicmp(
-        str1: *const cty::c_char,
-        str2: *const cty::c_char,
+        str1: *const core::ffi::c_char,
+        str2: *const core::ffi::c_char,
         count: usize,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igImStrncpy(dst: *mut cty::c_char, src: *const cty::c_char, count: usize);
+    pub fn igImStrncpy(dst: *mut core::ffi::c_char, src: *const core::ffi::c_char, count: usize);
 }
 extern "C" {
-    pub fn igImStrdup(str_: *const cty::c_char) -> *mut cty::c_char;
+    pub fn igImStrdup(str_: *const core::ffi::c_char) -> *mut core::ffi::c_char;
 }
 extern "C" {
     pub fn igImStrdupcpy(
-        dst: *mut cty::c_char,
+        dst: *mut core::ffi::c_char,
         p_dst_size: *mut usize,
-        str_: *const cty::c_char,
-    ) -> *mut cty::c_char;
+        str_: *const core::ffi::c_char,
+    ) -> *mut core::ffi::c_char;
 }
 extern "C" {
     pub fn igImStrchrRange(
-        str_begin: *const cty::c_char,
-        str_end: *const cty::c_char,
-        c: cty::c_char,
-    ) -> *const cty::c_char;
+        str_begin: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
+        c: core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImStreolRange(
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImStristr(
-        haystack: *const cty::c_char,
-        haystack_end: *const cty::c_char,
-        needle: *const cty::c_char,
-        needle_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        haystack: *const core::ffi::c_char,
+        haystack_end: *const core::ffi::c_char,
+        needle: *const core::ffi::c_char,
+        needle_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImStrTrimBlanks(str_: *mut cty::c_char);
+    pub fn igImStrTrimBlanks(str_: *mut core::ffi::c_char);
 }
 extern "C" {
-    pub fn igImStrSkipBlank(str_: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImStrSkipBlank(str_: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImStrlenW(str_: *const ImWchar) -> cty::c_int;
+    pub fn igImStrlenW(str_: *const ImWchar) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImStrbol(
-        buf_mid_line: *const cty::c_char,
-        buf_begin: *const cty::c_char,
-    ) -> *const cty::c_char;
+        buf_mid_line: *const core::ffi::c_char,
+        buf_begin: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImToUpper(c: cty::c_char) -> cty::c_char;
+    pub fn igImToUpper(c: core::ffi::c_char) -> core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImCharIsBlankA(c: cty::c_char) -> bool;
+    pub fn igImCharIsBlankA(c: core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igImCharIsBlankW(c: cty::c_uint) -> bool;
+    pub fn igImCharIsBlankW(c: core::ffi::c_uint) -> bool;
 }
 extern "C" {
-    pub fn igImCharIsXdigitA(c: cty::c_char) -> bool;
+    pub fn igImCharIsXdigitA(c: core::ffi::c_char) -> bool;
 }
 extern "C" {
     pub fn igImFormatString(
-        buf: *mut cty::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImFormatStringToTempBuffer(
-        out_buf: *mut *const cty::c_char,
-        out_buf_end: *mut *const cty::c_char,
-        fmt: *const cty::c_char,
+        out_buf: *mut *const core::ffi::c_char,
+        out_buf_end: *mut *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     );
 }
 extern "C" {
-    pub fn igImParseFormatFindStart(format: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImParseFormatFindStart(format: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igImParseFormatFindEnd(format: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImParseFormatFindEnd(format: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImParseFormatTrimDecorations(
-        format: *const cty::c_char,
-        buf: *mut cty::c_char,
+        format: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImParseFormatSanitizeForPrinting(
-        fmt_in: *const cty::c_char,
-        fmt_out: *mut cty::c_char,
+        fmt_in: *const core::ffi::c_char,
+        fmt_out: *mut core::ffi::c_char,
         fmt_out_size: usize,
     );
 }
 extern "C" {
     pub fn igImParseFormatSanitizeForScanning(
-        fmt_in: *const cty::c_char,
-        fmt_out: *mut cty::c_char,
+        fmt_in: *const core::ffi::c_char,
+        fmt_out: *mut core::ffi::c_char,
         fmt_out_size: usize,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImParseFormatPrecision(
-        format: *const cty::c_char,
-        default_value: cty::c_int,
-    ) -> cty::c_int;
+        format: *const core::ffi::c_char,
+        default_value: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igImTextCharToUtf8(out_buf: *mut cty::c_char, c: cty::c_uint) -> *const cty::c_char;
+    pub fn igImTextCharToUtf8(
+        out_buf: *mut core::ffi::c_char,
+        c: core::ffi::c_uint,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImTextStrToUtf8(
-        out_buf: *mut cty::c_char,
-        out_buf_size: cty::c_int,
+        out_buf: *mut core::ffi::c_char,
+        out_buf_size: core::ffi::c_int,
         in_text: *const ImWchar,
         in_text_end: *const ImWchar,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextCharFromUtf8(
-        out_char: *mut cty::c_uint,
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        out_char: *mut core::ffi::c_uint,
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextStrFromUtf8(
         out_buf: *mut ImWchar,
-        out_buf_size: cty::c_int,
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-        in_remaining: *mut *const cty::c_char,
-    ) -> cty::c_int;
+        out_buf_size: core::ffi::c_int,
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+        in_remaining: *mut *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextCountCharsFromUtf8(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextCountUtf8BytesFromChar(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextCountUtf8BytesFromStr(
         in_text: *const ImWchar,
         in_text_end: *const ImWchar,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImTextFindPreviousUtf8Codepoint(
-        in_text_start: *const cty::c_char,
-        in_text_curr: *const cty::c_char,
-    ) -> *const cty::c_char;
+        in_text_start: *const core::ffi::c_char,
+        in_text_curr: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igImTextCountLines(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igImFileOpen(filename: *const cty::c_char, mode: *const cty::c_char) -> ImFileHandle;
+    pub fn igImFileOpen(
+        filename: *const core::ffi::c_char,
+        mode: *const core::ffi::c_char,
+    ) -> ImFileHandle;
 }
 extern "C" {
     pub fn igImFileClose(file: ImFileHandle) -> bool;
@@ -9185,7 +9248,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igImFileRead(
-        data: *mut cty::c_void,
+        data: *mut core::ffi::c_void,
         size: ImU64,
         count: ImU64,
         file: ImFileHandle,
@@ -9193,7 +9256,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igImFileWrite(
-        data: *const cty::c_void,
+        data: *const core::ffi::c_void,
         size: ImU64,
         count: ImU64,
         file: ImFileHandle,
@@ -9201,11 +9264,11 @@ extern "C" {
 }
 extern "C" {
     pub fn igImFileLoadToMemory(
-        filename: *const cty::c_char,
-        mode: *const cty::c_char,
+        filename: *const core::ffi::c_char,
+        mode: *const core::ffi::c_char,
         out_file_size: *mut usize,
-        padding_bytes: cty::c_int,
-    ) -> *mut cty::c_void;
+        padding_bytes: core::ffi::c_int,
+    ) -> *mut core::ffi::c_void;
 }
 extern "C" {
     pub fn igImPow_Float(x: f32, y: f32) -> f32;
@@ -9220,7 +9283,7 @@ extern "C" {
     pub fn igImLog_double(x: f64) -> f64;
 }
 extern "C" {
-    pub fn igImAbs_Int(x: cty::c_int) -> cty::c_int;
+    pub fn igImAbs_Int(x: core::ffi::c_int) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImAbs_Float(x: f32) -> f32;
@@ -9283,7 +9346,7 @@ extern "C" {
     pub fn igImFloor_Vec2(pOut: *mut ImVec2, v: ImVec2);
 }
 extern "C" {
-    pub fn igImModPositive(a: cty::c_int, b: cty::c_int) -> cty::c_int;
+    pub fn igImModPositive(a: core::ffi::c_int, b: core::ffi::c_int) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igImDot(a: ImVec2, b: ImVec2) -> f32;
@@ -9304,7 +9367,7 @@ extern "C" {
     pub fn igImIsFloatAboveGuaranteedIntegerPrecision(f: f32) -> bool;
 }
 extern "C" {
-    pub fn igImExponentialMovingAverage(avg: f32, sample: f32, n: cty::c_int) -> f32;
+    pub fn igImExponentialMovingAverage(avg: f32, sample: f32, n: core::ffi::c_int) -> f32;
 }
 extern "C" {
     pub fn igImBezierCubicCalc(
@@ -9324,7 +9387,7 @@ extern "C" {
         p3: ImVec2,
         p4: ImVec2,
         p: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -9383,7 +9446,8 @@ extern "C" {
     pub fn ImVec2ih_destroy(self_: *mut ImVec2ih);
 }
 extern "C" {
-    pub fn ImVec2ih_ImVec2ih_short(_x: cty::c_short, _y: cty::c_short) -> *mut ImVec2ih;
+    pub fn ImVec2ih_ImVec2ih_short(_x: core::ffi::c_short, _y: core::ffi::c_short)
+        -> *mut ImVec2ih;
 }
 extern "C" {
     pub fn ImVec2ih_ImVec2ih_Vec2(rhs: ImVec2) -> *mut ImVec2ih;
@@ -9479,64 +9543,64 @@ extern "C" {
     pub fn ImRect_ToVec4(pOut: *mut ImVec4, self_: *mut ImRect);
 }
 extern "C" {
-    pub fn igImBitArrayGetStorageSizeInBytes(bitcount: cty::c_int) -> usize;
+    pub fn igImBitArrayGetStorageSizeInBytes(bitcount: core::ffi::c_int) -> usize;
 }
 extern "C" {
-    pub fn igImBitArrayClearAllBits(arr: *mut ImU32, bitcount: cty::c_int);
+    pub fn igImBitArrayClearAllBits(arr: *mut ImU32, bitcount: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igImBitArrayTestBit(arr: *const ImU32, n: cty::c_int) -> bool;
+    pub fn igImBitArrayTestBit(arr: *const ImU32, n: core::ffi::c_int) -> bool;
 }
 extern "C" {
-    pub fn igImBitArrayClearBit(arr: *mut ImU32, n: cty::c_int);
+    pub fn igImBitArrayClearBit(arr: *mut ImU32, n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igImBitArraySetBit(arr: *mut ImU32, n: cty::c_int);
+    pub fn igImBitArraySetBit(arr: *mut ImU32, n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igImBitArraySetBitRange(arr: *mut ImU32, n: cty::c_int, n2: cty::c_int);
+    pub fn igImBitArraySetBitRange(arr: *mut ImU32, n: core::ffi::c_int, n2: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImBitVector_Create(self_: *mut ImBitVector, sz: cty::c_int);
+    pub fn ImBitVector_Create(self_: *mut ImBitVector, sz: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImBitVector_Clear(self_: *mut ImBitVector);
 }
 extern "C" {
-    pub fn ImBitVector_TestBit(self_: *mut ImBitVector, n: cty::c_int) -> bool;
+    pub fn ImBitVector_TestBit(self_: *mut ImBitVector, n: core::ffi::c_int) -> bool;
 }
 extern "C" {
-    pub fn ImBitVector_SetBit(self_: *mut ImBitVector, n: cty::c_int);
+    pub fn ImBitVector_SetBit(self_: *mut ImBitVector, n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImBitVector_ClearBit(self_: *mut ImBitVector, n: cty::c_int);
+    pub fn ImBitVector_ClearBit(self_: *mut ImBitVector, n: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiTextIndex_clear(self_: *mut ImGuiTextIndex);
 }
 extern "C" {
-    pub fn ImGuiTextIndex_size(self_: *mut ImGuiTextIndex) -> cty::c_int;
+    pub fn ImGuiTextIndex_size(self_: *mut ImGuiTextIndex) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiTextIndex_get_line_begin(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        n: cty::c_int,
-    ) -> *const cty::c_char;
+        base: *const core::ffi::c_char,
+        n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiTextIndex_get_line_end(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        n: cty::c_int,
-    ) -> *const cty::c_char;
+        base: *const core::ffi::c_char,
+        n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiTextIndex_append(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        old_size: cty::c_int,
-        new_size: cty::c_int,
+        base: *const core::ffi::c_char,
+        old_size: core::ffi::c_int,
+        new_size: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -9567,12 +9631,14 @@ extern "C" {
 extern "C" {
     pub fn ImGuiDataVarInfo_GetVarPtr(
         self_: *mut ImGuiDataVarInfo,
-        parent: *mut cty::c_void,
-    ) -> *mut cty::c_void;
+        parent: *mut core::ffi::c_void,
+    ) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn ImGuiStyleMod_ImGuiStyleMod_Int(idx: ImGuiStyleVar, v: cty::c_int)
-        -> *mut ImGuiStyleMod;
+    pub fn ImGuiStyleMod_ImGuiStyleMod_Int(
+        idx: ImGuiStyleVar,
+        v: core::ffi::c_int,
+    ) -> *mut ImGuiStyleMod;
 }
 extern "C" {
     pub fn ImGuiStyleMod_destroy(self_: *mut ImGuiStyleMod);
@@ -9639,10 +9705,10 @@ extern "C" {
     pub fn ImGuiInputTextState_ClearFreeMemory(self_: *mut ImGuiInputTextState);
 }
 extern "C" {
-    pub fn ImGuiInputTextState_OnKeyPressed(self_: *mut ImGuiInputTextState, key: cty::c_int);
+    pub fn ImGuiInputTextState_OnKeyPressed(self_: *mut ImGuiInputTextState, key: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImGuiInputTextState_OnCharPressed(self_: *mut ImGuiInputTextState, c: cty::c_uint);
+    pub fn ImGuiInputTextState_OnCharPressed(self_: *mut ImGuiInputTextState, c: core::ffi::c_uint);
 }
 extern "C" {
     pub fn ImGuiInputTextState_CursorAnimReset(self_: *mut ImGuiInputTextState);
@@ -9657,13 +9723,16 @@ extern "C" {
     pub fn ImGuiInputTextState_ClearSelection(self_: *mut ImGuiInputTextState);
 }
 extern "C" {
-    pub fn ImGuiInputTextState_GetCursorPos(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetCursorPos(self_: *mut ImGuiInputTextState) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ImGuiInputTextState_GetSelectionStart(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetSelectionStart(
+        self_: *mut ImGuiInputTextState,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ImGuiInputTextState_GetSelectionEnd(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetSelectionEnd(self_: *mut ImGuiInputTextState)
+        -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiInputTextState_SelectAll(self_: *mut ImGuiInputTextState);
@@ -9708,13 +9777,14 @@ extern "C" {
     pub fn ImGuiErrorRecoveryState_destroy(self_: *mut ImGuiErrorRecoveryState);
 }
 extern "C" {
-    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Ptr(ptr: *mut cty::c_void) -> *mut ImGuiPtrOrIndex;
+    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Ptr(ptr: *mut core::ffi::c_void)
+        -> *mut ImGuiPtrOrIndex;
 }
 extern "C" {
     pub fn ImGuiPtrOrIndex_destroy(self_: *mut ImGuiPtrOrIndex);
 }
 extern "C" {
-    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Int(index: cty::c_int) -> *mut ImGuiPtrOrIndex;
+    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Int(index: core::ffi::c_int) -> *mut ImGuiPtrOrIndex;
 }
 extern "C" {
     pub fn ImGuiPopupData_ImGuiPopupData() -> *mut ImGuiPopupData;
@@ -9751,16 +9821,16 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiListClipperRange_FromIndices(
-        min: cty::c_int,
-        max: cty::c_int,
+        min: core::ffi::c_int,
+        max: core::ffi::c_int,
     ) -> ImGuiListClipperRange;
 }
 extern "C" {
     pub fn ImGuiListClipperRange_FromPositions(
         y1: f32,
         y2: f32,
-        off_min: cty::c_int,
-        off_max: cty::c_int,
+        off_min: core::ffi::c_int,
+        off_max: core::ffi::c_int,
     ) -> ImGuiListClipperRange;
 }
 extern "C" {
@@ -9920,7 +9990,7 @@ extern "C" {
     pub fn ImGuiWindowSettings_destroy(self_: *mut ImGuiWindowSettings);
 }
 extern "C" {
-    pub fn ImGuiWindowSettings_GetName(self_: *mut ImGuiWindowSettings) -> *mut cty::c_char;
+    pub fn ImGuiWindowSettings_GetName(self_: *mut ImGuiWindowSettings) -> *mut core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiSettingsHandler_ImGuiSettingsHandler() -> *mut ImGuiSettingsHandler;
@@ -9961,7 +10031,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiWindow_ImGuiWindow(
         context: *mut ImGuiContext,
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
     ) -> *mut ImGuiWindow;
 }
 extern "C" {
@@ -9970,15 +10040,16 @@ extern "C" {
 extern "C" {
     pub fn ImGuiWindow_GetID_Str(
         self_: *mut ImGuiWindow,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn ImGuiWindow_GetID_Ptr(self_: *mut ImGuiWindow, ptr: *const cty::c_void) -> ImGuiID;
+    pub fn ImGuiWindow_GetID_Ptr(self_: *mut ImGuiWindow, ptr: *const core::ffi::c_void)
+        -> ImGuiID;
 }
 extern "C" {
-    pub fn ImGuiWindow_GetID_Int(self_: *mut ImGuiWindow, n: cty::c_int) -> ImGuiID;
+    pub fn ImGuiWindow_GetID_Int(self_: *mut ImGuiWindow, n: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
     pub fn ImGuiWindow_GetIDFromPos(self_: *mut ImGuiWindow, p_abs: ImVec2) -> ImGuiID;
@@ -10061,7 +10132,7 @@ extern "C" {
     pub fn igFindWindowByID(id: ImGuiID) -> *mut ImGuiWindow;
 }
 extern "C" {
-    pub fn igFindWindowByName(name: *const cty::c_char) -> *mut ImGuiWindow;
+    pub fn igFindWindowByName(name: *const core::ffi::c_char) -> *mut ImGuiWindow;
 }
 extern "C" {
     pub fn igUpdateWindowParentAndRootLinks(
@@ -10160,7 +10231,7 @@ extern "C" {
     pub fn igBringWindowToDisplayBehind(window: *mut ImGuiWindow, above_window: *mut ImGuiWindow);
 }
 extern "C" {
-    pub fn igFindWindowDisplayIndex(window: *mut ImGuiWindow) -> cty::c_int;
+    pub fn igFindWindowDisplayIndex(window: *mut ImGuiWindow) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igFindBottomMostVisibleWindowWithinBeginStack(
@@ -10275,13 +10346,13 @@ extern "C" {
     pub fn igAddSettingsHandler(handler: *const ImGuiSettingsHandler);
 }
 extern "C" {
-    pub fn igRemoveSettingsHandler(type_name: *const cty::c_char);
+    pub fn igRemoveSettingsHandler(type_name: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igFindSettingsHandler(type_name: *const cty::c_char) -> *mut ImGuiSettingsHandler;
+    pub fn igFindSettingsHandler(type_name: *const core::ffi::c_char) -> *mut ImGuiSettingsHandler;
 }
 extern "C" {
-    pub fn igCreateNewWindowSettings(name: *const cty::c_char) -> *mut ImGuiWindowSettings;
+    pub fn igCreateNewWindowSettings(name: *const core::ffi::c_char) -> *mut ImGuiWindowSettings;
 }
 extern "C" {
     pub fn igFindWindowSettingsByID(id: ImGuiID) -> *mut ImGuiWindowSettings;
@@ -10290,13 +10361,13 @@ extern "C" {
     pub fn igFindWindowSettingsByWindow(window: *mut ImGuiWindow) -> *mut ImGuiWindowSettings;
 }
 extern "C" {
-    pub fn igClearWindowSettings(name: *const cty::c_char);
+    pub fn igClearWindowSettings(name: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLocalizeRegisterEntries(entries: *const ImGuiLocEntry, count: cty::c_int);
+    pub fn igLocalizeRegisterEntries(entries: *const ImGuiLocEntry, count: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igLocalizeGetMsg(key: ImGuiLocKey) -> *const cty::c_char;
+    pub fn igLocalizeGetMsg(key: ImGuiLocKey) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetScrollX_WindowPtr(window: *mut ImGuiWindow, scroll_x: f32);
@@ -10373,13 +10444,13 @@ extern "C" {
 }
 extern "C" {
     pub fn igGetIDWithSeed_Str(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
         seed: ImGuiID,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetIDWithSeed_Int(n: cty::c_int, seed: ImGuiID) -> ImGuiID;
+    pub fn igGetIDWithSeed_Int(n: core::ffi::c_int, seed: ImGuiID) -> ImGuiID;
 }
 extern "C" {
     pub fn igItemSize_Vec2(size: ImVec2, text_baseline_y: f32);
@@ -10419,10 +10490,14 @@ extern "C" {
     pub fn igCalcWrapWidthForPos(pos: ImVec2, wrap_pos_x: f32) -> f32;
 }
 extern "C" {
-    pub fn igPushMultiItemsWidths(components: cty::c_int, width_full: f32);
+    pub fn igPushMultiItemsWidths(components: core::ffi::c_int, width_full: f32);
 }
 extern "C" {
-    pub fn igShrinkWidths(items: *mut ImGuiShrinkWidthItem, count: cty::c_int, width_excess: f32);
+    pub fn igShrinkWidths(
+        items: *mut ImGuiShrinkWidthItem,
+        count: core::ffi::c_int,
+        width_excess: f32,
+    );
 }
 extern "C" {
     pub fn igGetStyleVarInfo(idx: ImGuiStyleVar) -> *const ImGuiDataVarInfo;
@@ -10434,24 +10509,27 @@ extern "C" {
     pub fn igEndDisabledOverrideReenable();
 }
 extern "C" {
-    pub fn igLogBegin(type_: ImGuiLogType, auto_open_depth: cty::c_int);
+    pub fn igLogBegin(type_: ImGuiLogType, auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igLogToBuffer(auto_open_depth: cty::c_int);
+    pub fn igLogToBuffer(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
     pub fn igLogRenderedText(
         ref_pos: *const ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
-    pub fn igLogSetNextTextDecoration(prefix: *const cty::c_char, suffix: *const cty::c_char);
+    pub fn igLogSetNextTextDecoration(
+        prefix: *const core::ffi::c_char,
+        suffix: *const core::ffi::c_char,
+    );
 }
 extern "C" {
     pub fn igBeginChildEx(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         id: ImGuiID,
         size_arg: ImVec2,
         child_flags: ImGuiChildFlags,
@@ -10465,7 +10543,10 @@ extern "C" {
     pub fn igOpenPopupEx(id: ImGuiID, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
-    pub fn igClosePopupToLevel(remaining: cty::c_int, restore_focus_to_window_under_popup: bool);
+    pub fn igClosePopupToLevel(
+        remaining: core::ffi::c_int,
+        restore_focus_to_window_under_popup: bool,
+    );
 }
 extern "C" {
     pub fn igClosePopupsOverWindow(
@@ -10516,7 +10597,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginViewportSideBar(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         viewport: *mut ImGuiViewport,
         dir: ImGuiDir,
         size: f32,
@@ -10525,16 +10606,16 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginMenuEx(
-        label: *const cty::c_char,
-        icon: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        icon: *const core::ffi::c_char,
         enabled: bool,
     ) -> bool;
 }
 extern "C" {
     pub fn igMenuItemEx(
-        label: *const cty::c_char,
-        icon: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        icon: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
@@ -10660,7 +10741,7 @@ extern "C" {
     pub fn igGetKeyData_Key(key: ImGuiKey) -> *mut ImGuiKeyData;
 }
 extern "C" {
-    pub fn igGetKeyChordName(key_chord: ImGuiKeyChord) -> *const cty::c_char;
+    pub fn igGetKeyChordName(key_chord: ImGuiKeyChord) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igMouseButtonToKey(button: ImGuiMouseButton) -> ImGuiKey;
@@ -10686,7 +10767,7 @@ extern "C" {
         t1: f32,
         repeat_delay: f32,
         repeat_rate: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igGetTypematicRepeatRate(
@@ -10867,7 +10948,7 @@ extern "C" {
     pub fn igDockNodeIsInHierarchyOf(node: *mut ImGuiDockNode, parent: *mut ImGuiDockNode) -> bool;
 }
 extern "C" {
-    pub fn igDockNodeGetDepth(node: *const ImGuiDockNode) -> cty::c_int;
+    pub fn igDockNodeGetDepth(node: *const ImGuiDockNode) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igDockNodeGetWindowMenuButtonId(node: *const ImGuiDockNode) -> ImGuiID;
@@ -10891,7 +10972,7 @@ extern "C" {
     pub fn igSetWindowDock(window: *mut ImGuiWindow, dock_id: ImGuiID, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igDockBuilderDockWindow(window_name: *const cty::c_char, node_id: ImGuiID);
+    pub fn igDockBuilderDockWindow(window_name: *const core::ffi::c_char, node_id: ImGuiID);
 }
 extern "C" {
     pub fn igDockBuilderGetNode(node_id: ImGuiID) -> *mut ImGuiDockNode;
@@ -10942,8 +11023,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igDockBuilderCopyWindowSettings(
-        src_name: *const cty::c_char,
-        dst_name: *const cty::c_char,
+        src_name: *const core::ffi::c_char,
+        dst_name: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -10980,34 +11061,43 @@ extern "C" {
 extern "C" {
     pub fn igTypingSelectFindMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        nav_item_idx: cty::c_int,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+        nav_item_idx: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igTypingSelectFindNextSingleCharMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        nav_item_idx: cty::c_int,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+        nav_item_idx: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igTypingSelectFindBestLeadingMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igBeginBoxSelect(
@@ -11037,7 +11127,7 @@ extern "C" {
     pub fn igMultiSelectAddSetRange(
         ms: *mut ImGuiMultiSelectTempData,
         selected: bool,
-        range_dir: cty::c_int,
+        range_dir: core::ffi::c_int,
         first_item: ImGuiSelectionUserData,
         last_item: ImGuiSelectionUserData,
     );
@@ -11053,8 +11143,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginColumns(
-        str_id: *const cty::c_char,
-        count: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        count: core::ffi::c_int,
         flags: ImGuiOldColumnFlags,
     );
 }
@@ -11062,7 +11152,7 @@ extern "C" {
     pub fn igEndColumns();
 }
 extern "C" {
-    pub fn igPushColumnClipRect(column_index: cty::c_int);
+    pub fn igPushColumnClipRect(column_index: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushColumnsBackground();
@@ -11071,7 +11161,7 @@ extern "C" {
     pub fn igPopColumnsBackground();
 }
 extern "C" {
-    pub fn igGetColumnsID(str_id: *const cty::c_char, count: cty::c_int) -> ImGuiID;
+    pub fn igGetColumnsID(str_id: *const core::ffi::c_char, count: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
     pub fn igFindOrCreateColumns(window: *mut ImGuiWindow, id: ImGuiID) -> *mut ImGuiOldColumns;
@@ -11083,20 +11173,20 @@ extern "C" {
     pub fn igGetColumnNormFromOffset(columns: *const ImGuiOldColumns, offset: f32) -> f32;
 }
 extern "C" {
-    pub fn igTableOpenContextMenu(column_n: cty::c_int);
+    pub fn igTableOpenContextMenu(column_n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igTableSetColumnWidth(column_n: cty::c_int, width: f32);
+    pub fn igTableSetColumnWidth(column_n: core::ffi::c_int, width: f32);
 }
 extern "C" {
     pub fn igTableSetColumnSortDirection(
-        column_n: cty::c_int,
+        column_n: core::ffi::c_int,
         sort_direction: ImGuiSortDirection,
         append_to_sort_specs: bool,
     );
 }
 extern "C" {
-    pub fn igTableGetHoveredRow() -> cty::c_int;
+    pub fn igTableGetHoveredRow() -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igTableGetHeaderRowHeight() -> f32;
@@ -11116,7 +11206,7 @@ extern "C" {
         angle: f32,
         max_label_width: f32,
         data: *const ImGuiTableHeaderData,
-        data_count: cty::c_int,
+        data_count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -11127,16 +11217,16 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginTableEx(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         id: ImGuiID,
-        columns_count: cty::c_int,
+        columns_count: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
     ) -> bool;
 }
 extern "C" {
-    pub fn igTableBeginInitMemory(table: *mut ImGuiTable, columns_count: cty::c_int);
+    pub fn igTableBeginInitMemory(table: *mut ImGuiTable, columns_count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igTableBeginApplyRequests(table: *mut ImGuiTable);
@@ -11171,11 +11261,11 @@ extern "C" {
 extern "C" {
     pub fn igTableGetInstanceData(
         table: *mut ImGuiTable,
-        instance_no: cty::c_int,
+        instance_no: core::ffi::c_int,
     ) -> *mut ImGuiTableInstanceData;
 }
 extern "C" {
-    pub fn igTableGetInstanceID(table: *mut ImGuiTable, instance_no: cty::c_int) -> ImGuiID;
+    pub fn igTableGetInstanceID(table: *mut ImGuiTable, instance_no: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
     pub fn igTableSortSpecsSanitize(table: *mut ImGuiTable);
@@ -11199,32 +11289,36 @@ extern "C" {
     pub fn igTableEndRow(table: *mut ImGuiTable);
 }
 extern "C" {
-    pub fn igTableBeginCell(table: *mut ImGuiTable, column_n: cty::c_int);
+    pub fn igTableBeginCell(table: *mut ImGuiTable, column_n: core::ffi::c_int);
 }
 extern "C" {
     pub fn igTableEndCell(table: *mut ImGuiTable);
 }
 extern "C" {
-    pub fn igTableGetCellBgRect(pOut: *mut ImRect, table: *const ImGuiTable, column_n: cty::c_int);
+    pub fn igTableGetCellBgRect(
+        pOut: *mut ImRect,
+        table: *const ImGuiTable,
+        column_n: core::ffi::c_int,
+    );
 }
 extern "C" {
     pub fn igTableGetColumnName_TablePtr(
         table: *const ImGuiTable,
-        column_n: cty::c_int,
-    ) -> *const cty::c_char;
+        column_n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igTableGetColumnResizeID(
         table: *mut ImGuiTable,
-        column_n: cty::c_int,
-        instance_no: cty::c_int,
+        column_n: core::ffi::c_int,
+        instance_no: core::ffi::c_int,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn igTableCalcMaxColumnWidth(table: *const ImGuiTable, column_n: cty::c_int) -> f32;
+    pub fn igTableCalcMaxColumnWidth(table: *const ImGuiTable, column_n: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igTableSetColumnWidthAutoSingle(table: *mut ImGuiTable, column_n: cty::c_int);
+    pub fn igTableSetColumnWidthAutoSingle(table: *mut ImGuiTable, column_n: core::ffi::c_int);
 }
 extern "C" {
     pub fn igTableSetColumnWidthAutoAll(table: *mut ImGuiTable);
@@ -11257,8 +11351,10 @@ extern "C" {
     pub fn igTableSettingsAddSettingsHandler();
 }
 extern "C" {
-    pub fn igTableSettingsCreate(id: ImGuiID, columns_count: cty::c_int)
-        -> *mut ImGuiTableSettings;
+    pub fn igTableSettingsCreate(
+        id: ImGuiID,
+        columns_count: core::ffi::c_int,
+    ) -> *mut ImGuiTableSettings;
 }
 extern "C" {
     pub fn igTableSettingsFindByID(id: ImGuiID) -> *mut ImGuiTableSettings;
@@ -11275,7 +11371,7 @@ extern "C" {
 extern "C" {
     pub fn igTabBarFindTabByOrder(
         tab_bar: *mut ImGuiTabBar,
-        order: cty::c_int,
+        order: core::ffi::c_int,
     ) -> *mut ImGuiTabItem;
 }
 extern "C" {
@@ -11287,13 +11383,16 @@ extern "C" {
     pub fn igTabBarGetCurrentTab(tab_bar: *mut ImGuiTabBar) -> *mut ImGuiTabItem;
 }
 extern "C" {
-    pub fn igTabBarGetTabOrder(tab_bar: *mut ImGuiTabBar, tab: *mut ImGuiTabItem) -> cty::c_int;
+    pub fn igTabBarGetTabOrder(
+        tab_bar: *mut ImGuiTabBar,
+        tab: *mut ImGuiTabItem,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igTabBarGetTabName(
         tab_bar: *mut ImGuiTabBar,
         tab: *mut ImGuiTabItem,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igTabBarAddTab(
@@ -11312,13 +11411,13 @@ extern "C" {
     pub fn igTabBarQueueFocus_TabItemPtr(tab_bar: *mut ImGuiTabBar, tab: *mut ImGuiTabItem);
 }
 extern "C" {
-    pub fn igTabBarQueueFocus_Str(tab_bar: *mut ImGuiTabBar, tab_name: *const cty::c_char);
+    pub fn igTabBarQueueFocus_Str(tab_bar: *mut ImGuiTabBar, tab_name: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igTabBarQueueReorder(
         tab_bar: *mut ImGuiTabBar,
         tab: *mut ImGuiTabItem,
-        offset: cty::c_int,
+        offset: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -11334,7 +11433,7 @@ extern "C" {
 extern "C" {
     pub fn igTabItemEx(
         tab_bar: *mut ImGuiTabBar,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
         docked_window: *mut ImGuiWindow,
@@ -11343,7 +11442,7 @@ extern "C" {
 extern "C" {
     pub fn igTabItemCalcSize_Str(
         pOut: *mut ImVec2,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         has_close_button_or_unsaved_marker: bool,
     );
 }
@@ -11364,7 +11463,7 @@ extern "C" {
         bb: ImRect,
         flags: ImGuiTabItemFlags,
         frame_padding: ImVec2,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         tab_id: ImGuiID,
         close_button_id: ImGuiID,
         is_contents_visible: bool,
@@ -11375,16 +11474,16 @@ extern "C" {
 extern "C" {
     pub fn igRenderText(
         pos: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_hash: bool,
     );
 }
 extern "C" {
     pub fn igRenderTextWrapped(
         pos: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
     );
 }
@@ -11392,8 +11491,8 @@ extern "C" {
     pub fn igRenderTextClipped(
         pos_min: ImVec2,
         pos_max: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
         align: ImVec2,
         clip_rect: *const ImRect,
@@ -11404,8 +11503,8 @@ extern "C" {
         draw_list: *mut ImDrawList,
         pos_min: ImVec2,
         pos_max: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
         align: ImVec2,
         clip_rect: *const ImRect,
@@ -11418,8 +11517,8 @@ extern "C" {
         pos_max: ImVec2,
         clip_max_x: f32,
         ellipsis_max_x: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
     );
 }
@@ -11452,9 +11551,9 @@ extern "C" {
 }
 extern "C" {
     pub fn igFindRenderedTextEnd(
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igRenderMouseCursor(
@@ -11520,15 +11619,22 @@ extern "C" {
     ) -> ImDrawFlags;
 }
 extern "C" {
-    pub fn igTextEx(text: *const cty::c_char, text_end: *const cty::c_char, flags: ImGuiTextFlags);
+    pub fn igTextEx(
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        flags: ImGuiTextFlags,
+    );
 }
 extern "C" {
-    pub fn igButtonEx(label: *const cty::c_char, size_arg: ImVec2, flags: ImGuiButtonFlags)
-        -> bool;
+    pub fn igButtonEx(
+        label: *const core::ffi::c_char,
+        size_arg: ImVec2,
+        flags: ImGuiButtonFlags,
+    ) -> bool;
 }
 extern "C" {
     pub fn igArrowButtonEx(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         dir: ImGuiDir,
         size_arg: ImVec2,
         flags: ImGuiButtonFlags,
@@ -11552,21 +11658,21 @@ extern "C" {
 extern "C" {
     pub fn igSeparatorTextEx(
         id: ImGuiID,
-        label: *const cty::c_char,
-        label_end: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        label_end: *const core::ffi::c_char,
         extra_width: f32,
     );
 }
 extern "C" {
     pub fn igCheckboxFlags_S64Ptr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: *mut ImS64,
         flags_value: ImS64,
     ) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_U64Ptr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: *mut ImU64,
         flags_value: ImU64,
     ) -> bool;
@@ -11598,7 +11704,7 @@ extern "C" {
     pub fn igGetWindowScrollbarID(window: *mut ImGuiWindow, axis: ImGuiAxis) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetWindowResizeCornerID(window: *mut ImGuiWindow, n: cty::c_int) -> ImGuiID;
+    pub fn igGetWindowResizeCornerID(window: *mut ImGuiWindow, n: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
     pub fn igGetWindowResizeBorderID(window: *mut ImGuiWindow, dir: ImGuiDir) -> ImGuiID;
@@ -11616,11 +11722,11 @@ extern "C" {
     pub fn igDragBehavior(
         id: ImGuiID,
         data_type: ImGuiDataType,
-        p_v: *mut cty::c_void,
+        p_v: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
@@ -11629,10 +11735,10 @@ extern "C" {
         bb: ImRect,
         id: ImGuiID,
         data_type: ImGuiDataType,
-        p_v: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_v: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
         out_grab_bb: *mut ImRect,
     ) -> bool;
@@ -11655,8 +11761,8 @@ extern "C" {
     pub fn igTreeNodeBehavior(
         id: ImGuiID,
         flags: ImGuiTreeNodeFlags,
-        label: *const cty::c_char,
-        label_end: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        label_end: *const core::ffi::c_char,
     ) -> bool;
 }
 extern "C" {
@@ -11676,59 +11782,59 @@ extern "C" {
 }
 extern "C" {
     pub fn igDataTypeFormatString(
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         data_type: ImGuiDataType,
-        p_data: *const cty::c_void,
-        format: *const cty::c_char,
-    ) -> cty::c_int;
+        p_data: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igDataTypeApplyOp(
         data_type: ImGuiDataType,
-        op: cty::c_int,
-        output: *mut cty::c_void,
-        arg_1: *const cty::c_void,
-        arg_2: *const cty::c_void,
+        op: core::ffi::c_int,
+        output: *mut core::ffi::c_void,
+        arg_1: *const core::ffi::c_void,
+        arg_2: *const core::ffi::c_void,
     );
 }
 extern "C" {
     pub fn igDataTypeApplyFromText(
-        buf: *const cty::c_char,
+        buf: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        format: *const cty::c_char,
-        p_data_when_empty: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        format: *const core::ffi::c_char,
+        p_data_when_empty: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igDataTypeCompare(
         data_type: ImGuiDataType,
-        arg_1: *const cty::c_void,
-        arg_2: *const cty::c_void,
-    ) -> cty::c_int;
+        arg_1: *const core::ffi::c_void,
+        arg_2: *const core::ffi::c_void,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igDataTypeClamp(
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
-    pub fn igDataTypeIsZero(data_type: ImGuiDataType, p_data: *const cty::c_void) -> bool;
+    pub fn igDataTypeIsZero(data_type: ImGuiDataType, p_data: *const core::ffi::c_void) -> bool;
 }
 extern "C" {
     pub fn igInputTextEx(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         size_arg: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
@@ -11738,9 +11844,9 @@ extern "C" {
     pub fn igTempInputText(
         bb: ImRect,
         id: ImGuiID,
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
@@ -11748,12 +11854,12 @@ extern "C" {
     pub fn igTempInputScalar(
         bb: ImRect,
         id: ImGuiID,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        format: *const cty::c_char,
-        p_clamp_min: *const cty::c_void,
-        p_clamp_max: *const cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        format: *const core::ffi::c_char,
+        p_clamp_min: *const core::ffi::c_void,
+        p_clamp_max: *const core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
@@ -11763,10 +11869,14 @@ extern "C" {
     pub fn igGetInputTextState(id: ImGuiID) -> *mut ImGuiInputTextState;
 }
 extern "C" {
-    pub fn igSetNextItemRefVal(data_type: ImGuiDataType, p_data: *mut cty::c_void);
+    pub fn igSetNextItemRefVal(data_type: ImGuiDataType, p_data: *mut core::ffi::c_void);
 }
 extern "C" {
-    pub fn igColorTooltip(text: *const cty::c_char, col: *const f32, flags: ImGuiColorEditFlags);
+    pub fn igColorTooltip(
+        text: *const core::ffi::c_char,
+        col: *const f32,
+        flags: ImGuiColorEditFlags,
+    );
 }
 extern "C" {
     pub fn igColorEditOptionsPopup(col: *const f32, flags: ImGuiColorEditFlags);
@@ -11777,24 +11887,24 @@ extern "C" {
 extern "C" {
     pub fn igPlotEx(
         plot_type: ImGuiPlotType,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         size_arg: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igShadeVertsLinearColorGradientKeepAlpha(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         gradient_p0: ImVec2,
         gradient_p1: ImVec2,
         col0: ImU32,
@@ -11804,8 +11914,8 @@ extern "C" {
 extern "C" {
     pub fn igShadeVertsLinearUV(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         a: ImVec2,
         b: ImVec2,
         uv_a: ImVec2,
@@ -11816,8 +11926,8 @@ extern "C" {
 extern "C" {
     pub fn igShadeVertsTransformPos(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         pivot_in: ImVec2,
         cos_a: f32,
         sin_a: f32,
@@ -11834,7 +11944,7 @@ extern "C" {
     pub fn igGcAwakeTransientWindowBuffers(window: *mut ImGuiWindow);
 }
 extern "C" {
-    pub fn igErrorLog(msg: *const cty::c_char) -> bool;
+    pub fn igErrorLog(msg: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
     pub fn igErrorRecoveryStoreState(state_out: *mut ImGuiErrorRecoveryState);
@@ -11860,8 +11970,8 @@ extern "C" {
 extern "C" {
     pub fn igDebugAllocHook(
         info: *mut ImGuiDebugAllocInfo,
-        frame_count: cty::c_int,
-        ptr: *mut cty::c_void,
+        frame_count: core::ffi::c_int,
+        ptr: *mut core::ffi::c_void,
         size: usize,
     );
 }
@@ -11876,8 +11986,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igDebugTextUnformattedWithLocateItem(
-        line_begin: *const cty::c_char,
-        line_end: *const cty::c_char,
+        line_begin: *const core::ffi::c_char,
+        line_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -11894,14 +12004,14 @@ extern "C" {
 }
 extern "C" {
     pub fn igDebugBreakButton(
-        label: *const cty::c_char,
-        description_of_location: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        description_of_location: *const core::ffi::c_char,
     ) -> bool;
 }
 extern "C" {
     pub fn igDebugBreakButtonTooltip(
         keyboard_only: bool,
-        description_of_location: *const cty::c_char,
+        description_of_location: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -11911,22 +12021,22 @@ extern "C" {
     pub fn igDebugHookIdInfo(
         id: ImGuiID,
         data_type: ImGuiDataType,
-        data_id: *const cty::c_void,
-        data_id_end: *const cty::c_void,
+        data_id: *const core::ffi::c_void,
+        data_id_end: *const core::ffi::c_void,
     );
 }
 extern "C" {
     pub fn igDebugNodeColumns(columns: *mut ImGuiOldColumns);
 }
 extern "C" {
-    pub fn igDebugNodeDockNode(node: *mut ImGuiDockNode, label: *const cty::c_char);
+    pub fn igDebugNodeDockNode(node: *mut ImGuiDockNode, label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugNodeDrawList(
         window: *mut ImGuiWindow,
         viewport: *mut ImGuiViewportP,
         draw_list: *const ImDrawList,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -11945,10 +12055,10 @@ extern "C" {
     pub fn igDebugNodeFontGlyph(font: *mut ImFont, glyph: *const ImFontGlyph);
 }
 extern "C" {
-    pub fn igDebugNodeStorage(storage: *mut ImGuiStorage, label: *const cty::c_char);
+    pub fn igDebugNodeStorage(storage: *mut ImGuiStorage, label: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igDebugNodeTabBar(tab_bar: *mut ImGuiTabBar, label: *const cty::c_char);
+    pub fn igDebugNodeTabBar(tab_bar: *mut ImGuiTabBar, label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugNodeTable(table: *mut ImGuiTable);
@@ -11966,18 +12076,21 @@ extern "C" {
     pub fn igDebugNodeMultiSelectState(state: *mut ImGuiMultiSelectState);
 }
 extern "C" {
-    pub fn igDebugNodeWindow(window: *mut ImGuiWindow, label: *const cty::c_char);
+    pub fn igDebugNodeWindow(window: *mut ImGuiWindow, label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugNodeWindowSettings(settings: *mut ImGuiWindowSettings);
 }
 extern "C" {
-    pub fn igDebugNodeWindowsList(windows: *mut ImVector_ImGuiWindowPtr, label: *const cty::c_char);
+    pub fn igDebugNodeWindowsList(
+        windows: *mut ImVector_ImGuiWindowPtr,
+        label: *const core::ffi::c_char,
+    );
 }
 extern "C" {
     pub fn igDebugNodeWindowsListByBeginStackParent(
         windows: *mut *mut ImGuiWindow,
-        windows_size: cty::c_int,
+        windows_size: core::ffi::c_int,
         parent_in_begin_stack: *mut ImGuiWindow,
     );
 }
@@ -11987,8 +12100,8 @@ extern "C" {
 extern "C" {
     pub fn igDebugNodePlatformMonitor(
         monitor: *mut ImGuiPlatformMonitor,
-        label: *const cty::c_char,
-        idx: cty::c_int,
+        label: *const core::ffi::c_char,
+        idx: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -12019,7 +12132,7 @@ extern "C" {
 extern "C" {
     pub fn igImFontAtlasBuildPackCustomRects(
         atlas: *mut ImFontAtlas,
-        stbrp_context_opaque: *mut cty::c_void,
+        stbrp_context_opaque: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -12028,42 +12141,42 @@ extern "C" {
 extern "C" {
     pub fn igImFontAtlasBuildRender8bppRectFromString(
         atlas: *mut ImFontAtlas,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        in_str: *const cty::c_char,
-        in_marker_char: cty::c_char,
-        in_marker_pixel_value: cty::c_uchar,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        in_str: *const core::ffi::c_char,
+        in_marker_char: core::ffi::c_char,
+        in_marker_pixel_value: core::ffi::c_uchar,
     );
 }
 extern "C" {
     pub fn igImFontAtlasBuildRender32bppRectFromString(
         atlas: *mut ImFontAtlas,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        in_str: *const cty::c_char,
-        in_marker_char: cty::c_char,
-        in_marker_pixel_value: cty::c_uint,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        in_str: *const core::ffi::c_char,
+        in_marker_char: core::ffi::c_char,
+        in_marker_pixel_value: core::ffi::c_uint,
     );
 }
 extern "C" {
     pub fn igImFontAtlasBuildMultiplyCalcLookupTable(
-        out_table: *mut cty::c_uchar,
+        out_table: *mut core::ffi::c_uchar,
         in_multiply_factor: f32,
     );
 }
 extern "C" {
     pub fn igImFontAtlasBuildMultiplyRectAlpha8(
-        table: *const cty::c_uchar,
-        pixels: *mut cty::c_uchar,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        stride: cty::c_int,
+        table: *const core::ffi::c_uchar,
+        pixels: *mut core::ffi::c_uchar,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -12072,17 +12185,24 @@ extern "C" {
 extern "C" {
     pub fn ImGuiFreeType_SetAllocatorFunctions(
         alloc_func: ::core::option::Option<
-            unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+            unsafe extern "C" fn(
+                sz: usize,
+                user_data: *mut core::ffi::c_void,
+            ) -> *mut core::ffi::c_void,
         >,
         free_func: ::core::option::Option<
-            unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+            unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
         >,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
-    pub fn igLogText(fmt: *const cty::c_char, ...);
+    pub fn igLogText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_appendf(buffer: *mut ImGuiTextBuffer, fmt: *const cty::c_char, ...);
+    pub fn ImGuiTextBuffer_appendf(
+        buffer: *mut ImGuiTextBuffer,
+        fmt: *const core::ffi::c_char,
+        ...
+    );
 }

--- a/imgui-sys/src/freetype_bindings.rs
+++ b/imgui-sys/src/freetype_bindings.rs
@@ -97,64 +97,64 @@ pub struct ImFontBuilderIO {
 pub struct ImGuiContext {
     _unused: [u8; 0],
 }
-pub type ImGuiID = cty::c_uint;
-pub type ImS8 = cty::c_schar;
-pub type ImU8 = cty::c_uchar;
-pub type ImS16 = cty::c_short;
-pub type ImU16 = cty::c_ushort;
-pub type ImU32 = cty::c_uint;
-pub type ImS64 = cty::c_longlong;
-pub type ImGuiCol = cty::c_int;
-pub type ImGuiCond = cty::c_int;
-pub type ImGuiDataType = cty::c_int;
-pub type ImGuiMouseButton = cty::c_int;
-pub type ImGuiMouseCursor = cty::c_int;
-pub type ImGuiStyleVar = cty::c_int;
-pub type ImGuiTableBgTarget = cty::c_int;
-pub type ImDrawFlags = cty::c_int;
-pub type ImDrawListFlags = cty::c_int;
-pub type ImFontAtlasFlags = cty::c_int;
-pub type ImGuiBackendFlags = cty::c_int;
-pub type ImGuiButtonFlags = cty::c_int;
-pub type ImGuiChildFlags = cty::c_int;
-pub type ImGuiColorEditFlags = cty::c_int;
-pub type ImGuiConfigFlags = cty::c_int;
-pub type ImGuiComboFlags = cty::c_int;
-pub type ImGuiDragDropFlags = cty::c_int;
-pub type ImGuiFocusedFlags = cty::c_int;
-pub type ImGuiHoveredFlags = cty::c_int;
-pub type ImGuiInputFlags = cty::c_int;
-pub type ImGuiInputTextFlags = cty::c_int;
-pub type ImGuiItemFlags = cty::c_int;
-pub type ImGuiKeyChord = cty::c_int;
-pub type ImGuiPopupFlags = cty::c_int;
-pub type ImGuiMultiSelectFlags = cty::c_int;
-pub type ImGuiSelectableFlags = cty::c_int;
-pub type ImGuiSliderFlags = cty::c_int;
-pub type ImGuiTabBarFlags = cty::c_int;
-pub type ImGuiTabItemFlags = cty::c_int;
-pub type ImGuiTableFlags = cty::c_int;
-pub type ImGuiTableColumnFlags = cty::c_int;
-pub type ImGuiTableRowFlags = cty::c_int;
-pub type ImGuiTreeNodeFlags = cty::c_int;
-pub type ImGuiViewportFlags = cty::c_int;
-pub type ImGuiWindowFlags = cty::c_int;
-pub type ImTextureID = *mut cty::c_void;
-pub type ImDrawIdx = cty::c_ushort;
-pub type ImWchar32 = cty::c_uint;
-pub type ImWchar16 = cty::c_ushort;
+pub type ImGuiID = core::ffi::c_uint;
+pub type ImS8 = core::ffi::c_schar;
+pub type ImU8 = core::ffi::c_uchar;
+pub type ImS16 = core::ffi::c_short;
+pub type ImU16 = core::ffi::c_ushort;
+pub type ImU32 = core::ffi::c_uint;
+pub type ImS64 = core::ffi::c_longlong;
+pub type ImGuiCol = core::ffi::c_int;
+pub type ImGuiCond = core::ffi::c_int;
+pub type ImGuiDataType = core::ffi::c_int;
+pub type ImGuiMouseButton = core::ffi::c_int;
+pub type ImGuiMouseCursor = core::ffi::c_int;
+pub type ImGuiStyleVar = core::ffi::c_int;
+pub type ImGuiTableBgTarget = core::ffi::c_int;
+pub type ImDrawFlags = core::ffi::c_int;
+pub type ImDrawListFlags = core::ffi::c_int;
+pub type ImFontAtlasFlags = core::ffi::c_int;
+pub type ImGuiBackendFlags = core::ffi::c_int;
+pub type ImGuiButtonFlags = core::ffi::c_int;
+pub type ImGuiChildFlags = core::ffi::c_int;
+pub type ImGuiColorEditFlags = core::ffi::c_int;
+pub type ImGuiConfigFlags = core::ffi::c_int;
+pub type ImGuiComboFlags = core::ffi::c_int;
+pub type ImGuiDragDropFlags = core::ffi::c_int;
+pub type ImGuiFocusedFlags = core::ffi::c_int;
+pub type ImGuiHoveredFlags = core::ffi::c_int;
+pub type ImGuiInputFlags = core::ffi::c_int;
+pub type ImGuiInputTextFlags = core::ffi::c_int;
+pub type ImGuiItemFlags = core::ffi::c_int;
+pub type ImGuiKeyChord = core::ffi::c_int;
+pub type ImGuiPopupFlags = core::ffi::c_int;
+pub type ImGuiMultiSelectFlags = core::ffi::c_int;
+pub type ImGuiSelectableFlags = core::ffi::c_int;
+pub type ImGuiSliderFlags = core::ffi::c_int;
+pub type ImGuiTabBarFlags = core::ffi::c_int;
+pub type ImGuiTabItemFlags = core::ffi::c_int;
+pub type ImGuiTableFlags = core::ffi::c_int;
+pub type ImGuiTableColumnFlags = core::ffi::c_int;
+pub type ImGuiTableRowFlags = core::ffi::c_int;
+pub type ImGuiTreeNodeFlags = core::ffi::c_int;
+pub type ImGuiViewportFlags = core::ffi::c_int;
+pub type ImGuiWindowFlags = core::ffi::c_int;
+pub type ImTextureID = *mut core::ffi::c_void;
+pub type ImDrawIdx = core::ffi::c_ushort;
+pub type ImWchar32 = core::ffi::c_uint;
+pub type ImWchar16 = core::ffi::c_ushort;
 pub type ImWchar = ImWchar32;
 pub type ImGuiSelectionUserData = ImS64;
 pub type ImGuiInputTextCallback = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> cty::c_int,
+    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> core::ffi::c_int,
 >;
 pub type ImGuiSizeCallback =
     ::core::option::Option<unsafe extern "C" fn(data: *mut ImGuiSizeCallbackData)>;
 pub type ImGuiMemAllocFunc = ::core::option::Option<
-    unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+    unsafe extern "C" fn(sz: usize, user_data: *mut core::ffi::c_void) -> *mut core::ffi::c_void,
 >;
 pub type ImGuiMemFreeFunc = ::core::option::Option<
-    unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+    unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -198,7 +198,7 @@ pub const ImGuiWindowFlags_Tooltip: ImGuiWindowFlags_ = 33554432;
 pub const ImGuiWindowFlags_Popup: ImGuiWindowFlags_ = 67108864;
 pub const ImGuiWindowFlags_Modal: ImGuiWindowFlags_ = 134217728;
 pub const ImGuiWindowFlags_ChildMenu: ImGuiWindowFlags_ = 268435456;
-pub type ImGuiWindowFlags_ = cty::c_uint;
+pub type ImGuiWindowFlags_ = core::ffi::c_uint;
 pub const ImGuiChildFlags_None: ImGuiChildFlags_ = 0;
 pub const ImGuiChildFlags_Borders: ImGuiChildFlags_ = 1;
 pub const ImGuiChildFlags_AlwaysUseWindowPadding: ImGuiChildFlags_ = 2;
@@ -209,7 +209,7 @@ pub const ImGuiChildFlags_AutoResizeY: ImGuiChildFlags_ = 32;
 pub const ImGuiChildFlags_AlwaysAutoResize: ImGuiChildFlags_ = 64;
 pub const ImGuiChildFlags_FrameStyle: ImGuiChildFlags_ = 128;
 pub const ImGuiChildFlags_NavFlattened: ImGuiChildFlags_ = 256;
-pub type ImGuiChildFlags_ = cty::c_uint;
+pub type ImGuiChildFlags_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_None: ImGuiItemFlags_ = 0;
 pub const ImGuiItemFlags_NoTabStop: ImGuiItemFlags_ = 1;
 pub const ImGuiItemFlags_NoNav: ImGuiItemFlags_ = 2;
@@ -217,7 +217,7 @@ pub const ImGuiItemFlags_NoNavDefaultFocus: ImGuiItemFlags_ = 4;
 pub const ImGuiItemFlags_ButtonRepeat: ImGuiItemFlags_ = 8;
 pub const ImGuiItemFlags_AutoClosePopups: ImGuiItemFlags_ = 16;
 pub const ImGuiItemFlags_AllowDuplicateId: ImGuiItemFlags_ = 32;
-pub type ImGuiItemFlags_ = cty::c_uint;
+pub type ImGuiItemFlags_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_None: ImGuiInputTextFlags_ = 0;
 pub const ImGuiInputTextFlags_CharsDecimal: ImGuiInputTextFlags_ = 1;
 pub const ImGuiInputTextFlags_CharsHexadecimal: ImGuiInputTextFlags_ = 2;
@@ -242,7 +242,7 @@ pub const ImGuiInputTextFlags_CallbackAlways: ImGuiInputTextFlags_ = 524288;
 pub const ImGuiInputTextFlags_CallbackCharFilter: ImGuiInputTextFlags_ = 1048576;
 pub const ImGuiInputTextFlags_CallbackResize: ImGuiInputTextFlags_ = 2097152;
 pub const ImGuiInputTextFlags_CallbackEdit: ImGuiInputTextFlags_ = 4194304;
-pub type ImGuiInputTextFlags_ = cty::c_uint;
+pub type ImGuiInputTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_None: ImGuiTreeNodeFlags_ = 0;
 pub const ImGuiTreeNodeFlags_Selected: ImGuiTreeNodeFlags_ = 1;
 pub const ImGuiTreeNodeFlags_Framed: ImGuiTreeNodeFlags_ = 2;
@@ -261,7 +261,7 @@ pub const ImGuiTreeNodeFlags_SpanTextWidth: ImGuiTreeNodeFlags_ = 8192;
 pub const ImGuiTreeNodeFlags_SpanAllColumns: ImGuiTreeNodeFlags_ = 16384;
 pub const ImGuiTreeNodeFlags_NavLeftJumpsBackHere: ImGuiTreeNodeFlags_ = 32768;
 pub const ImGuiTreeNodeFlags_CollapsingHeader: ImGuiTreeNodeFlags_ = 26;
-pub type ImGuiTreeNodeFlags_ = cty::c_uint;
+pub type ImGuiTreeNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiPopupFlags_None: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonLeft: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonRight: ImGuiPopupFlags_ = 1;
@@ -274,7 +274,7 @@ pub const ImGuiPopupFlags_NoOpenOverItems: ImGuiPopupFlags_ = 256;
 pub const ImGuiPopupFlags_AnyPopupId: ImGuiPopupFlags_ = 1024;
 pub const ImGuiPopupFlags_AnyPopupLevel: ImGuiPopupFlags_ = 2048;
 pub const ImGuiPopupFlags_AnyPopup: ImGuiPopupFlags_ = 3072;
-pub type ImGuiPopupFlags_ = cty::c_uint;
+pub type ImGuiPopupFlags_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_None: ImGuiSelectableFlags_ = 0;
 pub const ImGuiSelectableFlags_NoAutoClosePopups: ImGuiSelectableFlags_ = 1;
 pub const ImGuiSelectableFlags_SpanAllColumns: ImGuiSelectableFlags_ = 2;
@@ -282,7 +282,7 @@ pub const ImGuiSelectableFlags_AllowDoubleClick: ImGuiSelectableFlags_ = 4;
 pub const ImGuiSelectableFlags_Disabled: ImGuiSelectableFlags_ = 8;
 pub const ImGuiSelectableFlags_AllowOverlap: ImGuiSelectableFlags_ = 16;
 pub const ImGuiSelectableFlags_Highlight: ImGuiSelectableFlags_ = 32;
-pub type ImGuiSelectableFlags_ = cty::c_uint;
+pub type ImGuiSelectableFlags_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_None: ImGuiComboFlags_ = 0;
 pub const ImGuiComboFlags_PopupAlignLeft: ImGuiComboFlags_ = 1;
 pub const ImGuiComboFlags_HeightSmall: ImGuiComboFlags_ = 2;
@@ -293,7 +293,7 @@ pub const ImGuiComboFlags_NoArrowButton: ImGuiComboFlags_ = 32;
 pub const ImGuiComboFlags_NoPreview: ImGuiComboFlags_ = 64;
 pub const ImGuiComboFlags_WidthFitPreview: ImGuiComboFlags_ = 128;
 pub const ImGuiComboFlags_HeightMask_: ImGuiComboFlags_ = 30;
-pub type ImGuiComboFlags_ = cty::c_uint;
+pub type ImGuiComboFlags_ = core::ffi::c_uint;
 pub const ImGuiTabBarFlags_None: ImGuiTabBarFlags_ = 0;
 pub const ImGuiTabBarFlags_Reorderable: ImGuiTabBarFlags_ = 1;
 pub const ImGuiTabBarFlags_AutoSelectNewTabs: ImGuiTabBarFlags_ = 2;
@@ -306,7 +306,7 @@ pub const ImGuiTabBarFlags_FittingPolicyResizeDown: ImGuiTabBarFlags_ = 128;
 pub const ImGuiTabBarFlags_FittingPolicyScroll: ImGuiTabBarFlags_ = 256;
 pub const ImGuiTabBarFlags_FittingPolicyMask_: ImGuiTabBarFlags_ = 384;
 pub const ImGuiTabBarFlags_FittingPolicyDefault_: ImGuiTabBarFlags_ = 128;
-pub type ImGuiTabBarFlags_ = cty::c_uint;
+pub type ImGuiTabBarFlags_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_None: ImGuiTabItemFlags_ = 0;
 pub const ImGuiTabItemFlags_UnsavedDocument: ImGuiTabItemFlags_ = 1;
 pub const ImGuiTabItemFlags_SetSelected: ImGuiTabItemFlags_ = 2;
@@ -317,14 +317,14 @@ pub const ImGuiTabItemFlags_NoReorder: ImGuiTabItemFlags_ = 32;
 pub const ImGuiTabItemFlags_Leading: ImGuiTabItemFlags_ = 64;
 pub const ImGuiTabItemFlags_Trailing: ImGuiTabItemFlags_ = 128;
 pub const ImGuiTabItemFlags_NoAssumedClosure: ImGuiTabItemFlags_ = 256;
-pub type ImGuiTabItemFlags_ = cty::c_uint;
+pub type ImGuiTabItemFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusedFlags_None: ImGuiFocusedFlags_ = 0;
 pub const ImGuiFocusedFlags_ChildWindows: ImGuiFocusedFlags_ = 1;
 pub const ImGuiFocusedFlags_RootWindow: ImGuiFocusedFlags_ = 2;
 pub const ImGuiFocusedFlags_AnyWindow: ImGuiFocusedFlags_ = 4;
 pub const ImGuiFocusedFlags_NoPopupHierarchy: ImGuiFocusedFlags_ = 8;
 pub const ImGuiFocusedFlags_RootAndChildWindows: ImGuiFocusedFlags_ = 3;
-pub type ImGuiFocusedFlags_ = cty::c_uint;
+pub type ImGuiFocusedFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_None: ImGuiHoveredFlags_ = 0;
 pub const ImGuiHoveredFlags_ChildWindows: ImGuiHoveredFlags_ = 1;
 pub const ImGuiHoveredFlags_RootWindow: ImGuiHoveredFlags_ = 2;
@@ -345,7 +345,7 @@ pub const ImGuiHoveredFlags_DelayNone: ImGuiHoveredFlags_ = 16384;
 pub const ImGuiHoveredFlags_DelayShort: ImGuiHoveredFlags_ = 32768;
 pub const ImGuiHoveredFlags_DelayNormal: ImGuiHoveredFlags_ = 65536;
 pub const ImGuiHoveredFlags_NoSharedDelay: ImGuiHoveredFlags_ = 131072;
-pub type ImGuiHoveredFlags_ = cty::c_uint;
+pub type ImGuiHoveredFlags_ = core::ffi::c_uint;
 pub const ImGuiDragDropFlags_None: ImGuiDragDropFlags_ = 0;
 pub const ImGuiDragDropFlags_SourceNoPreviewTooltip: ImGuiDragDropFlags_ = 1;
 pub const ImGuiDragDropFlags_SourceNoDisableHover: ImGuiDragDropFlags_ = 2;
@@ -359,7 +359,7 @@ pub const ImGuiDragDropFlags_AcceptBeforeDelivery: ImGuiDragDropFlags_ = 1024;
 pub const ImGuiDragDropFlags_AcceptNoDrawDefaultRect: ImGuiDragDropFlags_ = 2048;
 pub const ImGuiDragDropFlags_AcceptNoPreviewTooltip: ImGuiDragDropFlags_ = 4096;
 pub const ImGuiDragDropFlags_AcceptPeekOnly: ImGuiDragDropFlags_ = 3072;
-pub type ImGuiDragDropFlags_ = cty::c_uint;
+pub type ImGuiDragDropFlags_ = core::ffi::c_uint;
 pub const ImGuiDataType_S8: ImGuiDataType_ = 0;
 pub const ImGuiDataType_U8: ImGuiDataType_ = 1;
 pub const ImGuiDataType_S16: ImGuiDataType_ = 2;
@@ -372,18 +372,18 @@ pub const ImGuiDataType_Float: ImGuiDataType_ = 8;
 pub const ImGuiDataType_Double: ImGuiDataType_ = 9;
 pub const ImGuiDataType_Bool: ImGuiDataType_ = 10;
 pub const ImGuiDataType_COUNT: ImGuiDataType_ = 11;
-pub type ImGuiDataType_ = cty::c_uint;
+pub type ImGuiDataType_ = core::ffi::c_uint;
 pub const ImGuiDir_None: ImGuiDir = -1;
 pub const ImGuiDir_Left: ImGuiDir = 0;
 pub const ImGuiDir_Right: ImGuiDir = 1;
 pub const ImGuiDir_Up: ImGuiDir = 2;
 pub const ImGuiDir_Down: ImGuiDir = 3;
 pub const ImGuiDir_COUNT: ImGuiDir = 4;
-pub type ImGuiDir = cty::c_int;
+pub type ImGuiDir = core::ffi::c_int;
 pub const ImGuiSortDirection_None: ImGuiSortDirection = 0;
 pub const ImGuiSortDirection_Ascending: ImGuiSortDirection = 1;
 pub const ImGuiSortDirection_Descending: ImGuiSortDirection = 2;
-pub type ImGuiSortDirection = cty::c_uint;
+pub type ImGuiSortDirection = core::ffi::c_uint;
 pub const ImGuiKey_None: ImGuiKey = 0;
 pub const ImGuiKey_Tab: ImGuiKey = 512;
 pub const ImGuiKey_LeftArrow: ImGuiKey = 513;
@@ -551,7 +551,7 @@ pub const ImGuiKey_NamedKey_END: ImGuiKey = 666;
 pub const ImGuiKey_NamedKey_COUNT: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_SIZE: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_OFFSET: ImGuiKey = 512;
-pub type ImGuiKey = cty::c_uint;
+pub type ImGuiKey = core::ffi::c_uint;
 pub const ImGuiInputFlags_None: ImGuiInputFlags_ = 0;
 pub const ImGuiInputFlags_Repeat: ImGuiInputFlags_ = 1;
 pub const ImGuiInputFlags_RouteActive: ImGuiInputFlags_ = 1024;
@@ -563,7 +563,7 @@ pub const ImGuiInputFlags_RouteOverActive: ImGuiInputFlags_ = 32768;
 pub const ImGuiInputFlags_RouteUnlessBgFocused: ImGuiInputFlags_ = 65536;
 pub const ImGuiInputFlags_RouteFromRootWindow: ImGuiInputFlags_ = 131072;
 pub const ImGuiInputFlags_Tooltip: ImGuiInputFlags_ = 262144;
-pub type ImGuiInputFlags_ = cty::c_uint;
+pub type ImGuiInputFlags_ = core::ffi::c_uint;
 pub const ImGuiConfigFlags_None: ImGuiConfigFlags_ = 0;
 pub const ImGuiConfigFlags_NavEnableKeyboard: ImGuiConfigFlags_ = 1;
 pub const ImGuiConfigFlags_NavEnableGamepad: ImGuiConfigFlags_ = 2;
@@ -574,13 +574,13 @@ pub const ImGuiConfigFlags_NoMouseCursorChange: ImGuiConfigFlags_ = 32;
 pub const ImGuiConfigFlags_NoKeyboard: ImGuiConfigFlags_ = 64;
 pub const ImGuiConfigFlags_IsSRGB: ImGuiConfigFlags_ = 1048576;
 pub const ImGuiConfigFlags_IsTouchScreen: ImGuiConfigFlags_ = 2097152;
-pub type ImGuiConfigFlags_ = cty::c_uint;
+pub type ImGuiConfigFlags_ = core::ffi::c_uint;
 pub const ImGuiBackendFlags_None: ImGuiBackendFlags_ = 0;
 pub const ImGuiBackendFlags_HasGamepad: ImGuiBackendFlags_ = 1;
 pub const ImGuiBackendFlags_HasMouseCursors: ImGuiBackendFlags_ = 2;
 pub const ImGuiBackendFlags_HasSetMousePos: ImGuiBackendFlags_ = 4;
 pub const ImGuiBackendFlags_RendererHasVtxOffset: ImGuiBackendFlags_ = 8;
-pub type ImGuiBackendFlags_ = cty::c_uint;
+pub type ImGuiBackendFlags_ = core::ffi::c_uint;
 pub const ImGuiCol_Text: ImGuiCol_ = 0;
 pub const ImGuiCol_TextDisabled: ImGuiCol_ = 1;
 pub const ImGuiCol_WindowBg: ImGuiCol_ = 2;
@@ -638,7 +638,7 @@ pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 53;
 pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 54;
 pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 55;
 pub const ImGuiCol_COUNT: ImGuiCol_ = 56;
-pub type ImGuiCol_ = cty::c_uint;
+pub type ImGuiCol_ = core::ffi::c_uint;
 pub const ImGuiStyleVar_Alpha: ImGuiStyleVar_ = 0;
 pub const ImGuiStyleVar_DisabledAlpha: ImGuiStyleVar_ = 1;
 pub const ImGuiStyleVar_WindowPadding: ImGuiStyleVar_ = 2;
@@ -673,13 +673,13 @@ pub const ImGuiStyleVar_SeparatorTextBorderSize: ImGuiStyleVar_ = 30;
 pub const ImGuiStyleVar_SeparatorTextAlign: ImGuiStyleVar_ = 31;
 pub const ImGuiStyleVar_SeparatorTextPadding: ImGuiStyleVar_ = 32;
 pub const ImGuiStyleVar_COUNT: ImGuiStyleVar_ = 33;
-pub type ImGuiStyleVar_ = cty::c_uint;
+pub type ImGuiStyleVar_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_None: ImGuiButtonFlags_ = 0;
 pub const ImGuiButtonFlags_MouseButtonLeft: ImGuiButtonFlags_ = 1;
 pub const ImGuiButtonFlags_MouseButtonRight: ImGuiButtonFlags_ = 2;
 pub const ImGuiButtonFlags_MouseButtonMiddle: ImGuiButtonFlags_ = 4;
 pub const ImGuiButtonFlags_MouseButtonMask_: ImGuiButtonFlags_ = 7;
-pub type ImGuiButtonFlags_ = cty::c_uint;
+pub type ImGuiButtonFlags_ = core::ffi::c_uint;
 pub const ImGuiColorEditFlags_None: ImGuiColorEditFlags_ = 0;
 pub const ImGuiColorEditFlags_NoAlpha: ImGuiColorEditFlags_ = 2;
 pub const ImGuiColorEditFlags_NoPicker: ImGuiColorEditFlags_ = 4;
@@ -709,7 +709,7 @@ pub const ImGuiColorEditFlags_DisplayMask_: ImGuiColorEditFlags_ = 7340032;
 pub const ImGuiColorEditFlags_DataTypeMask_: ImGuiColorEditFlags_ = 25165824;
 pub const ImGuiColorEditFlags_PickerMask_: ImGuiColorEditFlags_ = 100663296;
 pub const ImGuiColorEditFlags_InputMask_: ImGuiColorEditFlags_ = 402653184;
-pub type ImGuiColorEditFlags_ = cty::c_uint;
+pub type ImGuiColorEditFlags_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_None: ImGuiSliderFlags_ = 0;
 pub const ImGuiSliderFlags_Logarithmic: ImGuiSliderFlags_ = 32;
 pub const ImGuiSliderFlags_NoRoundToFormat: ImGuiSliderFlags_ = 64;
@@ -719,12 +719,12 @@ pub const ImGuiSliderFlags_ClampOnInput: ImGuiSliderFlags_ = 512;
 pub const ImGuiSliderFlags_ClampZeroRange: ImGuiSliderFlags_ = 1024;
 pub const ImGuiSliderFlags_AlwaysClamp: ImGuiSliderFlags_ = 1536;
 pub const ImGuiSliderFlags_InvalidMask_: ImGuiSliderFlags_ = 1879048207;
-pub type ImGuiSliderFlags_ = cty::c_uint;
+pub type ImGuiSliderFlags_ = core::ffi::c_uint;
 pub const ImGuiMouseButton_Left: ImGuiMouseButton_ = 0;
 pub const ImGuiMouseButton_Right: ImGuiMouseButton_ = 1;
 pub const ImGuiMouseButton_Middle: ImGuiMouseButton_ = 2;
 pub const ImGuiMouseButton_COUNT: ImGuiMouseButton_ = 5;
-pub type ImGuiMouseButton_ = cty::c_uint;
+pub type ImGuiMouseButton_ = core::ffi::c_uint;
 pub const ImGuiMouseCursor_None: ImGuiMouseCursor_ = -1;
 pub const ImGuiMouseCursor_Arrow: ImGuiMouseCursor_ = 0;
 pub const ImGuiMouseCursor_TextInput: ImGuiMouseCursor_ = 1;
@@ -736,18 +736,18 @@ pub const ImGuiMouseCursor_ResizeNWSE: ImGuiMouseCursor_ = 6;
 pub const ImGuiMouseCursor_Hand: ImGuiMouseCursor_ = 7;
 pub const ImGuiMouseCursor_NotAllowed: ImGuiMouseCursor_ = 8;
 pub const ImGuiMouseCursor_COUNT: ImGuiMouseCursor_ = 9;
-pub type ImGuiMouseCursor_ = cty::c_int;
+pub type ImGuiMouseCursor_ = core::ffi::c_int;
 pub const ImGuiMouseSource_Mouse: ImGuiMouseSource = 0;
 pub const ImGuiMouseSource_TouchScreen: ImGuiMouseSource = 1;
 pub const ImGuiMouseSource_Pen: ImGuiMouseSource = 2;
 pub const ImGuiMouseSource_COUNT: ImGuiMouseSource = 3;
-pub type ImGuiMouseSource = cty::c_uint;
+pub type ImGuiMouseSource = core::ffi::c_uint;
 pub const ImGuiCond_None: ImGuiCond_ = 0;
 pub const ImGuiCond_Always: ImGuiCond_ = 1;
 pub const ImGuiCond_Once: ImGuiCond_ = 2;
 pub const ImGuiCond_FirstUseEver: ImGuiCond_ = 4;
 pub const ImGuiCond_Appearing: ImGuiCond_ = 8;
-pub type ImGuiCond_ = cty::c_uint;
+pub type ImGuiCond_ = core::ffi::c_uint;
 pub const ImGuiTableFlags_None: ImGuiTableFlags_ = 0;
 pub const ImGuiTableFlags_Resizable: ImGuiTableFlags_ = 1;
 pub const ImGuiTableFlags_Reorderable: ImGuiTableFlags_ = 2;
@@ -785,7 +785,7 @@ pub const ImGuiTableFlags_SortMulti: ImGuiTableFlags_ = 67108864;
 pub const ImGuiTableFlags_SortTristate: ImGuiTableFlags_ = 134217728;
 pub const ImGuiTableFlags_HighlightHoveredColumn: ImGuiTableFlags_ = 268435456;
 pub const ImGuiTableFlags_SizingMask_: ImGuiTableFlags_ = 57344;
-pub type ImGuiTableFlags_ = cty::c_uint;
+pub type ImGuiTableFlags_ = core::ffi::c_uint;
 pub const ImGuiTableColumnFlags_None: ImGuiTableColumnFlags_ = 0;
 pub const ImGuiTableColumnFlags_Disabled: ImGuiTableColumnFlags_ = 1;
 pub const ImGuiTableColumnFlags_DefaultHide: ImGuiTableColumnFlags_ = 2;
@@ -814,20 +814,20 @@ pub const ImGuiTableColumnFlags_WidthMask_: ImGuiTableColumnFlags_ = 24;
 pub const ImGuiTableColumnFlags_IndentMask_: ImGuiTableColumnFlags_ = 196608;
 pub const ImGuiTableColumnFlags_StatusMask_: ImGuiTableColumnFlags_ = 251658240;
 pub const ImGuiTableColumnFlags_NoDirectResize_: ImGuiTableColumnFlags_ = 1073741824;
-pub type ImGuiTableColumnFlags_ = cty::c_uint;
+pub type ImGuiTableColumnFlags_ = core::ffi::c_uint;
 pub const ImGuiTableRowFlags_None: ImGuiTableRowFlags_ = 0;
 pub const ImGuiTableRowFlags_Headers: ImGuiTableRowFlags_ = 1;
-pub type ImGuiTableRowFlags_ = cty::c_uint;
+pub type ImGuiTableRowFlags_ = core::ffi::c_uint;
 pub const ImGuiTableBgTarget_None: ImGuiTableBgTarget_ = 0;
 pub const ImGuiTableBgTarget_RowBg0: ImGuiTableBgTarget_ = 1;
 pub const ImGuiTableBgTarget_RowBg1: ImGuiTableBgTarget_ = 2;
 pub const ImGuiTableBgTarget_CellBg: ImGuiTableBgTarget_ = 3;
-pub type ImGuiTableBgTarget_ = cty::c_uint;
+pub type ImGuiTableBgTarget_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTableSortSpecs {
     pub Specs: *const ImGuiTableColumnSortSpecs,
-    pub SpecsCount: cty::c_int,
+    pub SpecsCount: core::ffi::c_int,
     pub SpecsDirty: bool,
 }
 impl Default for ImGuiTableSortSpecs {
@@ -933,8 +933,8 @@ pub struct ImGuiKeyData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImWchar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImWchar,
 }
 impl Default for ImVector_ImWchar {
@@ -954,9 +954,9 @@ pub struct ImGuiIO {
     pub DisplaySize: ImVec2,
     pub DeltaTime: f32,
     pub IniSavingRate: f32,
-    pub IniFilename: *const cty::c_char,
-    pub LogFilename: *const cty::c_char,
-    pub UserData: *mut cty::c_void,
+    pub IniFilename: *const core::ffi::c_char,
+    pub LogFilename: *const core::ffi::c_char,
+    pub UserData: *mut core::ffi::c_void,
     pub Fonts: *mut ImFontAtlas,
     pub FontGlobalScale: f32,
     pub FontAllowUserScaling: bool,
@@ -988,11 +988,11 @@ pub struct ImGuiIO {
     pub ConfigDebugBeginReturnValueLoop: bool,
     pub ConfigDebugIgnoreFocusLoss: bool,
     pub ConfigDebugIniSettings: bool,
-    pub BackendPlatformName: *const cty::c_char,
-    pub BackendRendererName: *const cty::c_char,
-    pub BackendPlatformUserData: *mut cty::c_void,
-    pub BackendRendererUserData: *mut cty::c_void,
-    pub BackendLanguageUserData: *mut cty::c_void,
+    pub BackendPlatformName: *const core::ffi::c_char,
+    pub BackendRendererName: *const core::ffi::c_char,
+    pub BackendPlatformUserData: *mut core::ffi::c_void,
+    pub BackendRendererUserData: *mut core::ffi::c_void,
+    pub BackendLanguageUserData: *mut core::ffi::c_void,
     pub WantCaptureMouse: bool,
     pub WantCaptureKeyboard: bool,
     pub WantTextInput: bool,
@@ -1001,10 +1001,10 @@ pub struct ImGuiIO {
     pub NavActive: bool,
     pub NavVisible: bool,
     pub Framerate: f32,
-    pub MetricsRenderVertices: cty::c_int,
-    pub MetricsRenderIndices: cty::c_int,
-    pub MetricsRenderWindows: cty::c_int,
-    pub MetricsActiveWindows: cty::c_int,
+    pub MetricsRenderVertices: core::ffi::c_int,
+    pub MetricsRenderIndices: core::ffi::c_int,
+    pub MetricsRenderWindows: core::ffi::c_int,
+    pub MetricsActiveWindows: core::ffi::c_int,
     pub MouseDelta: ImVec2,
     pub Ctx: *mut ImGuiContext,
     pub MousePos: ImVec2,
@@ -1057,16 +1057,16 @@ pub struct ImGuiInputTextCallbackData {
     pub Ctx: *mut ImGuiContext,
     pub EventFlag: ImGuiInputTextFlags,
     pub Flags: ImGuiInputTextFlags,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub EventChar: ImWchar,
     pub EventKey: ImGuiKey,
-    pub Buf: *mut cty::c_char,
-    pub BufTextLen: cty::c_int,
-    pub BufSize: cty::c_int,
+    pub Buf: *mut core::ffi::c_char,
+    pub BufTextLen: core::ffi::c_int,
+    pub BufSize: core::ffi::c_int,
     pub BufDirty: bool,
-    pub CursorPos: cty::c_int,
-    pub SelectionStart: cty::c_int,
-    pub SelectionEnd: cty::c_int,
+    pub CursorPos: core::ffi::c_int,
+    pub SelectionStart: core::ffi::c_int,
+    pub SelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextCallbackData {
     fn default() -> Self {
@@ -1080,7 +1080,7 @@ impl Default for ImGuiInputTextCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiSizeCallbackData {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub Pos: ImVec2,
     pub CurrentSize: ImVec2,
     pub DesiredSize: ImVec2,
@@ -1097,12 +1097,12 @@ impl Default for ImGuiSizeCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPayload {
-    pub Data: *mut cty::c_void,
-    pub DataSize: cty::c_int,
+    pub Data: *mut core::ffi::c_void,
+    pub DataSize: core::ffi::c_int,
     pub SourceId: ImGuiID,
     pub SourceParentId: ImGuiID,
-    pub DataFrameCount: cty::c_int,
-    pub DataType: [cty::c_char; 33usize],
+    pub DataFrameCount: core::ffi::c_int,
+    pub DataType: [core::ffi::c_char; 33usize],
     pub Preview: bool,
     pub Delivery: bool,
 }
@@ -1118,13 +1118,13 @@ impl Default for ImGuiPayload {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiOnceUponAFrame {
-    pub RefFrame: cty::c_int,
+    pub RefFrame: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextRange {
-    pub b: *const cty::c_char,
-    pub e: *const cty::c_char,
+    pub b: *const core::ffi::c_char,
+    pub e: *const core::ffi::c_char,
 }
 impl Default for ImGuiTextRange {
     fn default() -> Self {
@@ -1138,8 +1138,8 @@ impl Default for ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTextRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTextRange,
 }
 impl Default for ImVector_ImGuiTextRange {
@@ -1154,9 +1154,9 @@ impl Default for ImVector_ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextFilter {
-    pub InputBuf: [cty::c_char; 256usize],
+    pub InputBuf: [core::ffi::c_char; 256usize],
     pub Filters: ImVector_ImGuiTextRange,
-    pub CountGrep: cty::c_int,
+    pub CountGrep: core::ffi::c_int,
 }
 impl Default for ImGuiTextFilter {
     fn default() -> Self {
@@ -1170,9 +1170,9 @@ impl Default for ImGuiTextFilter {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_char,
 }
 impl Default for ImVector_char {
     fn default() -> Self {
@@ -1206,9 +1206,9 @@ pub struct ImGuiStoragePair {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStoragePair__bindgen_ty_1 {
-    pub val_i: cty::c_int,
+    pub val_i: core::ffi::c_int,
     pub val_f: f32,
-    pub val_p: *mut cty::c_void,
+    pub val_p: *mut core::ffi::c_void,
 }
 impl Default for ImGuiStoragePair__bindgen_ty_1 {
     fn default() -> Self {
@@ -1245,8 +1245,8 @@ impl ::core::fmt::Debug for ImGuiStoragePair {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStoragePair {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStoragePair,
 }
 impl Default for ImVector_ImGuiStoragePair {
@@ -1276,13 +1276,13 @@ impl Default for ImGuiStorage {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiListClipper {
     pub Ctx: *mut ImGuiContext,
-    pub DisplayStart: cty::c_int,
-    pub DisplayEnd: cty::c_int,
-    pub ItemsCount: cty::c_int,
+    pub DisplayStart: core::ffi::c_int,
+    pub DisplayEnd: core::ffi::c_int,
+    pub ItemsCount: core::ffi::c_int,
     pub ItemsHeight: f32,
     pub StartPosY: f32,
     pub StartSeekOffsetY: f64,
-    pub TempData: *mut cty::c_void,
+    pub TempData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiListClipper {
     fn default() -> Self {
@@ -1315,12 +1315,12 @@ pub const ImGuiMultiSelectFlags_ScopeRect: ImGuiMultiSelectFlags_ = 4096;
 pub const ImGuiMultiSelectFlags_SelectOnClick: ImGuiMultiSelectFlags_ = 8192;
 pub const ImGuiMultiSelectFlags_SelectOnClickRelease: ImGuiMultiSelectFlags_ = 16384;
 pub const ImGuiMultiSelectFlags_NavWrapX: ImGuiMultiSelectFlags_ = 65536;
-pub type ImGuiMultiSelectFlags_ = cty::c_uint;
+pub type ImGuiMultiSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSelectionRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSelectionRequest,
 }
 impl Default for ImVector_ImGuiSelectionRequest {
@@ -1340,7 +1340,7 @@ pub struct ImGuiMultiSelectIO {
     pub NavIdItem: ImGuiSelectionUserData,
     pub NavIdSelected: bool,
     pub RangeSrcReset: bool,
-    pub ItemsCount: cty::c_int,
+    pub ItemsCount: core::ffi::c_int,
 }
 impl Default for ImGuiMultiSelectIO {
     fn default() -> Self {
@@ -1354,7 +1354,7 @@ impl Default for ImGuiMultiSelectIO {
 pub const ImGuiSelectionRequestType_None: ImGuiSelectionRequestType = 0;
 pub const ImGuiSelectionRequestType_SetAll: ImGuiSelectionRequestType = 1;
 pub const ImGuiSelectionRequestType_SetRange: ImGuiSelectionRequestType = 2;
-pub type ImGuiSelectionRequestType = cty::c_uint;
+pub type ImGuiSelectionRequestType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionRequest {
@@ -1376,13 +1376,16 @@ impl Default for ImGuiSelectionRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionBasicStorage {
-    pub Size: cty::c_int,
+    pub Size: core::ffi::c_int,
     pub PreserveOrder: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterIndexToStorageId: ::core::option::Option<
-        unsafe extern "C" fn(self_: *mut ImGuiSelectionBasicStorage, idx: cty::c_int) -> ImGuiID,
+        unsafe extern "C" fn(
+            self_: *mut ImGuiSelectionBasicStorage,
+            idx: core::ffi::c_int,
+        ) -> ImGuiID,
     >,
-    pub _SelectionOrder: cty::c_int,
+    pub _SelectionOrder: core::ffi::c_int,
     pub _Storage: ImGuiStorage,
 }
 impl Default for ImGuiSelectionBasicStorage {
@@ -1397,11 +1400,11 @@ impl Default for ImGuiSelectionBasicStorage {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionExternalStorage {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterSetItemSelected: ::core::option::Option<
         unsafe extern "C" fn(
             self_: *mut ImGuiSelectionExternalStorage,
-            idx: cty::c_int,
+            idx: core::ffi::c_int,
             selected: bool,
         ),
     >,
@@ -1423,11 +1426,11 @@ pub type ImDrawCallback = ::core::option::Option<
 pub struct ImDrawCmd {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
-    pub IdxOffset: cty::c_uint,
-    pub ElemCount: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
+    pub IdxOffset: core::ffi::c_uint,
+    pub ElemCount: core::ffi::c_uint,
     pub UserCallback: ImDrawCallback,
-    pub UserCallbackData: *mut cty::c_void,
+    pub UserCallbackData: *mut core::ffi::c_void,
 }
 impl Default for ImDrawCmd {
     fn default() -> Self {
@@ -1450,7 +1453,7 @@ pub struct ImDrawVert {
 pub struct ImDrawCmdHeader {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
 }
 impl Default for ImDrawCmdHeader {
     fn default() -> Self {
@@ -1464,8 +1467,8 @@ impl Default for ImDrawCmdHeader {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawCmd {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawCmd,
 }
 impl Default for ImVector_ImDrawCmd {
@@ -1480,8 +1483,8 @@ impl Default for ImVector_ImDrawCmd {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawIdx {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawIdx,
 }
 impl Default for ImVector_ImDrawIdx {
@@ -1511,8 +1514,8 @@ impl Default for ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawChannel {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawChannel,
 }
 impl Default for ImVector_ImDrawChannel {
@@ -1527,8 +1530,8 @@ impl Default for ImVector_ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImDrawListSplitter {
-    pub _Current: cty::c_int,
-    pub _Count: cty::c_int,
+    pub _Current: core::ffi::c_int,
+    pub _Count: core::ffi::c_int,
     pub _Channels: ImVector_ImDrawChannel,
 }
 impl Default for ImDrawListSplitter {
@@ -1554,18 +1557,18 @@ pub const ImDrawFlags_RoundCornersRight: ImDrawFlags_ = 160;
 pub const ImDrawFlags_RoundCornersAll: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersDefault_: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersMask_: ImDrawFlags_ = 496;
-pub type ImDrawFlags_ = cty::c_uint;
+pub type ImDrawFlags_ = core::ffi::c_uint;
 pub const ImDrawListFlags_None: ImDrawListFlags_ = 0;
 pub const ImDrawListFlags_AntiAliasedLines: ImDrawListFlags_ = 1;
 pub const ImDrawListFlags_AntiAliasedLinesUseTex: ImDrawListFlags_ = 2;
 pub const ImDrawListFlags_AntiAliasedFill: ImDrawListFlags_ = 4;
 pub const ImDrawListFlags_AllowVtxOffset: ImDrawListFlags_ = 8;
-pub type ImDrawListFlags_ = cty::c_uint;
+pub type ImDrawListFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawVert {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawVert,
 }
 impl Default for ImVector_ImDrawVert {
@@ -1580,8 +1583,8 @@ impl Default for ImVector_ImDrawVert {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec2 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec2,
 }
 impl Default for ImVector_ImVec2 {
@@ -1596,8 +1599,8 @@ impl Default for ImVector_ImVec2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec4 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec4,
 }
 impl Default for ImVector_ImVec4 {
@@ -1612,8 +1615,8 @@ impl Default for ImVector_ImVec4 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImTextureID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImTextureID,
 }
 impl Default for ImVector_ImTextureID {
@@ -1632,7 +1635,7 @@ pub struct ImDrawList {
     pub IdxBuffer: ImVector_ImDrawIdx,
     pub VtxBuffer: ImVector_ImDrawVert,
     pub Flags: ImDrawListFlags,
-    pub _VtxCurrentIdx: cty::c_uint,
+    pub _VtxCurrentIdx: core::ffi::c_uint,
     pub _Data: *mut ImDrawListSharedData,
     pub _VtxWritePtr: *mut ImDrawVert,
     pub _IdxWritePtr: *mut ImDrawIdx,
@@ -1642,7 +1645,7 @@ pub struct ImDrawList {
     pub _ClipRectStack: ImVector_ImVec4,
     pub _TextureIdStack: ImVector_ImTextureID,
     pub _FringeScale: f32,
-    pub _OwnerName: *const cty::c_char,
+    pub _OwnerName: *const core::ffi::c_char,
 }
 impl Default for ImDrawList {
     fn default() -> Self {
@@ -1656,8 +1659,8 @@ impl Default for ImDrawList {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawListPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImDrawList,
 }
 impl Default for ImVector_ImDrawListPtr {
@@ -1673,9 +1676,9 @@ impl Default for ImVector_ImDrawListPtr {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImDrawData {
     pub Valid: bool,
-    pub CmdListsCount: cty::c_int,
-    pub TotalIdxCount: cty::c_int,
-    pub TotalVtxCount: cty::c_int,
+    pub CmdListsCount: core::ffi::c_int,
+    pub TotalIdxCount: core::ffi::c_int,
+    pub TotalVtxCount: core::ffi::c_int,
     pub CmdLists: ImVector_ImDrawListPtr,
     pub DisplayPos: ImVec2,
     pub DisplaySize: ImVec2,
@@ -1694,13 +1697,13 @@ impl Default for ImDrawData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontConfig {
-    pub FontData: *mut cty::c_void,
-    pub FontDataSize: cty::c_int,
+    pub FontData: *mut core::ffi::c_void,
+    pub FontDataSize: core::ffi::c_int,
     pub FontDataOwnedByAtlas: bool,
-    pub FontNo: cty::c_int,
+    pub FontNo: core::ffi::c_int,
     pub SizePixels: f32,
-    pub OversampleH: cty::c_int,
-    pub OversampleV: cty::c_int,
+    pub OversampleH: core::ffi::c_int,
+    pub OversampleV: core::ffi::c_int,
     pub PixelSnapH: bool,
     pub GlyphExtraSpacing: ImVec2,
     pub GlyphOffset: ImVec2,
@@ -1708,11 +1711,11 @@ pub struct ImFontConfig {
     pub GlyphMinAdvanceX: f32,
     pub GlyphMaxAdvanceX: f32,
     pub MergeMode: bool,
-    pub FontBuilderFlags: cty::c_uint,
+    pub FontBuilderFlags: core::ffi::c_uint,
     pub RasterizerMultiply: f32,
     pub RasterizerDensity: f32,
     pub EllipsisChar: ImWchar,
-    pub Name: [cty::c_char; 40usize],
+    pub Name: [core::ffi::c_char; 40usize],
     pub DstFont: *mut ImFont,
 }
 impl Default for ImFontConfig {
@@ -1741,33 +1744,33 @@ pub struct ImFontGlyph {
 }
 impl ImFontGlyph {
     #[inline]
-    pub fn Colored(&self) -> cty::c_uint {
+    pub fn Colored(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Colored(&mut self, val: cty::c_uint) {
+    pub fn set_Colored(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Visible(&self) -> cty::c_uint {
+    pub fn Visible(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Visible(&mut self, val: cty::c_uint) {
+    pub fn set_Visible(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(1usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Codepoint(&self) -> cty::c_uint {
+    pub fn Codepoint(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
     }
     #[inline]
-    pub fn set_Codepoint(&mut self, val: cty::c_uint) {
+    pub fn set_Codepoint(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(2usize, 30u8, val as u64)
@@ -1775,9 +1778,9 @@ impl ImFontGlyph {
     }
     #[inline]
     pub fn new_bitfield_1(
-        Colored: cty::c_uint,
-        Visible: cty::c_uint,
-        Codepoint: cty::c_uint,
+        Colored: core::ffi::c_uint,
+        Visible: core::ffi::c_uint,
+        Codepoint: core::ffi::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1798,8 +1801,8 @@ impl ImFontGlyph {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImU32 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImU32,
 }
 impl Default for ImVector_ImU32 {
@@ -1828,11 +1831,11 @@ impl Default for ImFontGlyphRangesBuilder {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontAtlasCustomRect {
-    pub Width: cty::c_ushort,
-    pub Height: cty::c_ushort,
-    pub X: cty::c_ushort,
-    pub Y: cty::c_ushort,
-    pub GlyphID: cty::c_uint,
+    pub Width: core::ffi::c_ushort,
+    pub Height: core::ffi::c_ushort,
+    pub X: core::ffi::c_ushort,
+    pub Y: core::ffi::c_ushort,
+    pub GlyphID: core::ffi::c_uint,
     pub GlyphAdvanceX: f32,
     pub GlyphOffset: ImVec2,
     pub Font: *mut ImFont,
@@ -1850,12 +1853,12 @@ pub const ImFontAtlasFlags_None: ImFontAtlasFlags_ = 0;
 pub const ImFontAtlasFlags_NoPowerOfTwoHeight: ImFontAtlasFlags_ = 1;
 pub const ImFontAtlasFlags_NoMouseCursors: ImFontAtlasFlags_ = 2;
 pub const ImFontAtlasFlags_NoBakedLines: ImFontAtlasFlags_ = 4;
-pub type ImFontAtlasFlags_ = cty::c_uint;
+pub type ImFontAtlasFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImFont,
 }
 impl Default for ImVector_ImFontPtr {
@@ -1870,8 +1873,8 @@ impl Default for ImVector_ImFontPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontAtlasCustomRect {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontAtlasCustomRect,
 }
 impl Default for ImVector_ImFontAtlasCustomRect {
@@ -1886,8 +1889,8 @@ impl Default for ImVector_ImFontAtlasCustomRect {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontConfig {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontConfig,
 }
 impl Default for ImVector_ImFontConfig {
@@ -1904,16 +1907,16 @@ impl Default for ImVector_ImFontConfig {
 pub struct ImFontAtlas {
     pub Flags: ImFontAtlasFlags,
     pub TexID: ImTextureID,
-    pub TexDesiredWidth: cty::c_int,
-    pub TexGlyphPadding: cty::c_int,
+    pub TexDesiredWidth: core::ffi::c_int,
+    pub TexGlyphPadding: core::ffi::c_int,
     pub Locked: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub TexReady: bool,
     pub TexPixelsUseColors: bool,
-    pub TexPixelsAlpha8: *mut cty::c_uchar,
-    pub TexPixelsRGBA32: *mut cty::c_uint,
-    pub TexWidth: cty::c_int,
-    pub TexHeight: cty::c_int,
+    pub TexPixelsAlpha8: *mut core::ffi::c_uchar,
+    pub TexPixelsRGBA32: *mut core::ffi::c_uint,
+    pub TexWidth: core::ffi::c_int,
+    pub TexHeight: core::ffi::c_int,
     pub TexUvScale: ImVec2,
     pub TexUvWhitePixel: ImVec2,
     pub Fonts: ImVector_ImFontPtr,
@@ -1921,9 +1924,9 @@ pub struct ImFontAtlas {
     pub ConfigData: ImVector_ImFontConfig,
     pub TexUvLines: [ImVec4; 64usize],
     pub FontBuilderIO: *const ImFontBuilderIO,
-    pub FontBuilderFlags: cty::c_uint,
-    pub PackIdMouseCursors: cty::c_int,
-    pub PackIdLines: cty::c_int,
+    pub FontBuilderFlags: core::ffi::c_uint,
+    pub PackIdMouseCursors: core::ffi::c_int,
+    pub PackIdLines: core::ffi::c_int,
 }
 impl Default for ImFontAtlas {
     fn default() -> Self {
@@ -1937,8 +1940,8 @@ impl Default for ImFontAtlas {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_float {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut f32,
 }
 impl Default for ImVector_float {
@@ -1953,8 +1956,8 @@ impl Default for ImVector_float {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontGlyph {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontGlyph,
 }
 impl Default for ImVector_ImFontGlyph {
@@ -1977,17 +1980,17 @@ pub struct ImFont {
     pub FallbackGlyph: *const ImFontGlyph,
     pub ContainerAtlas: *mut ImFontAtlas,
     pub ConfigData: *const ImFontConfig,
-    pub ConfigDataCount: cty::c_short,
+    pub ConfigDataCount: core::ffi::c_short,
     pub FallbackChar: ImWchar,
     pub EllipsisChar: ImWchar,
-    pub EllipsisCharCount: cty::c_short,
+    pub EllipsisCharCount: core::ffi::c_short,
     pub EllipsisWidth: f32,
     pub EllipsisCharStep: f32,
     pub DirtyLookupTables: bool,
     pub Scale: f32,
     pub Ascent: f32,
     pub Descent: f32,
-    pub MetricsTotalSurface: cty::c_int,
+    pub MetricsTotalSurface: core::ffi::c_int,
     pub Used4kPagesMap: [ImU8; 34usize],
 }
 impl Default for ImFont {
@@ -2003,7 +2006,7 @@ pub const ImGuiViewportFlags_None: ImGuiViewportFlags_ = 0;
 pub const ImGuiViewportFlags_IsPlatformWindow: ImGuiViewportFlags_ = 1;
 pub const ImGuiViewportFlags_IsPlatformMonitor: ImGuiViewportFlags_ = 2;
 pub const ImGuiViewportFlags_OwnedByApp: ImGuiViewportFlags_ = 4;
-pub type ImGuiViewportFlags_ = cty::c_uint;
+pub type ImGuiViewportFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiViewport {
@@ -2013,8 +2016,8 @@ pub struct ImGuiViewport {
     pub Size: ImVec2,
     pub WorkPos: ImVec2,
     pub WorkSize: ImVec2,
-    pub PlatformHandle: *mut cty::c_void,
-    pub PlatformHandleRaw: *mut cty::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
+    pub PlatformHandleRaw: *mut core::ffi::c_void,
 }
 impl Default for ImGuiViewport {
     fn default() -> Self {
@@ -2028,16 +2031,17 @@ impl Default for ImGuiViewport {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPlatformIO {
-    pub Platform_GetClipboardTextFn:
-        ::core::option::Option<unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const cty::c_char>,
+    pub Platform_GetClipboardTextFn: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const core::ffi::c_char,
+    >,
     pub Platform_SetClipboardTextFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const cty::c_char),
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const core::ffi::c_char),
     >,
-    pub Platform_ClipboardUserData: *mut cty::c_void,
+    pub Platform_ClipboardUserData: *mut core::ffi::c_void,
     pub Platform_OpenInShellFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const cty::c_char) -> bool,
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const core::ffi::c_char) -> bool,
     >,
-    pub Platform_OpenInShellUserData: *mut cty::c_void,
+    pub Platform_OpenInShellUserData: *mut core::ffi::c_void,
     pub Platform_SetImeDataFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
@@ -2045,7 +2049,7 @@ pub struct ImGuiPlatformIO {
             data: *mut ImGuiPlatformImeData,
         ),
     >,
-    pub Platform_ImeUserData: *mut cty::c_void,
+    pub Platform_ImeUserData: *mut core::ffi::c_void,
     pub Platform_LocaleDecimalPoint: ImWchar,
 }
 impl Default for ImGuiPlatformIO {
@@ -2074,7 +2078,7 @@ pub const ImGuiFreeTypeBuilderFlags_Oblique: ImGuiFreeTypeBuilderFlags = 64;
 pub const ImGuiFreeTypeBuilderFlags_Monochrome: ImGuiFreeTypeBuilderFlags = 128;
 pub const ImGuiFreeTypeBuilderFlags_LoadColor: ImGuiFreeTypeBuilderFlags = 256;
 pub const ImGuiFreeTypeBuilderFlags_Bitmap: ImGuiFreeTypeBuilderFlags = 512;
-pub type ImGuiFreeTypeBuilderFlags = cty::c_uint;
+pub type ImGuiFreeTypeBuilderFlags = core::ffi::c_uint;
 extern "C" {
     pub fn ImVec2_ImVec2_Nil() -> *mut ImVec2;
 }
@@ -2145,16 +2149,16 @@ extern "C" {
     pub fn igShowStyleEditor(ref_: *mut ImGuiStyle);
 }
 extern "C" {
-    pub fn igShowStyleSelector(label: *const cty::c_char) -> bool;
+    pub fn igShowStyleSelector(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igShowFontSelector(label: *const cty::c_char);
+    pub fn igShowFontSelector(label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igShowUserGuide();
 }
 extern "C" {
-    pub fn igGetVersion() -> *const cty::c_char;
+    pub fn igGetVersion() -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igStyleColorsDark(dst: *mut ImGuiStyle);
@@ -2166,14 +2170,18 @@ extern "C" {
     pub fn igStyleColorsClassic(dst: *mut ImGuiStyle);
 }
 extern "C" {
-    pub fn igBegin(name: *const cty::c_char, p_open: *mut bool, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBegin(
+        name: *const core::ffi::c_char,
+        p_open: *mut bool,
+        flags: ImGuiWindowFlags,
+    ) -> bool;
 }
 extern "C" {
     pub fn igEnd();
 }
 extern "C" {
     pub fn igBeginChild_Str(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         child_flags: ImGuiChildFlags,
         window_flags: ImGuiWindowFlags,
@@ -2228,7 +2236,7 @@ extern "C" {
         size_min: ImVec2,
         size_max: ImVec2,
         custom_callback: ImGuiSizeCallback,
-        custom_callback_data: *mut cty::c_void,
+        custom_callback_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -2262,16 +2270,20 @@ extern "C" {
     pub fn igSetWindowFontScale(scale: f32);
 }
 extern "C" {
-    pub fn igSetWindowPos_Str(name: *const cty::c_char, pos: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowPos_Str(name: *const core::ffi::c_char, pos: ImVec2, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igSetWindowSize_Str(name: *const cty::c_char, size: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowSize_Str(name: *const core::ffi::c_char, size: ImVec2, cond: ImGuiCond);
 }
 extern "C" {
-    pub fn igSetWindowCollapsed_Str(name: *const cty::c_char, collapsed: bool, cond: ImGuiCond);
+    pub fn igSetWindowCollapsed_Str(
+        name: *const core::ffi::c_char,
+        collapsed: bool,
+        cond: ImGuiCond,
+    );
 }
 extern "C" {
-    pub fn igSetWindowFocus_Str(name: *const cty::c_char);
+    pub fn igSetWindowFocus_Str(name: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igGetScrollX() -> f32;
@@ -2316,7 +2328,7 @@ extern "C" {
     pub fn igPushStyleColor_Vec4(idx: ImGuiCol, col: ImVec4);
 }
 extern "C" {
-    pub fn igPopStyleColor(count: cty::c_int);
+    pub fn igPopStyleColor(count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushStyleVar_Float(idx: ImGuiStyleVar, val: f32);
@@ -2331,7 +2343,7 @@ extern "C" {
     pub fn igPushStyleVarY(idx: ImGuiStyleVar, val_y: f32);
 }
 extern "C" {
-    pub fn igPopStyleVar(count: cty::c_int);
+    pub fn igPopStyleVar(count: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPushItemFlag(option: ImGuiItemFlags, enabled: bool);
@@ -2451,113 +2463,116 @@ extern "C" {
     pub fn igGetFrameHeightWithSpacing() -> f32;
 }
 extern "C" {
-    pub fn igPushID_Str(str_id: *const cty::c_char);
+    pub fn igPushID_Str(str_id: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igPushID_StrStr(str_id_begin: *const cty::c_char, str_id_end: *const cty::c_char);
+    pub fn igPushID_StrStr(
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
+    );
 }
 extern "C" {
-    pub fn igPushID_Ptr(ptr_id: *const cty::c_void);
+    pub fn igPushID_Ptr(ptr_id: *const core::ffi::c_void);
 }
 extern "C" {
-    pub fn igPushID_Int(int_id: cty::c_int);
+    pub fn igPushID_Int(int_id: core::ffi::c_int);
 }
 extern "C" {
     pub fn igPopID();
 }
 extern "C" {
-    pub fn igGetID_Str(str_id: *const cty::c_char) -> ImGuiID;
+    pub fn igGetID_Str(str_id: *const core::ffi::c_char) -> ImGuiID;
 }
 extern "C" {
     pub fn igGetID_StrStr(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetID_Ptr(ptr_id: *const cty::c_void) -> ImGuiID;
+    pub fn igGetID_Ptr(ptr_id: *const core::ffi::c_void) -> ImGuiID;
 }
 extern "C" {
-    pub fn igGetID_Int(int_id: cty::c_int) -> ImGuiID;
+    pub fn igGetID_Int(int_id: core::ffi::c_int) -> ImGuiID;
 }
 extern "C" {
-    pub fn igTextUnformatted(text: *const cty::c_char, text_end: *const cty::c_char);
+    pub fn igTextUnformatted(text: *const core::ffi::c_char, text_end: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igText(fmt: *const cty::c_char, ...);
+    pub fn igText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextColored(col: ImVec4, fmt: *const cty::c_char, ...);
+    pub fn igTextColored(col: ImVec4, fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextDisabled(fmt: *const cty::c_char, ...);
+    pub fn igTextDisabled(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igTextWrapped(fmt: *const cty::c_char, ...);
+    pub fn igTextWrapped(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igLabelText(label: *const cty::c_char, fmt: *const cty::c_char, ...);
+    pub fn igLabelText(label: *const core::ffi::c_char, fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igBulletText(fmt: *const cty::c_char, ...);
+    pub fn igBulletText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igSeparatorText(label: *const cty::c_char);
+    pub fn igSeparatorText(label: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igButton(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igButton(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 extern "C" {
-    pub fn igSmallButton(label: *const cty::c_char) -> bool;
+    pub fn igSmallButton(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
     pub fn igInvisibleButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         flags: ImGuiButtonFlags,
     ) -> bool;
 }
 extern "C" {
-    pub fn igArrowButton(str_id: *const cty::c_char, dir: ImGuiDir) -> bool;
+    pub fn igArrowButton(str_id: *const core::ffi::c_char, dir: ImGuiDir) -> bool;
 }
 extern "C" {
-    pub fn igCheckbox(label: *const cty::c_char, v: *mut bool) -> bool;
+    pub fn igCheckbox(label: *const core::ffi::c_char, v: *mut bool) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_IntPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_int,
-        flags_value: cty::c_int,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_int,
+        flags_value: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCheckboxFlags_UintPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_uint,
-        flags_value: cty::c_uint,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_uint,
+        flags_value: core::ffi::c_uint,
     ) -> bool;
 }
 extern "C" {
-    pub fn igRadioButton_Bool(label: *const cty::c_char, active: bool) -> bool;
+    pub fn igRadioButton_Bool(label: *const core::ffi::c_char, active: bool) -> bool;
 }
 extern "C" {
     pub fn igRadioButton_IntPtr(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_button: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_button: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
-    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const cty::c_char);
+    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igBullet();
 }
 extern "C" {
-    pub fn igTextLink(label: *const cty::c_char) -> bool;
+    pub fn igTextLink(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igTextLinkOpenURL(label: *const cty::c_char, url: *const cty::c_char);
+    pub fn igTextLinkOpenURL(label: *const core::ffi::c_char, url: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igImage(
@@ -2571,7 +2586,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igImageButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         user_texture_id: ImTextureID,
         image_size: ImVec2,
         uv0: ImVec2,
@@ -2582,8 +2597,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igBeginCombo(
-        label: *const cty::c_char,
-        preview_value: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        preview_value: *const core::ffi::c_char,
         flags: ImGuiComboFlags,
     ) -> bool;
 }
@@ -2592,475 +2607,475 @@ extern "C" {
 }
 extern "C" {
     pub fn igCombo_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCombo_Str(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items_separated_by_zeros: *const cty::c_char,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items_separated_by_zeros: *const core::ffi::c_char,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igCombo_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragFloatRange2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_current_min: *mut f32,
         v_current_max: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragIntRange2(
-        label: *const cty::c_char,
-        v_current_min: *mut cty::c_int,
-        v_current_max: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v_current_min: *mut core::ffi::c_int,
+        v_current_max: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igDragScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderAngle(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_rad: *mut f32,
         v_degrees_min: f32,
         v_degrees_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igSliderScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderInt(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igVSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputText(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputTextMultiline(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         size: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputTextWithHint(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         step: f32,
         step_fast: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        step: cty::c_int,
-        step_fast: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        step: core::ffi::c_int,
+        step_fast: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputDouble(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f64,
         step: f64,
         step_fast: f64,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igInputScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorEdit3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorEdit4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorPicker3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igColorPicker4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
         ref_col: *const f32,
@@ -3068,7 +3083,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igColorButton(
-        desc_id: *const cty::c_char,
+        desc_id: *const core::ffi::c_char,
         col: ImVec4,
         flags: ImGuiColorEditFlags,
         size: ImVec2,
@@ -3078,38 +3093,46 @@ extern "C" {
     pub fn igSetColorEditOptions(flags: ImGuiColorEditFlags);
 }
 extern "C" {
-    pub fn igTreeNode_Str(label: *const cty::c_char) -> bool;
+    pub fn igTreeNode_Str(label: *const core::ffi::c_char) -> bool;
 }
 extern "C" {
-    pub fn igTreeNode_StrStr(str_id: *const cty::c_char, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_StrStr(
+        str_id: *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 extern "C" {
-    pub fn igTreeNode_Ptr(ptr_id: *const cty::c_void, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_Ptr(
+        ptr_id: *const core::ffi::c_void,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 extern "C" {
-    pub fn igTreeNodeEx_Str(label: *const cty::c_char, flags: ImGuiTreeNodeFlags) -> bool;
+    pub fn igTreeNodeEx_Str(label: *const core::ffi::c_char, flags: ImGuiTreeNodeFlags) -> bool;
 }
 extern "C" {
     pub fn igTreeNodeEx_StrStr(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 extern "C" {
     pub fn igTreeNodeEx_Ptr(
-        ptr_id: *const cty::c_void,
+        ptr_id: *const core::ffi::c_void,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 extern "C" {
-    pub fn igTreePush_Str(str_id: *const cty::c_char);
+    pub fn igTreePush_Str(str_id: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igTreePush_Ptr(ptr_id: *const cty::c_void);
+    pub fn igTreePush_Ptr(ptr_id: *const core::ffi::c_void);
 }
 extern "C" {
     pub fn igTreePop();
@@ -3119,13 +3142,13 @@ extern "C" {
 }
 extern "C" {
     pub fn igCollapsingHeader_TreeNodeFlags(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igCollapsingHeader_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_visible: *mut bool,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
@@ -3138,7 +3161,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igSelectable_Bool(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         selected: bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -3146,7 +3169,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igSelectable_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_selected: *mut bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -3155,8 +3178,8 @@ extern "C" {
 extern "C" {
     pub fn igBeginMultiSelect(
         flags: ImGuiMultiSelectFlags,
-        selection_size: cty::c_int,
-        items_count: cty::c_int,
+        selection_size: core::ffi::c_int,
+        items_count: core::ffi::c_int,
     ) -> *mut ImGuiMultiSelectIO;
 }
 extern "C" {
@@ -3169,58 +3192,58 @@ extern "C" {
     pub fn igIsItemToggledSelection() -> bool;
 }
 extern "C" {
-    pub fn igBeginListBox(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igBeginListBox(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 extern "C" {
     pub fn igEndListBox();
 }
 extern "C" {
     pub fn igListBox_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igListBox_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 extern "C" {
     pub fn igPlotLines_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn igPlotLines_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -3228,43 +3251,47 @@ extern "C" {
 }
 extern "C" {
     pub fn igPlotHistogram_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn igPlotHistogram_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
     );
 }
 extern "C" {
-    pub fn igValue_Bool(prefix: *const cty::c_char, b: bool);
+    pub fn igValue_Bool(prefix: *const core::ffi::c_char, b: bool);
 }
 extern "C" {
-    pub fn igValue_Int(prefix: *const cty::c_char, v: cty::c_int);
+    pub fn igValue_Int(prefix: *const core::ffi::c_char, v: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igValue_Uint(prefix: *const cty::c_char, v: cty::c_uint);
+    pub fn igValue_Uint(prefix: *const core::ffi::c_char, v: core::ffi::c_uint);
 }
 extern "C" {
-    pub fn igValue_Float(prefix: *const cty::c_char, v: f32, float_format: *const cty::c_char);
+    pub fn igValue_Float(
+        prefix: *const core::ffi::c_char,
+        v: f32,
+        float_format: *const core::ffi::c_char,
+    );
 }
 extern "C" {
     pub fn igBeginMenuBar() -> bool;
@@ -3279,23 +3306,23 @@ extern "C" {
     pub fn igEndMainMenuBar();
 }
 extern "C" {
-    pub fn igBeginMenu(label: *const cty::c_char, enabled: bool) -> bool;
+    pub fn igBeginMenu(label: *const core::ffi::c_char, enabled: bool) -> bool;
 }
 extern "C" {
     pub fn igEndMenu();
 }
 extern "C" {
     pub fn igMenuItem_Bool(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
 }
 extern "C" {
     pub fn igMenuItem_BoolPtr(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         p_selected: *mut bool,
         enabled: bool,
     ) -> bool;
@@ -3307,20 +3334,20 @@ extern "C" {
     pub fn igEndTooltip();
 }
 extern "C" {
-    pub fn igSetTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetTooltip(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
     pub fn igBeginItemTooltip() -> bool;
 }
 extern "C" {
-    pub fn igSetItemTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetItemTooltip(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn igBeginPopup(str_id: *const cty::c_char, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBeginPopup(str_id: *const core::ffi::c_char, flags: ImGuiWindowFlags) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupModal(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiWindowFlags,
     ) -> bool;
@@ -3329,42 +3356,42 @@ extern "C" {
     pub fn igEndPopup();
 }
 extern "C" {
-    pub fn igOpenPopup_Str(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopup_Str(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
     pub fn igOpenPopup_ID(id: ImGuiID, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
-    pub fn igOpenPopupOnItemClick(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopupOnItemClick(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 extern "C" {
     pub fn igCloseCurrentPopup();
 }
 extern "C" {
     pub fn igBeginPopupContextItem(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupContextWindow(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
     pub fn igBeginPopupContextVoid(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 extern "C" {
-    pub fn igIsPopupOpen(str_id: *const cty::c_char, flags: ImGuiPopupFlags) -> bool;
+    pub fn igIsPopupOpen(str_id: *const core::ffi::c_char, flags: ImGuiPopupFlags) -> bool;
 }
 extern "C" {
     pub fn igBeginTable(
-        str_id: *const cty::c_char,
-        columns: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        columns: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -3380,21 +3407,21 @@ extern "C" {
     pub fn igTableNextColumn() -> bool;
 }
 extern "C" {
-    pub fn igTableSetColumnIndex(column_n: cty::c_int) -> bool;
+    pub fn igTableSetColumnIndex(column_n: core::ffi::c_int) -> bool;
 }
 extern "C" {
     pub fn igTableSetupColumn(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTableColumnFlags,
         init_width_or_weight: f32,
         user_id: ImGuiID,
     );
 }
 extern "C" {
-    pub fn igTableSetupScrollFreeze(cols: cty::c_int, rows: cty::c_int);
+    pub fn igTableSetupScrollFreeze(cols: core::ffi::c_int, rows: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igTableHeader(label: *const cty::c_char);
+    pub fn igTableHeader(label: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igTableHeadersRow();
@@ -3406,62 +3433,62 @@ extern "C" {
     pub fn igTableGetSortSpecs() -> *mut ImGuiTableSortSpecs;
 }
 extern "C" {
-    pub fn igTableGetColumnCount() -> cty::c_int;
+    pub fn igTableGetColumnCount() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetColumnIndex() -> cty::c_int;
+    pub fn igTableGetColumnIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetRowIndex() -> cty::c_int;
+    pub fn igTableGetRowIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableGetColumnName(column_n: cty::c_int) -> *const cty::c_char;
+    pub fn igTableGetColumnName(column_n: core::ffi::c_int) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igTableGetColumnFlags(column_n: cty::c_int) -> ImGuiTableColumnFlags;
+    pub fn igTableGetColumnFlags(column_n: core::ffi::c_int) -> ImGuiTableColumnFlags;
 }
 extern "C" {
-    pub fn igTableSetColumnEnabled(column_n: cty::c_int, v: bool);
+    pub fn igTableSetColumnEnabled(column_n: core::ffi::c_int, v: bool);
 }
 extern "C" {
-    pub fn igTableGetHoveredColumn() -> cty::c_int;
+    pub fn igTableGetHoveredColumn() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: cty::c_int);
+    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igColumns(count: cty::c_int, id: *const cty::c_char, borders: bool);
+    pub fn igColumns(count: core::ffi::c_int, id: *const core::ffi::c_char, borders: bool);
 }
 extern "C" {
     pub fn igNextColumn();
 }
 extern "C" {
-    pub fn igGetColumnIndex() -> cty::c_int;
+    pub fn igGetColumnIndex() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igGetColumnWidth(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnWidth(column_index: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igSetColumnWidth(column_index: cty::c_int, width: f32);
+    pub fn igSetColumnWidth(column_index: core::ffi::c_int, width: f32);
 }
 extern "C" {
-    pub fn igGetColumnOffset(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnOffset(column_index: core::ffi::c_int) -> f32;
 }
 extern "C" {
-    pub fn igSetColumnOffset(column_index: cty::c_int, offset_x: f32);
+    pub fn igSetColumnOffset(column_index: core::ffi::c_int, offset_x: f32);
 }
 extern "C" {
-    pub fn igGetColumnsCount() -> cty::c_int;
+    pub fn igGetColumnsCount() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igBeginTabBar(str_id: *const cty::c_char, flags: ImGuiTabBarFlags) -> bool;
+    pub fn igBeginTabBar(str_id: *const core::ffi::c_char, flags: ImGuiTabBarFlags) -> bool;
 }
 extern "C" {
     pub fn igEndTabBar();
 }
 extern "C" {
     pub fn igBeginTabItem(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
     ) -> bool;
@@ -3470,19 +3497,19 @@ extern "C" {
     pub fn igEndTabItem();
 }
 extern "C" {
-    pub fn igTabItemButton(label: *const cty::c_char, flags: ImGuiTabItemFlags) -> bool;
+    pub fn igTabItemButton(label: *const core::ffi::c_char, flags: ImGuiTabItemFlags) -> bool;
 }
 extern "C" {
-    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const cty::c_char);
+    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLogToTTY(auto_open_depth: cty::c_int);
+    pub fn igLogToTTY(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
-    pub fn igLogToFile(auto_open_depth: cty::c_int, filename: *const cty::c_char);
+    pub fn igLogToFile(auto_open_depth: core::ffi::c_int, filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLogToClipboard(auto_open_depth: cty::c_int);
+    pub fn igLogToClipboard(auto_open_depth: core::ffi::c_int);
 }
 extern "C" {
     pub fn igLogFinish();
@@ -3495,8 +3522,8 @@ extern "C" {
 }
 extern "C" {
     pub fn igSetDragDropPayload(
-        type_: *const cty::c_char,
-        data: *const cty::c_void,
+        type_: *const core::ffi::c_char,
+        data: *const core::ffi::c_void,
         sz: usize,
         cond: ImGuiCond,
     ) -> bool;
@@ -3509,7 +3536,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igAcceptDragDropPayload(
-        type_: *const cty::c_char,
+        type_: *const core::ffi::c_char,
         flags: ImGuiDragDropFlags,
     ) -> *const ImGuiPayload;
 }
@@ -3539,7 +3566,7 @@ extern "C" {
     pub fn igSetItemDefaultFocus();
 }
 extern "C" {
-    pub fn igSetKeyboardFocusHere(offset: cty::c_int);
+    pub fn igSetKeyboardFocusHere(offset: core::ffi::c_int);
 }
 extern "C" {
     pub fn igSetNextItemAllowOverlap();
@@ -3614,13 +3641,13 @@ extern "C" {
     pub fn igGetTime() -> f64;
 }
 extern "C" {
-    pub fn igGetFrameCount() -> cty::c_int;
+    pub fn igGetFrameCount() -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igGetDrawListSharedData() -> *mut ImDrawListSharedData;
 }
 extern "C" {
-    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const cty::c_char;
+    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetStateStorage(storage: *mut ImGuiStorage);
@@ -3631,8 +3658,8 @@ extern "C" {
 extern "C" {
     pub fn igCalcTextSize(
         pOut: *mut ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_double_hash: bool,
         wrap_width: f32,
     );
@@ -3676,10 +3703,10 @@ extern "C" {
     pub fn igIsKeyChordPressed(key_chord: ImGuiKeyChord) -> bool;
 }
 extern "C" {
-    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> cty::c_int;
+    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn igGetKeyName(key: ImGuiKey) -> *const cty::c_char;
+    pub fn igGetKeyName(key: ImGuiKey) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn igSetNextFrameWantCaptureKeyboard(want_capture_keyboard: bool);
@@ -3706,7 +3733,7 @@ extern "C" {
     pub fn igIsMouseDoubleClicked(button: ImGuiMouseButton) -> bool;
 }
 extern "C" {
-    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> cty::c_int;
+    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn igIsMouseHoveringRect(r_min: ImVec2, r_max: ImVec2, clip: bool) -> bool;
@@ -3742,25 +3769,25 @@ extern "C" {
     pub fn igSetNextFrameWantCaptureMouse(want_capture_mouse: bool);
 }
 extern "C" {
-    pub fn igGetClipboardText() -> *const cty::c_char;
+    pub fn igGetClipboardText() -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igSetClipboardText(text: *const cty::c_char);
+    pub fn igSetClipboardText(text: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLoadIniSettingsFromDisk(ini_filename: *const cty::c_char);
+    pub fn igLoadIniSettingsFromDisk(ini_filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igLoadIniSettingsFromMemory(ini_data: *const cty::c_char, ini_size: usize);
+    pub fn igLoadIniSettingsFromMemory(ini_data: *const core::ffi::c_char, ini_size: usize);
 }
 extern "C" {
-    pub fn igSaveIniSettingsToDisk(ini_filename: *const cty::c_char);
+    pub fn igSaveIniSettingsToDisk(ini_filename: *const core::ffi::c_char);
 }
 extern "C" {
-    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const cty::c_char;
+    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn igDebugTextEncoding(text: *const cty::c_char);
+    pub fn igDebugTextEncoding(text: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn igDebugFlashStyleColor(idx: ImGuiCol);
@@ -3770,7 +3797,7 @@ extern "C" {
 }
 extern "C" {
     pub fn igDebugCheckVersionAndDataLayout(
-        version_str: *const cty::c_char,
+        version_str: *const core::ffi::c_char,
         sz_io: usize,
         sz_style: usize,
         sz_vec2: usize,
@@ -3780,27 +3807,27 @@ extern "C" {
     ) -> bool;
 }
 extern "C" {
-    pub fn igDebugLog(fmt: *const cty::c_char, ...);
+    pub fn igDebugLog(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
     pub fn igSetAllocatorFunctions(
         alloc_func: ImGuiMemAllocFunc,
         free_func: ImGuiMemFreeFunc,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
     pub fn igGetAllocatorFunctions(
         p_alloc_func: *mut ImGuiMemAllocFunc,
         p_free_func: *mut ImGuiMemFreeFunc,
-        p_user_data: *mut *mut cty::c_void,
+        p_user_data: *mut *mut core::ffi::c_void,
     );
 }
 extern "C" {
-    pub fn igMemAlloc(size: usize) -> *mut cty::c_void;
+    pub fn igMemAlloc(size: usize) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn igMemFree(ptr: *mut cty::c_void);
+    pub fn igMemFree(ptr: *mut core::ffi::c_void);
 }
 extern "C" {
     pub fn ImGuiTableSortSpecs_ImGuiTableSortSpecs() -> *mut ImGuiTableSortSpecs;
@@ -3833,7 +3860,7 @@ extern "C" {
     pub fn ImGuiIO_AddMousePosEvent(self_: *mut ImGuiIO, x: f32, y: f32);
 }
 extern "C" {
-    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: cty::c_int, down: bool);
+    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: core::ffi::c_int, down: bool);
 }
 extern "C" {
     pub fn ImGuiIO_AddMouseWheelEvent(self_: *mut ImGuiIO, wheel_x: f32, wheel_y: f32);
@@ -3845,21 +3872,21 @@ extern "C" {
     pub fn ImGuiIO_AddFocusEvent(self_: *mut ImGuiIO, focused: bool);
 }
 extern "C" {
-    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: cty::c_uint);
+    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: core::ffi::c_uint);
 }
 extern "C" {
     pub fn ImGuiIO_AddInputCharacterUTF16(self_: *mut ImGuiIO, c: ImWchar16);
 }
 extern "C" {
-    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const cty::c_char);
+    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const core::ffi::c_char);
 }
 extern "C" {
     pub fn ImGuiIO_SetKeyEventNativeData(
         self_: *mut ImGuiIO,
         key: ImGuiKey,
-        native_keycode: cty::c_int,
-        native_scancode: cty::c_int,
-        native_legacy_index: cty::c_int,
+        native_keycode: core::ffi::c_int,
+        native_scancode: core::ffi::c_int,
+        native_legacy_index: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -3889,16 +3916,16 @@ extern "C" {
 extern "C" {
     pub fn ImGuiInputTextCallbackData_DeleteChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        bytes_count: cty::c_int,
+        pos: core::ffi::c_int,
+        bytes_count: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImGuiInputTextCallbackData_InsertChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        pos: core::ffi::c_int,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -3920,7 +3947,10 @@ extern "C" {
     pub fn ImGuiPayload_Clear(self_: *mut ImGuiPayload);
 }
 extern "C" {
-    pub fn ImGuiPayload_IsDataType(self_: *mut ImGuiPayload, type_: *const cty::c_char) -> bool;
+    pub fn ImGuiPayload_IsDataType(
+        self_: *mut ImGuiPayload,
+        type_: *const core::ffi::c_char,
+    ) -> bool;
 }
 extern "C" {
     pub fn ImGuiPayload_IsPreview(self_: *mut ImGuiPayload) -> bool;
@@ -3936,7 +3966,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiTextFilter_ImGuiTextFilter(
-        default_filter: *const cty::c_char,
+        default_filter: *const core::ffi::c_char,
     ) -> *mut ImGuiTextFilter;
 }
 extern "C" {
@@ -3945,15 +3975,15 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_Draw(
         self_: *mut ImGuiTextFilter,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         width: f32,
     ) -> bool;
 }
 extern "C" {
     pub fn ImGuiTextFilter_PassFilter(
         self_: *mut ImGuiTextFilter,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     ) -> bool;
 }
 extern "C" {
@@ -3973,8 +4003,8 @@ extern "C" {
 }
 extern "C" {
     pub fn ImGuiTextRange_ImGuiTextRange_Str(
-        _b: *const cty::c_char,
-        _e: *const cty::c_char,
+        _b: *const core::ffi::c_char,
+        _e: *const core::ffi::c_char,
     ) -> *mut ImGuiTextRange;
 }
 extern "C" {
@@ -3983,7 +4013,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextRange_split(
         self_: *mut ImGuiTextRange,
-        separator: cty::c_char,
+        separator: core::ffi::c_char,
         out: *mut ImVector_ImGuiTextRange,
     );
 }
@@ -3994,13 +4024,13 @@ extern "C" {
     pub fn ImGuiTextBuffer_destroy(self_: *mut ImGuiTextBuffer);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> cty::c_int;
+    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiTextBuffer_empty(self_: *mut ImGuiTextBuffer) -> bool;
@@ -4009,22 +4039,22 @@ extern "C" {
     pub fn ImGuiTextBuffer_clear(self_: *mut ImGuiTextBuffer);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: cty::c_int);
+    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: core::ffi::c_int);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImGuiTextBuffer_append(
         self_: *mut ImGuiTextBuffer,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Int(
         _key: ImGuiID,
-        _val: cty::c_int,
+        _val: core::ffi::c_int,
     ) -> *mut ImGuiStoragePair;
 }
 extern "C" {
@@ -4039,7 +4069,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Ptr(
         _key: ImGuiID,
-        _val: *mut cty::c_void,
+        _val: *mut core::ffi::c_void,
     ) -> *mut ImGuiStoragePair;
 }
 extern "C" {
@@ -4049,11 +4079,11 @@ extern "C" {
     pub fn ImGuiStorage_GetInt(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: cty::c_int);
+    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiStorage_GetBool(self_: *mut ImGuiStorage, key: ImGuiID, default_val: bool) -> bool;
@@ -4068,17 +4098,24 @@ extern "C" {
     pub fn ImGuiStorage_SetFloat(self_: *mut ImGuiStorage, key: ImGuiID, val: f32);
 }
 extern "C" {
-    pub fn ImGuiStorage_GetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID) -> *mut cty::c_void;
+    pub fn ImGuiStorage_GetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+    ) -> *mut core::ffi::c_void;
 }
 extern "C" {
-    pub fn ImGuiStorage_SetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID, val: *mut cty::c_void);
+    pub fn ImGuiStorage_SetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+        val: *mut core::ffi::c_void,
+    );
 }
 extern "C" {
     pub fn ImGuiStorage_GetIntRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> *mut cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> *mut core::ffi::c_int;
 }
 extern "C" {
     pub fn ImGuiStorage_GetBoolRef(
@@ -4098,14 +4135,14 @@ extern "C" {
     pub fn ImGuiStorage_GetVoidPtrRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: *mut cty::c_void,
-    ) -> *mut *mut cty::c_void;
+        default_val: *mut core::ffi::c_void,
+    ) -> *mut *mut core::ffi::c_void;
 }
 extern "C" {
     pub fn ImGuiStorage_BuildSortByKey(self_: *mut ImGuiStorage);
 }
 extern "C" {
-    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: cty::c_int);
+    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImGuiListClipper_ImGuiListClipper() -> *mut ImGuiListClipper;
@@ -4116,7 +4153,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_Begin(
         self_: *mut ImGuiListClipper,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         items_height: f32,
     );
 }
@@ -4129,18 +4166,21 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemByIndex(
         self_: *mut ImGuiListClipper,
-        item_index: cty::c_int,
+        item_index: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemsByIndex(
         self_: *mut ImGuiListClipper,
-        item_begin: cty::c_int,
-        item_end: cty::c_int,
+        item_begin: core::ffi::c_int,
+        item_end: core::ffi::c_int,
     );
 }
 extern "C" {
-    pub fn ImGuiListClipper_SeekCursorForItem(self_: *mut ImGuiListClipper, item_index: cty::c_int);
+    pub fn ImGuiListClipper_SeekCursorForItem(
+        self_: *mut ImGuiListClipper,
+        item_index: core::ffi::c_int,
+    );
 }
 extern "C" {
     pub fn ImColor_ImColor_Nil() -> *mut ImColor;
@@ -4156,10 +4196,10 @@ extern "C" {
 }
 extern "C" {
     pub fn ImColor_ImColor_Int(
-        r: cty::c_int,
-        g: cty::c_int,
-        b: cty::c_int,
-        a: cty::c_int,
+        r: core::ffi::c_int,
+        g: core::ffi::c_int,
+        b: core::ffi::c_int,
+        a: core::ffi::c_int,
     ) -> *mut ImColor;
 }
 extern "C" {
@@ -4208,14 +4248,14 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetNextSelectedItem(
         self_: *mut ImGuiSelectionBasicStorage,
-        opaque_it: *mut *mut cty::c_void,
+        opaque_it: *mut *mut core::ffi::c_void,
         out_id: *mut ImGuiID,
     ) -> bool;
 }
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetStorageIdFromIndex(
         self_: *mut ImGuiSelectionBasicStorage,
-        idx: cty::c_int,
+        idx: core::ffi::c_int,
     ) -> ImGuiID;
 }
 extern "C" {
@@ -4256,7 +4296,7 @@ extern "C" {
     pub fn ImDrawListSplitter_Split(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        count: cty::c_int,
+        count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4266,7 +4306,7 @@ extern "C" {
     pub fn ImDrawListSplitter_SetCurrentChannel(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        channel_idx: cty::c_int,
+        channel_idx: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4388,7 +4428,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4398,7 +4438,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4407,7 +4447,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4417,7 +4457,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4427,7 +4467,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4438,7 +4478,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4446,8 +4486,8 @@ extern "C" {
         self_: *mut ImDrawList,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -4457,8 +4497,8 @@ extern "C" {
         font_size: f32,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip_rect: *const ImVec4,
     );
@@ -4472,7 +4512,7 @@ extern "C" {
         p4: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4483,14 +4523,14 @@ extern "C" {
         p3: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImDrawList_AddPolyline(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
         flags: ImDrawFlags,
         thickness: f32,
@@ -4500,7 +4540,7 @@ extern "C" {
     pub fn ImDrawList_AddConvexPolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -4508,7 +4548,7 @@ extern "C" {
     pub fn ImDrawList_AddConcavePolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -4581,7 +4621,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4589,8 +4629,8 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_of_12: cty::c_int,
-        a_max_of_12: cty::c_int,
+        a_min_of_12: core::ffi::c_int,
+        a_max_of_12: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4601,7 +4641,7 @@ extern "C" {
         rot: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4610,7 +4650,7 @@ extern "C" {
         p2: ImVec2,
         p3: ImVec2,
         p4: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4618,7 +4658,7 @@ extern "C" {
         self_: *mut ImDrawList,
         p2: ImVec2,
         p3: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4634,7 +4674,7 @@ extern "C" {
     pub fn ImDrawList_AddCallback(
         self_: *mut ImDrawList,
         callback: ImDrawCallback,
-        callback_data: *mut cty::c_void,
+        callback_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
@@ -4644,26 +4684,26 @@ extern "C" {
     pub fn ImDrawList_CloneOutput(self_: *mut ImDrawList) -> *mut ImDrawList;
 }
 extern "C" {
-    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: cty::c_int);
+    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImDrawList_ChannelsMerge(self_: *mut ImDrawList);
 }
 extern "C" {
-    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: cty::c_int);
+    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImDrawList_PrimReserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImDrawList_PrimUnreserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4730,16 +4770,16 @@ extern "C" {
     pub fn ImDrawList__CalcCircleAutoSegmentCount(
         self_: *mut ImDrawList,
         radius: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImDrawList__PathArcToFastEx(
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_sample: cty::c_int,
-        a_max_sample: cty::c_int,
-        a_step: cty::c_int,
+        a_min_sample: core::ffi::c_int,
+        a_max_sample: core::ffi::c_int,
+        a_step: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4749,7 +4789,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4797,8 +4837,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontGlyphRangesBuilder_AddText(
         self_: *mut ImFontGlyphRangesBuilder,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 extern "C" {
@@ -4843,7 +4883,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromFileTTF(
         self_: *mut ImFontAtlas,
-        filename: *const cty::c_char,
+        filename: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -4852,8 +4892,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryTTF(
         self_: *mut ImFontAtlas,
-        font_data: *mut cty::c_void,
-        font_data_size: cty::c_int,
+        font_data: *mut core::ffi::c_void,
+        font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -4862,8 +4902,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedTTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data: *const cty::c_void,
-        compressed_font_data_size: cty::c_int,
+        compressed_font_data: *const core::ffi::c_void,
+        compressed_font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -4872,7 +4912,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data_base85: *const cty::c_char,
+        compressed_font_data_base85: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -4896,19 +4936,19 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsAlpha8(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsRGBA32(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 extern "C" {
@@ -4949,25 +4989,25 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectRegular(
         self_: *mut ImFontAtlas,
-        width: cty::c_int,
-        height: cty::c_int,
-    ) -> cty::c_int;
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectFontGlyph(
         self_: *mut ImFontAtlas,
         font: *mut ImFont,
         id: ImWchar,
-        width: cty::c_int,
-        height: cty::c_int,
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
         advance_x: f32,
         offset: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 extern "C" {
     pub fn ImFontAtlas_GetCustomRectByIndex(
         self_: *mut ImFontAtlas,
-        index: cty::c_int,
+        index: core::ffi::c_int,
     ) -> *mut ImFontAtlasCustomRect;
 }
 extern "C" {
@@ -5007,7 +5047,7 @@ extern "C" {
     pub fn ImFont_IsLoaded(self_: *mut ImFont) -> bool;
 }
 extern "C" {
-    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const cty::c_char;
+    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImFont_CalcTextSizeA(
@@ -5016,19 +5056,19 @@ extern "C" {
         size: f32,
         max_width: f32,
         wrap_width: f32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
-        remaining: *mut *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        remaining: *mut *const core::ffi::c_char,
     );
 }
 extern "C" {
     pub fn ImFont_CalcWordWrapPositionA(
         self_: *mut ImFont,
         scale: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 extern "C" {
     pub fn ImFont_RenderChar(
@@ -5048,8 +5088,8 @@ extern "C" {
         pos: ImVec2,
         col: ImU32,
         clip_rect: ImVec4,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip: bool,
     );
@@ -5061,7 +5101,7 @@ extern "C" {
     pub fn ImFont_ClearOutputData(self_: *mut ImFont);
 }
 extern "C" {
-    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: cty::c_int);
+    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: core::ffi::c_int);
 }
 extern "C" {
     pub fn ImFont_AddGlyph(
@@ -5088,8 +5128,8 @@ extern "C" {
 extern "C" {
     pub fn ImFont_IsGlyphRangeUnused(
         self_: *mut ImFont,
-        c_begin: cty::c_uint,
-        c_last: cty::c_uint,
+        c_begin: core::ffi::c_uint,
+        c_last: core::ffi::c_uint,
     ) -> bool;
 }
 extern "C" {
@@ -5122,17 +5162,24 @@ extern "C" {
 extern "C" {
     pub fn ImGuiFreeType_SetAllocatorFunctions(
         alloc_func: ::core::option::Option<
-            unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+            unsafe extern "C" fn(
+                sz: usize,
+                user_data: *mut core::ffi::c_void,
+            ) -> *mut core::ffi::c_void,
         >,
         free_func: ::core::option::Option<
-            unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+            unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
         >,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 extern "C" {
-    pub fn igLogText(fmt: *const cty::c_char, ...);
+    pub fn igLogText(fmt: *const core::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn ImGuiTextBuffer_appendf(buffer: *mut ImGuiTextBuffer, fmt: *const cty::c_char, ...);
+    pub fn ImGuiTextBuffer_appendf(
+        buffer: *mut ImGuiTextBuffer,
+        fmt: *const core::ffi::c_char,
+        ...
+    );
 }

--- a/imgui-sys/src/lib.rs
+++ b/imgui-sys/src/lib.rs
@@ -1,24 +1,4 @@
 #![no_std]
-// We use `chlorine` over (the more well known) `cty` right now since `cty`
-// doesn't fully match std::os::raw (leading to issues like
-// https://github.com/japaric/cty/issues/18). Chlorine *does* match std::os::raw
-// (and libc), but has a longer and more confusing name, so we just alias it.
-// Also, this makes it easier to switch to something else/back easier, if we
-// decide to.
-//
-// Note that with the exception of bugs like the above, which crate we use (cty,
-// chlorine, libc, std::os::raw, ...) shouldn't matter to end user code¹, since
-// these are type aliases that should all be equivalent. This means that we're
-// free to switch back iff the bug is fixed, and users are free to use whichever
-// they prefer regardless of what we chose.
-//
-// (TODO: using extern crate for this is a hack, we probably should replace this
-// with `use chlorine as cty` in the binding files eventually, but lets punt on
-// it for a bit)
-//
-// ¹ The exception to this is that `std::os::raw` isn't there for `no_std`, and
-// `libc` has potentially undesirable linking impacts on windows.
-pub extern crate chlorine as cty;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "wasm")] {

--- a/imgui-sys/src/wasm_bindings.rs
+++ b/imgui-sys/src/wasm_bindings.rs
@@ -97,64 +97,64 @@ pub struct ImFontBuilderIO {
 pub struct ImGuiContext {
     _unused: [u8; 0],
 }
-pub type ImGuiID = cty::c_uint;
-pub type ImS8 = cty::c_schar;
-pub type ImU8 = cty::c_uchar;
-pub type ImS16 = cty::c_short;
-pub type ImU16 = cty::c_ushort;
-pub type ImU32 = cty::c_uint;
-pub type ImS64 = cty::c_longlong;
-pub type ImGuiCol = cty::c_int;
-pub type ImGuiCond = cty::c_int;
-pub type ImGuiDataType = cty::c_int;
-pub type ImGuiMouseButton = cty::c_int;
-pub type ImGuiMouseCursor = cty::c_int;
-pub type ImGuiStyleVar = cty::c_int;
-pub type ImGuiTableBgTarget = cty::c_int;
-pub type ImDrawFlags = cty::c_int;
-pub type ImDrawListFlags = cty::c_int;
-pub type ImFontAtlasFlags = cty::c_int;
-pub type ImGuiBackendFlags = cty::c_int;
-pub type ImGuiButtonFlags = cty::c_int;
-pub type ImGuiChildFlags = cty::c_int;
-pub type ImGuiColorEditFlags = cty::c_int;
-pub type ImGuiConfigFlags = cty::c_int;
-pub type ImGuiComboFlags = cty::c_int;
-pub type ImGuiDragDropFlags = cty::c_int;
-pub type ImGuiFocusedFlags = cty::c_int;
-pub type ImGuiHoveredFlags = cty::c_int;
-pub type ImGuiInputFlags = cty::c_int;
-pub type ImGuiInputTextFlags = cty::c_int;
-pub type ImGuiItemFlags = cty::c_int;
-pub type ImGuiKeyChord = cty::c_int;
-pub type ImGuiPopupFlags = cty::c_int;
-pub type ImGuiMultiSelectFlags = cty::c_int;
-pub type ImGuiSelectableFlags = cty::c_int;
-pub type ImGuiSliderFlags = cty::c_int;
-pub type ImGuiTabBarFlags = cty::c_int;
-pub type ImGuiTabItemFlags = cty::c_int;
-pub type ImGuiTableFlags = cty::c_int;
-pub type ImGuiTableColumnFlags = cty::c_int;
-pub type ImGuiTableRowFlags = cty::c_int;
-pub type ImGuiTreeNodeFlags = cty::c_int;
-pub type ImGuiViewportFlags = cty::c_int;
-pub type ImGuiWindowFlags = cty::c_int;
-pub type ImTextureID = *mut cty::c_void;
-pub type ImDrawIdx = cty::c_ushort;
-pub type ImWchar32 = cty::c_uint;
-pub type ImWchar16 = cty::c_ushort;
+pub type ImGuiID = core::ffi::c_uint;
+pub type ImS8 = core::ffi::c_schar;
+pub type ImU8 = core::ffi::c_uchar;
+pub type ImS16 = core::ffi::c_short;
+pub type ImU16 = core::ffi::c_ushort;
+pub type ImU32 = core::ffi::c_uint;
+pub type ImS64 = core::ffi::c_longlong;
+pub type ImGuiCol = core::ffi::c_int;
+pub type ImGuiCond = core::ffi::c_int;
+pub type ImGuiDataType = core::ffi::c_int;
+pub type ImGuiMouseButton = core::ffi::c_int;
+pub type ImGuiMouseCursor = core::ffi::c_int;
+pub type ImGuiStyleVar = core::ffi::c_int;
+pub type ImGuiTableBgTarget = core::ffi::c_int;
+pub type ImDrawFlags = core::ffi::c_int;
+pub type ImDrawListFlags = core::ffi::c_int;
+pub type ImFontAtlasFlags = core::ffi::c_int;
+pub type ImGuiBackendFlags = core::ffi::c_int;
+pub type ImGuiButtonFlags = core::ffi::c_int;
+pub type ImGuiChildFlags = core::ffi::c_int;
+pub type ImGuiColorEditFlags = core::ffi::c_int;
+pub type ImGuiConfigFlags = core::ffi::c_int;
+pub type ImGuiComboFlags = core::ffi::c_int;
+pub type ImGuiDragDropFlags = core::ffi::c_int;
+pub type ImGuiFocusedFlags = core::ffi::c_int;
+pub type ImGuiHoveredFlags = core::ffi::c_int;
+pub type ImGuiInputFlags = core::ffi::c_int;
+pub type ImGuiInputTextFlags = core::ffi::c_int;
+pub type ImGuiItemFlags = core::ffi::c_int;
+pub type ImGuiKeyChord = core::ffi::c_int;
+pub type ImGuiPopupFlags = core::ffi::c_int;
+pub type ImGuiMultiSelectFlags = core::ffi::c_int;
+pub type ImGuiSelectableFlags = core::ffi::c_int;
+pub type ImGuiSliderFlags = core::ffi::c_int;
+pub type ImGuiTabBarFlags = core::ffi::c_int;
+pub type ImGuiTabItemFlags = core::ffi::c_int;
+pub type ImGuiTableFlags = core::ffi::c_int;
+pub type ImGuiTableColumnFlags = core::ffi::c_int;
+pub type ImGuiTableRowFlags = core::ffi::c_int;
+pub type ImGuiTreeNodeFlags = core::ffi::c_int;
+pub type ImGuiViewportFlags = core::ffi::c_int;
+pub type ImGuiWindowFlags = core::ffi::c_int;
+pub type ImTextureID = *mut core::ffi::c_void;
+pub type ImDrawIdx = core::ffi::c_ushort;
+pub type ImWchar32 = core::ffi::c_uint;
+pub type ImWchar16 = core::ffi::c_ushort;
 pub type ImWchar = ImWchar32;
 pub type ImGuiSelectionUserData = ImS64;
 pub type ImGuiInputTextCallback = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> cty::c_int,
+    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> core::ffi::c_int,
 >;
 pub type ImGuiSizeCallback =
     ::core::option::Option<unsafe extern "C" fn(data: *mut ImGuiSizeCallbackData)>;
 pub type ImGuiMemAllocFunc = ::core::option::Option<
-    unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+    unsafe extern "C" fn(sz: usize, user_data: *mut core::ffi::c_void) -> *mut core::ffi::c_void,
 >;
 pub type ImGuiMemFreeFunc = ::core::option::Option<
-    unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+    unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -198,7 +198,7 @@ pub const ImGuiWindowFlags_Tooltip: ImGuiWindowFlags_ = 33554432;
 pub const ImGuiWindowFlags_Popup: ImGuiWindowFlags_ = 67108864;
 pub const ImGuiWindowFlags_Modal: ImGuiWindowFlags_ = 134217728;
 pub const ImGuiWindowFlags_ChildMenu: ImGuiWindowFlags_ = 268435456;
-pub type ImGuiWindowFlags_ = cty::c_uint;
+pub type ImGuiWindowFlags_ = core::ffi::c_uint;
 pub const ImGuiChildFlags_None: ImGuiChildFlags_ = 0;
 pub const ImGuiChildFlags_Borders: ImGuiChildFlags_ = 1;
 pub const ImGuiChildFlags_AlwaysUseWindowPadding: ImGuiChildFlags_ = 2;
@@ -209,7 +209,7 @@ pub const ImGuiChildFlags_AutoResizeY: ImGuiChildFlags_ = 32;
 pub const ImGuiChildFlags_AlwaysAutoResize: ImGuiChildFlags_ = 64;
 pub const ImGuiChildFlags_FrameStyle: ImGuiChildFlags_ = 128;
 pub const ImGuiChildFlags_NavFlattened: ImGuiChildFlags_ = 256;
-pub type ImGuiChildFlags_ = cty::c_uint;
+pub type ImGuiChildFlags_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_None: ImGuiItemFlags_ = 0;
 pub const ImGuiItemFlags_NoTabStop: ImGuiItemFlags_ = 1;
 pub const ImGuiItemFlags_NoNav: ImGuiItemFlags_ = 2;
@@ -217,7 +217,7 @@ pub const ImGuiItemFlags_NoNavDefaultFocus: ImGuiItemFlags_ = 4;
 pub const ImGuiItemFlags_ButtonRepeat: ImGuiItemFlags_ = 8;
 pub const ImGuiItemFlags_AutoClosePopups: ImGuiItemFlags_ = 16;
 pub const ImGuiItemFlags_AllowDuplicateId: ImGuiItemFlags_ = 32;
-pub type ImGuiItemFlags_ = cty::c_uint;
+pub type ImGuiItemFlags_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_None: ImGuiInputTextFlags_ = 0;
 pub const ImGuiInputTextFlags_CharsDecimal: ImGuiInputTextFlags_ = 1;
 pub const ImGuiInputTextFlags_CharsHexadecimal: ImGuiInputTextFlags_ = 2;
@@ -242,7 +242,7 @@ pub const ImGuiInputTextFlags_CallbackAlways: ImGuiInputTextFlags_ = 524288;
 pub const ImGuiInputTextFlags_CallbackCharFilter: ImGuiInputTextFlags_ = 1048576;
 pub const ImGuiInputTextFlags_CallbackResize: ImGuiInputTextFlags_ = 2097152;
 pub const ImGuiInputTextFlags_CallbackEdit: ImGuiInputTextFlags_ = 4194304;
-pub type ImGuiInputTextFlags_ = cty::c_uint;
+pub type ImGuiInputTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_None: ImGuiTreeNodeFlags_ = 0;
 pub const ImGuiTreeNodeFlags_Selected: ImGuiTreeNodeFlags_ = 1;
 pub const ImGuiTreeNodeFlags_Framed: ImGuiTreeNodeFlags_ = 2;
@@ -261,7 +261,7 @@ pub const ImGuiTreeNodeFlags_SpanTextWidth: ImGuiTreeNodeFlags_ = 8192;
 pub const ImGuiTreeNodeFlags_SpanAllColumns: ImGuiTreeNodeFlags_ = 16384;
 pub const ImGuiTreeNodeFlags_NavLeftJumpsBackHere: ImGuiTreeNodeFlags_ = 32768;
 pub const ImGuiTreeNodeFlags_CollapsingHeader: ImGuiTreeNodeFlags_ = 26;
-pub type ImGuiTreeNodeFlags_ = cty::c_uint;
+pub type ImGuiTreeNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiPopupFlags_None: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonLeft: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonRight: ImGuiPopupFlags_ = 1;
@@ -274,7 +274,7 @@ pub const ImGuiPopupFlags_NoOpenOverItems: ImGuiPopupFlags_ = 256;
 pub const ImGuiPopupFlags_AnyPopupId: ImGuiPopupFlags_ = 1024;
 pub const ImGuiPopupFlags_AnyPopupLevel: ImGuiPopupFlags_ = 2048;
 pub const ImGuiPopupFlags_AnyPopup: ImGuiPopupFlags_ = 3072;
-pub type ImGuiPopupFlags_ = cty::c_uint;
+pub type ImGuiPopupFlags_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_None: ImGuiSelectableFlags_ = 0;
 pub const ImGuiSelectableFlags_NoAutoClosePopups: ImGuiSelectableFlags_ = 1;
 pub const ImGuiSelectableFlags_SpanAllColumns: ImGuiSelectableFlags_ = 2;
@@ -282,7 +282,7 @@ pub const ImGuiSelectableFlags_AllowDoubleClick: ImGuiSelectableFlags_ = 4;
 pub const ImGuiSelectableFlags_Disabled: ImGuiSelectableFlags_ = 8;
 pub const ImGuiSelectableFlags_AllowOverlap: ImGuiSelectableFlags_ = 16;
 pub const ImGuiSelectableFlags_Highlight: ImGuiSelectableFlags_ = 32;
-pub type ImGuiSelectableFlags_ = cty::c_uint;
+pub type ImGuiSelectableFlags_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_None: ImGuiComboFlags_ = 0;
 pub const ImGuiComboFlags_PopupAlignLeft: ImGuiComboFlags_ = 1;
 pub const ImGuiComboFlags_HeightSmall: ImGuiComboFlags_ = 2;
@@ -293,7 +293,7 @@ pub const ImGuiComboFlags_NoArrowButton: ImGuiComboFlags_ = 32;
 pub const ImGuiComboFlags_NoPreview: ImGuiComboFlags_ = 64;
 pub const ImGuiComboFlags_WidthFitPreview: ImGuiComboFlags_ = 128;
 pub const ImGuiComboFlags_HeightMask_: ImGuiComboFlags_ = 30;
-pub type ImGuiComboFlags_ = cty::c_uint;
+pub type ImGuiComboFlags_ = core::ffi::c_uint;
 pub const ImGuiTabBarFlags_None: ImGuiTabBarFlags_ = 0;
 pub const ImGuiTabBarFlags_Reorderable: ImGuiTabBarFlags_ = 1;
 pub const ImGuiTabBarFlags_AutoSelectNewTabs: ImGuiTabBarFlags_ = 2;
@@ -306,7 +306,7 @@ pub const ImGuiTabBarFlags_FittingPolicyResizeDown: ImGuiTabBarFlags_ = 128;
 pub const ImGuiTabBarFlags_FittingPolicyScroll: ImGuiTabBarFlags_ = 256;
 pub const ImGuiTabBarFlags_FittingPolicyMask_: ImGuiTabBarFlags_ = 384;
 pub const ImGuiTabBarFlags_FittingPolicyDefault_: ImGuiTabBarFlags_ = 128;
-pub type ImGuiTabBarFlags_ = cty::c_uint;
+pub type ImGuiTabBarFlags_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_None: ImGuiTabItemFlags_ = 0;
 pub const ImGuiTabItemFlags_UnsavedDocument: ImGuiTabItemFlags_ = 1;
 pub const ImGuiTabItemFlags_SetSelected: ImGuiTabItemFlags_ = 2;
@@ -317,14 +317,14 @@ pub const ImGuiTabItemFlags_NoReorder: ImGuiTabItemFlags_ = 32;
 pub const ImGuiTabItemFlags_Leading: ImGuiTabItemFlags_ = 64;
 pub const ImGuiTabItemFlags_Trailing: ImGuiTabItemFlags_ = 128;
 pub const ImGuiTabItemFlags_NoAssumedClosure: ImGuiTabItemFlags_ = 256;
-pub type ImGuiTabItemFlags_ = cty::c_uint;
+pub type ImGuiTabItemFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusedFlags_None: ImGuiFocusedFlags_ = 0;
 pub const ImGuiFocusedFlags_ChildWindows: ImGuiFocusedFlags_ = 1;
 pub const ImGuiFocusedFlags_RootWindow: ImGuiFocusedFlags_ = 2;
 pub const ImGuiFocusedFlags_AnyWindow: ImGuiFocusedFlags_ = 4;
 pub const ImGuiFocusedFlags_NoPopupHierarchy: ImGuiFocusedFlags_ = 8;
 pub const ImGuiFocusedFlags_RootAndChildWindows: ImGuiFocusedFlags_ = 3;
-pub type ImGuiFocusedFlags_ = cty::c_uint;
+pub type ImGuiFocusedFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_None: ImGuiHoveredFlags_ = 0;
 pub const ImGuiHoveredFlags_ChildWindows: ImGuiHoveredFlags_ = 1;
 pub const ImGuiHoveredFlags_RootWindow: ImGuiHoveredFlags_ = 2;
@@ -345,7 +345,7 @@ pub const ImGuiHoveredFlags_DelayNone: ImGuiHoveredFlags_ = 16384;
 pub const ImGuiHoveredFlags_DelayShort: ImGuiHoveredFlags_ = 32768;
 pub const ImGuiHoveredFlags_DelayNormal: ImGuiHoveredFlags_ = 65536;
 pub const ImGuiHoveredFlags_NoSharedDelay: ImGuiHoveredFlags_ = 131072;
-pub type ImGuiHoveredFlags_ = cty::c_uint;
+pub type ImGuiHoveredFlags_ = core::ffi::c_uint;
 pub const ImGuiDragDropFlags_None: ImGuiDragDropFlags_ = 0;
 pub const ImGuiDragDropFlags_SourceNoPreviewTooltip: ImGuiDragDropFlags_ = 1;
 pub const ImGuiDragDropFlags_SourceNoDisableHover: ImGuiDragDropFlags_ = 2;
@@ -359,7 +359,7 @@ pub const ImGuiDragDropFlags_AcceptBeforeDelivery: ImGuiDragDropFlags_ = 1024;
 pub const ImGuiDragDropFlags_AcceptNoDrawDefaultRect: ImGuiDragDropFlags_ = 2048;
 pub const ImGuiDragDropFlags_AcceptNoPreviewTooltip: ImGuiDragDropFlags_ = 4096;
 pub const ImGuiDragDropFlags_AcceptPeekOnly: ImGuiDragDropFlags_ = 3072;
-pub type ImGuiDragDropFlags_ = cty::c_uint;
+pub type ImGuiDragDropFlags_ = core::ffi::c_uint;
 pub const ImGuiDataType_S8: ImGuiDataType_ = 0;
 pub const ImGuiDataType_U8: ImGuiDataType_ = 1;
 pub const ImGuiDataType_S16: ImGuiDataType_ = 2;
@@ -372,18 +372,18 @@ pub const ImGuiDataType_Float: ImGuiDataType_ = 8;
 pub const ImGuiDataType_Double: ImGuiDataType_ = 9;
 pub const ImGuiDataType_Bool: ImGuiDataType_ = 10;
 pub const ImGuiDataType_COUNT: ImGuiDataType_ = 11;
-pub type ImGuiDataType_ = cty::c_uint;
+pub type ImGuiDataType_ = core::ffi::c_uint;
 pub const ImGuiDir_None: ImGuiDir = -1;
 pub const ImGuiDir_Left: ImGuiDir = 0;
 pub const ImGuiDir_Right: ImGuiDir = 1;
 pub const ImGuiDir_Up: ImGuiDir = 2;
 pub const ImGuiDir_Down: ImGuiDir = 3;
 pub const ImGuiDir_COUNT: ImGuiDir = 4;
-pub type ImGuiDir = cty::c_int;
+pub type ImGuiDir = core::ffi::c_int;
 pub const ImGuiSortDirection_None: ImGuiSortDirection = 0;
 pub const ImGuiSortDirection_Ascending: ImGuiSortDirection = 1;
 pub const ImGuiSortDirection_Descending: ImGuiSortDirection = 2;
-pub type ImGuiSortDirection = cty::c_uint;
+pub type ImGuiSortDirection = core::ffi::c_uint;
 pub const ImGuiKey_None: ImGuiKey = 0;
 pub const ImGuiKey_Tab: ImGuiKey = 512;
 pub const ImGuiKey_LeftArrow: ImGuiKey = 513;
@@ -551,7 +551,7 @@ pub const ImGuiKey_NamedKey_END: ImGuiKey = 666;
 pub const ImGuiKey_NamedKey_COUNT: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_SIZE: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_OFFSET: ImGuiKey = 512;
-pub type ImGuiKey = cty::c_uint;
+pub type ImGuiKey = core::ffi::c_uint;
 pub const ImGuiInputFlags_None: ImGuiInputFlags_ = 0;
 pub const ImGuiInputFlags_Repeat: ImGuiInputFlags_ = 1;
 pub const ImGuiInputFlags_RouteActive: ImGuiInputFlags_ = 1024;
@@ -563,7 +563,7 @@ pub const ImGuiInputFlags_RouteOverActive: ImGuiInputFlags_ = 32768;
 pub const ImGuiInputFlags_RouteUnlessBgFocused: ImGuiInputFlags_ = 65536;
 pub const ImGuiInputFlags_RouteFromRootWindow: ImGuiInputFlags_ = 131072;
 pub const ImGuiInputFlags_Tooltip: ImGuiInputFlags_ = 262144;
-pub type ImGuiInputFlags_ = cty::c_uint;
+pub type ImGuiInputFlags_ = core::ffi::c_uint;
 pub const ImGuiConfigFlags_None: ImGuiConfigFlags_ = 0;
 pub const ImGuiConfigFlags_NavEnableKeyboard: ImGuiConfigFlags_ = 1;
 pub const ImGuiConfigFlags_NavEnableGamepad: ImGuiConfigFlags_ = 2;
@@ -574,13 +574,13 @@ pub const ImGuiConfigFlags_NoMouseCursorChange: ImGuiConfigFlags_ = 32;
 pub const ImGuiConfigFlags_NoKeyboard: ImGuiConfigFlags_ = 64;
 pub const ImGuiConfigFlags_IsSRGB: ImGuiConfigFlags_ = 1048576;
 pub const ImGuiConfigFlags_IsTouchScreen: ImGuiConfigFlags_ = 2097152;
-pub type ImGuiConfigFlags_ = cty::c_uint;
+pub type ImGuiConfigFlags_ = core::ffi::c_uint;
 pub const ImGuiBackendFlags_None: ImGuiBackendFlags_ = 0;
 pub const ImGuiBackendFlags_HasGamepad: ImGuiBackendFlags_ = 1;
 pub const ImGuiBackendFlags_HasMouseCursors: ImGuiBackendFlags_ = 2;
 pub const ImGuiBackendFlags_HasSetMousePos: ImGuiBackendFlags_ = 4;
 pub const ImGuiBackendFlags_RendererHasVtxOffset: ImGuiBackendFlags_ = 8;
-pub type ImGuiBackendFlags_ = cty::c_uint;
+pub type ImGuiBackendFlags_ = core::ffi::c_uint;
 pub const ImGuiCol_Text: ImGuiCol_ = 0;
 pub const ImGuiCol_TextDisabled: ImGuiCol_ = 1;
 pub const ImGuiCol_WindowBg: ImGuiCol_ = 2;
@@ -638,7 +638,7 @@ pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 53;
 pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 54;
 pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 55;
 pub const ImGuiCol_COUNT: ImGuiCol_ = 56;
-pub type ImGuiCol_ = cty::c_uint;
+pub type ImGuiCol_ = core::ffi::c_uint;
 pub const ImGuiStyleVar_Alpha: ImGuiStyleVar_ = 0;
 pub const ImGuiStyleVar_DisabledAlpha: ImGuiStyleVar_ = 1;
 pub const ImGuiStyleVar_WindowPadding: ImGuiStyleVar_ = 2;
@@ -673,13 +673,13 @@ pub const ImGuiStyleVar_SeparatorTextBorderSize: ImGuiStyleVar_ = 30;
 pub const ImGuiStyleVar_SeparatorTextAlign: ImGuiStyleVar_ = 31;
 pub const ImGuiStyleVar_SeparatorTextPadding: ImGuiStyleVar_ = 32;
 pub const ImGuiStyleVar_COUNT: ImGuiStyleVar_ = 33;
-pub type ImGuiStyleVar_ = cty::c_uint;
+pub type ImGuiStyleVar_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_None: ImGuiButtonFlags_ = 0;
 pub const ImGuiButtonFlags_MouseButtonLeft: ImGuiButtonFlags_ = 1;
 pub const ImGuiButtonFlags_MouseButtonRight: ImGuiButtonFlags_ = 2;
 pub const ImGuiButtonFlags_MouseButtonMiddle: ImGuiButtonFlags_ = 4;
 pub const ImGuiButtonFlags_MouseButtonMask_: ImGuiButtonFlags_ = 7;
-pub type ImGuiButtonFlags_ = cty::c_uint;
+pub type ImGuiButtonFlags_ = core::ffi::c_uint;
 pub const ImGuiColorEditFlags_None: ImGuiColorEditFlags_ = 0;
 pub const ImGuiColorEditFlags_NoAlpha: ImGuiColorEditFlags_ = 2;
 pub const ImGuiColorEditFlags_NoPicker: ImGuiColorEditFlags_ = 4;
@@ -709,7 +709,7 @@ pub const ImGuiColorEditFlags_DisplayMask_: ImGuiColorEditFlags_ = 7340032;
 pub const ImGuiColorEditFlags_DataTypeMask_: ImGuiColorEditFlags_ = 25165824;
 pub const ImGuiColorEditFlags_PickerMask_: ImGuiColorEditFlags_ = 100663296;
 pub const ImGuiColorEditFlags_InputMask_: ImGuiColorEditFlags_ = 402653184;
-pub type ImGuiColorEditFlags_ = cty::c_uint;
+pub type ImGuiColorEditFlags_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_None: ImGuiSliderFlags_ = 0;
 pub const ImGuiSliderFlags_Logarithmic: ImGuiSliderFlags_ = 32;
 pub const ImGuiSliderFlags_NoRoundToFormat: ImGuiSliderFlags_ = 64;
@@ -719,12 +719,12 @@ pub const ImGuiSliderFlags_ClampOnInput: ImGuiSliderFlags_ = 512;
 pub const ImGuiSliderFlags_ClampZeroRange: ImGuiSliderFlags_ = 1024;
 pub const ImGuiSliderFlags_AlwaysClamp: ImGuiSliderFlags_ = 1536;
 pub const ImGuiSliderFlags_InvalidMask_: ImGuiSliderFlags_ = 1879048207;
-pub type ImGuiSliderFlags_ = cty::c_uint;
+pub type ImGuiSliderFlags_ = core::ffi::c_uint;
 pub const ImGuiMouseButton_Left: ImGuiMouseButton_ = 0;
 pub const ImGuiMouseButton_Right: ImGuiMouseButton_ = 1;
 pub const ImGuiMouseButton_Middle: ImGuiMouseButton_ = 2;
 pub const ImGuiMouseButton_COUNT: ImGuiMouseButton_ = 5;
-pub type ImGuiMouseButton_ = cty::c_uint;
+pub type ImGuiMouseButton_ = core::ffi::c_uint;
 pub const ImGuiMouseCursor_None: ImGuiMouseCursor_ = -1;
 pub const ImGuiMouseCursor_Arrow: ImGuiMouseCursor_ = 0;
 pub const ImGuiMouseCursor_TextInput: ImGuiMouseCursor_ = 1;
@@ -736,18 +736,18 @@ pub const ImGuiMouseCursor_ResizeNWSE: ImGuiMouseCursor_ = 6;
 pub const ImGuiMouseCursor_Hand: ImGuiMouseCursor_ = 7;
 pub const ImGuiMouseCursor_NotAllowed: ImGuiMouseCursor_ = 8;
 pub const ImGuiMouseCursor_COUNT: ImGuiMouseCursor_ = 9;
-pub type ImGuiMouseCursor_ = cty::c_int;
+pub type ImGuiMouseCursor_ = core::ffi::c_int;
 pub const ImGuiMouseSource_Mouse: ImGuiMouseSource = 0;
 pub const ImGuiMouseSource_TouchScreen: ImGuiMouseSource = 1;
 pub const ImGuiMouseSource_Pen: ImGuiMouseSource = 2;
 pub const ImGuiMouseSource_COUNT: ImGuiMouseSource = 3;
-pub type ImGuiMouseSource = cty::c_uint;
+pub type ImGuiMouseSource = core::ffi::c_uint;
 pub const ImGuiCond_None: ImGuiCond_ = 0;
 pub const ImGuiCond_Always: ImGuiCond_ = 1;
 pub const ImGuiCond_Once: ImGuiCond_ = 2;
 pub const ImGuiCond_FirstUseEver: ImGuiCond_ = 4;
 pub const ImGuiCond_Appearing: ImGuiCond_ = 8;
-pub type ImGuiCond_ = cty::c_uint;
+pub type ImGuiCond_ = core::ffi::c_uint;
 pub const ImGuiTableFlags_None: ImGuiTableFlags_ = 0;
 pub const ImGuiTableFlags_Resizable: ImGuiTableFlags_ = 1;
 pub const ImGuiTableFlags_Reorderable: ImGuiTableFlags_ = 2;
@@ -785,7 +785,7 @@ pub const ImGuiTableFlags_SortMulti: ImGuiTableFlags_ = 67108864;
 pub const ImGuiTableFlags_SortTristate: ImGuiTableFlags_ = 134217728;
 pub const ImGuiTableFlags_HighlightHoveredColumn: ImGuiTableFlags_ = 268435456;
 pub const ImGuiTableFlags_SizingMask_: ImGuiTableFlags_ = 57344;
-pub type ImGuiTableFlags_ = cty::c_uint;
+pub type ImGuiTableFlags_ = core::ffi::c_uint;
 pub const ImGuiTableColumnFlags_None: ImGuiTableColumnFlags_ = 0;
 pub const ImGuiTableColumnFlags_Disabled: ImGuiTableColumnFlags_ = 1;
 pub const ImGuiTableColumnFlags_DefaultHide: ImGuiTableColumnFlags_ = 2;
@@ -814,20 +814,20 @@ pub const ImGuiTableColumnFlags_WidthMask_: ImGuiTableColumnFlags_ = 24;
 pub const ImGuiTableColumnFlags_IndentMask_: ImGuiTableColumnFlags_ = 196608;
 pub const ImGuiTableColumnFlags_StatusMask_: ImGuiTableColumnFlags_ = 251658240;
 pub const ImGuiTableColumnFlags_NoDirectResize_: ImGuiTableColumnFlags_ = 1073741824;
-pub type ImGuiTableColumnFlags_ = cty::c_uint;
+pub type ImGuiTableColumnFlags_ = core::ffi::c_uint;
 pub const ImGuiTableRowFlags_None: ImGuiTableRowFlags_ = 0;
 pub const ImGuiTableRowFlags_Headers: ImGuiTableRowFlags_ = 1;
-pub type ImGuiTableRowFlags_ = cty::c_uint;
+pub type ImGuiTableRowFlags_ = core::ffi::c_uint;
 pub const ImGuiTableBgTarget_None: ImGuiTableBgTarget_ = 0;
 pub const ImGuiTableBgTarget_RowBg0: ImGuiTableBgTarget_ = 1;
 pub const ImGuiTableBgTarget_RowBg1: ImGuiTableBgTarget_ = 2;
 pub const ImGuiTableBgTarget_CellBg: ImGuiTableBgTarget_ = 3;
-pub type ImGuiTableBgTarget_ = cty::c_uint;
+pub type ImGuiTableBgTarget_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTableSortSpecs {
     pub Specs: *const ImGuiTableColumnSortSpecs,
-    pub SpecsCount: cty::c_int,
+    pub SpecsCount: core::ffi::c_int,
     pub SpecsDirty: bool,
 }
 impl Default for ImGuiTableSortSpecs {
@@ -933,8 +933,8 @@ pub struct ImGuiKeyData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImWchar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImWchar,
 }
 impl Default for ImVector_ImWchar {
@@ -954,9 +954,9 @@ pub struct ImGuiIO {
     pub DisplaySize: ImVec2,
     pub DeltaTime: f32,
     pub IniSavingRate: f32,
-    pub IniFilename: *const cty::c_char,
-    pub LogFilename: *const cty::c_char,
-    pub UserData: *mut cty::c_void,
+    pub IniFilename: *const core::ffi::c_char,
+    pub LogFilename: *const core::ffi::c_char,
+    pub UserData: *mut core::ffi::c_void,
     pub Fonts: *mut ImFontAtlas,
     pub FontGlobalScale: f32,
     pub FontAllowUserScaling: bool,
@@ -988,11 +988,11 @@ pub struct ImGuiIO {
     pub ConfigDebugBeginReturnValueLoop: bool,
     pub ConfigDebugIgnoreFocusLoss: bool,
     pub ConfigDebugIniSettings: bool,
-    pub BackendPlatformName: *const cty::c_char,
-    pub BackendRendererName: *const cty::c_char,
-    pub BackendPlatformUserData: *mut cty::c_void,
-    pub BackendRendererUserData: *mut cty::c_void,
-    pub BackendLanguageUserData: *mut cty::c_void,
+    pub BackendPlatformName: *const core::ffi::c_char,
+    pub BackendRendererName: *const core::ffi::c_char,
+    pub BackendPlatformUserData: *mut core::ffi::c_void,
+    pub BackendRendererUserData: *mut core::ffi::c_void,
+    pub BackendLanguageUserData: *mut core::ffi::c_void,
     pub WantCaptureMouse: bool,
     pub WantCaptureKeyboard: bool,
     pub WantTextInput: bool,
@@ -1001,10 +1001,10 @@ pub struct ImGuiIO {
     pub NavActive: bool,
     pub NavVisible: bool,
     pub Framerate: f32,
-    pub MetricsRenderVertices: cty::c_int,
-    pub MetricsRenderIndices: cty::c_int,
-    pub MetricsRenderWindows: cty::c_int,
-    pub MetricsActiveWindows: cty::c_int,
+    pub MetricsRenderVertices: core::ffi::c_int,
+    pub MetricsRenderIndices: core::ffi::c_int,
+    pub MetricsRenderWindows: core::ffi::c_int,
+    pub MetricsActiveWindows: core::ffi::c_int,
     pub MouseDelta: ImVec2,
     pub Ctx: *mut ImGuiContext,
     pub MousePos: ImVec2,
@@ -1057,16 +1057,16 @@ pub struct ImGuiInputTextCallbackData {
     pub Ctx: *mut ImGuiContext,
     pub EventFlag: ImGuiInputTextFlags,
     pub Flags: ImGuiInputTextFlags,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub EventChar: ImWchar,
     pub EventKey: ImGuiKey,
-    pub Buf: *mut cty::c_char,
-    pub BufTextLen: cty::c_int,
-    pub BufSize: cty::c_int,
+    pub Buf: *mut core::ffi::c_char,
+    pub BufTextLen: core::ffi::c_int,
+    pub BufSize: core::ffi::c_int,
     pub BufDirty: bool,
-    pub CursorPos: cty::c_int,
-    pub SelectionStart: cty::c_int,
-    pub SelectionEnd: cty::c_int,
+    pub CursorPos: core::ffi::c_int,
+    pub SelectionStart: core::ffi::c_int,
+    pub SelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextCallbackData {
     fn default() -> Self {
@@ -1080,7 +1080,7 @@ impl Default for ImGuiInputTextCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiSizeCallbackData {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub Pos: ImVec2,
     pub CurrentSize: ImVec2,
     pub DesiredSize: ImVec2,
@@ -1097,12 +1097,12 @@ impl Default for ImGuiSizeCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPayload {
-    pub Data: *mut cty::c_void,
-    pub DataSize: cty::c_int,
+    pub Data: *mut core::ffi::c_void,
+    pub DataSize: core::ffi::c_int,
     pub SourceId: ImGuiID,
     pub SourceParentId: ImGuiID,
-    pub DataFrameCount: cty::c_int,
-    pub DataType: [cty::c_char; 33usize],
+    pub DataFrameCount: core::ffi::c_int,
+    pub DataType: [core::ffi::c_char; 33usize],
     pub Preview: bool,
     pub Delivery: bool,
 }
@@ -1118,13 +1118,13 @@ impl Default for ImGuiPayload {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiOnceUponAFrame {
-    pub RefFrame: cty::c_int,
+    pub RefFrame: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextRange {
-    pub b: *const cty::c_char,
-    pub e: *const cty::c_char,
+    pub b: *const core::ffi::c_char,
+    pub e: *const core::ffi::c_char,
 }
 impl Default for ImGuiTextRange {
     fn default() -> Self {
@@ -1138,8 +1138,8 @@ impl Default for ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTextRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTextRange,
 }
 impl Default for ImVector_ImGuiTextRange {
@@ -1154,9 +1154,9 @@ impl Default for ImVector_ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextFilter {
-    pub InputBuf: [cty::c_char; 256usize],
+    pub InputBuf: [core::ffi::c_char; 256usize],
     pub Filters: ImVector_ImGuiTextRange,
-    pub CountGrep: cty::c_int,
+    pub CountGrep: core::ffi::c_int,
 }
 impl Default for ImGuiTextFilter {
     fn default() -> Self {
@@ -1170,9 +1170,9 @@ impl Default for ImGuiTextFilter {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_char,
 }
 impl Default for ImVector_char {
     fn default() -> Self {
@@ -1206,9 +1206,9 @@ pub struct ImGuiStoragePair {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStoragePair__bindgen_ty_1 {
-    pub val_i: cty::c_int,
+    pub val_i: core::ffi::c_int,
     pub val_f: f32,
-    pub val_p: *mut cty::c_void,
+    pub val_p: *mut core::ffi::c_void,
 }
 impl Default for ImGuiStoragePair__bindgen_ty_1 {
     fn default() -> Self {
@@ -1245,8 +1245,8 @@ impl ::core::fmt::Debug for ImGuiStoragePair {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStoragePair {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStoragePair,
 }
 impl Default for ImVector_ImGuiStoragePair {
@@ -1276,13 +1276,13 @@ impl Default for ImGuiStorage {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiListClipper {
     pub Ctx: *mut ImGuiContext,
-    pub DisplayStart: cty::c_int,
-    pub DisplayEnd: cty::c_int,
-    pub ItemsCount: cty::c_int,
+    pub DisplayStart: core::ffi::c_int,
+    pub DisplayEnd: core::ffi::c_int,
+    pub ItemsCount: core::ffi::c_int,
     pub ItemsHeight: f32,
     pub StartPosY: f32,
     pub StartSeekOffsetY: f64,
-    pub TempData: *mut cty::c_void,
+    pub TempData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiListClipper {
     fn default() -> Self {
@@ -1315,12 +1315,12 @@ pub const ImGuiMultiSelectFlags_ScopeRect: ImGuiMultiSelectFlags_ = 4096;
 pub const ImGuiMultiSelectFlags_SelectOnClick: ImGuiMultiSelectFlags_ = 8192;
 pub const ImGuiMultiSelectFlags_SelectOnClickRelease: ImGuiMultiSelectFlags_ = 16384;
 pub const ImGuiMultiSelectFlags_NavWrapX: ImGuiMultiSelectFlags_ = 65536;
-pub type ImGuiMultiSelectFlags_ = cty::c_uint;
+pub type ImGuiMultiSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSelectionRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSelectionRequest,
 }
 impl Default for ImVector_ImGuiSelectionRequest {
@@ -1340,7 +1340,7 @@ pub struct ImGuiMultiSelectIO {
     pub NavIdItem: ImGuiSelectionUserData,
     pub NavIdSelected: bool,
     pub RangeSrcReset: bool,
-    pub ItemsCount: cty::c_int,
+    pub ItemsCount: core::ffi::c_int,
 }
 impl Default for ImGuiMultiSelectIO {
     fn default() -> Self {
@@ -1354,7 +1354,7 @@ impl Default for ImGuiMultiSelectIO {
 pub const ImGuiSelectionRequestType_None: ImGuiSelectionRequestType = 0;
 pub const ImGuiSelectionRequestType_SetAll: ImGuiSelectionRequestType = 1;
 pub const ImGuiSelectionRequestType_SetRange: ImGuiSelectionRequestType = 2;
-pub type ImGuiSelectionRequestType = cty::c_uint;
+pub type ImGuiSelectionRequestType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionRequest {
@@ -1376,13 +1376,16 @@ impl Default for ImGuiSelectionRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionBasicStorage {
-    pub Size: cty::c_int,
+    pub Size: core::ffi::c_int,
     pub PreserveOrder: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterIndexToStorageId: ::core::option::Option<
-        unsafe extern "C" fn(self_: *mut ImGuiSelectionBasicStorage, idx: cty::c_int) -> ImGuiID,
+        unsafe extern "C" fn(
+            self_: *mut ImGuiSelectionBasicStorage,
+            idx: core::ffi::c_int,
+        ) -> ImGuiID,
     >,
-    pub _SelectionOrder: cty::c_int,
+    pub _SelectionOrder: core::ffi::c_int,
     pub _Storage: ImGuiStorage,
 }
 impl Default for ImGuiSelectionBasicStorage {
@@ -1397,11 +1400,11 @@ impl Default for ImGuiSelectionBasicStorage {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionExternalStorage {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterSetItemSelected: ::core::option::Option<
         unsafe extern "C" fn(
             self_: *mut ImGuiSelectionExternalStorage,
-            idx: cty::c_int,
+            idx: core::ffi::c_int,
             selected: bool,
         ),
     >,
@@ -1423,11 +1426,11 @@ pub type ImDrawCallback = ::core::option::Option<
 pub struct ImDrawCmd {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
-    pub IdxOffset: cty::c_uint,
-    pub ElemCount: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
+    pub IdxOffset: core::ffi::c_uint,
+    pub ElemCount: core::ffi::c_uint,
     pub UserCallback: ImDrawCallback,
-    pub UserCallbackData: *mut cty::c_void,
+    pub UserCallbackData: *mut core::ffi::c_void,
 }
 impl Default for ImDrawCmd {
     fn default() -> Self {
@@ -1450,7 +1453,7 @@ pub struct ImDrawVert {
 pub struct ImDrawCmdHeader {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
 }
 impl Default for ImDrawCmdHeader {
     fn default() -> Self {
@@ -1464,8 +1467,8 @@ impl Default for ImDrawCmdHeader {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawCmd {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawCmd,
 }
 impl Default for ImVector_ImDrawCmd {
@@ -1480,8 +1483,8 @@ impl Default for ImVector_ImDrawCmd {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawIdx {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawIdx,
 }
 impl Default for ImVector_ImDrawIdx {
@@ -1511,8 +1514,8 @@ impl Default for ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawChannel {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawChannel,
 }
 impl Default for ImVector_ImDrawChannel {
@@ -1527,8 +1530,8 @@ impl Default for ImVector_ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImDrawListSplitter {
-    pub _Current: cty::c_int,
-    pub _Count: cty::c_int,
+    pub _Current: core::ffi::c_int,
+    pub _Count: core::ffi::c_int,
     pub _Channels: ImVector_ImDrawChannel,
 }
 impl Default for ImDrawListSplitter {
@@ -1554,18 +1557,18 @@ pub const ImDrawFlags_RoundCornersRight: ImDrawFlags_ = 160;
 pub const ImDrawFlags_RoundCornersAll: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersDefault_: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersMask_: ImDrawFlags_ = 496;
-pub type ImDrawFlags_ = cty::c_uint;
+pub type ImDrawFlags_ = core::ffi::c_uint;
 pub const ImDrawListFlags_None: ImDrawListFlags_ = 0;
 pub const ImDrawListFlags_AntiAliasedLines: ImDrawListFlags_ = 1;
 pub const ImDrawListFlags_AntiAliasedLinesUseTex: ImDrawListFlags_ = 2;
 pub const ImDrawListFlags_AntiAliasedFill: ImDrawListFlags_ = 4;
 pub const ImDrawListFlags_AllowVtxOffset: ImDrawListFlags_ = 8;
-pub type ImDrawListFlags_ = cty::c_uint;
+pub type ImDrawListFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawVert {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawVert,
 }
 impl Default for ImVector_ImDrawVert {
@@ -1580,8 +1583,8 @@ impl Default for ImVector_ImDrawVert {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec2 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec2,
 }
 impl Default for ImVector_ImVec2 {
@@ -1596,8 +1599,8 @@ impl Default for ImVector_ImVec2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec4 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec4,
 }
 impl Default for ImVector_ImVec4 {
@@ -1612,8 +1615,8 @@ impl Default for ImVector_ImVec4 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImTextureID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImTextureID,
 }
 impl Default for ImVector_ImTextureID {
@@ -1632,7 +1635,7 @@ pub struct ImDrawList {
     pub IdxBuffer: ImVector_ImDrawIdx,
     pub VtxBuffer: ImVector_ImDrawVert,
     pub Flags: ImDrawListFlags,
-    pub _VtxCurrentIdx: cty::c_uint,
+    pub _VtxCurrentIdx: core::ffi::c_uint,
     pub _Data: *mut ImDrawListSharedData,
     pub _VtxWritePtr: *mut ImDrawVert,
     pub _IdxWritePtr: *mut ImDrawIdx,
@@ -1642,7 +1645,7 @@ pub struct ImDrawList {
     pub _ClipRectStack: ImVector_ImVec4,
     pub _TextureIdStack: ImVector_ImTextureID,
     pub _FringeScale: f32,
-    pub _OwnerName: *const cty::c_char,
+    pub _OwnerName: *const core::ffi::c_char,
 }
 impl Default for ImDrawList {
     fn default() -> Self {
@@ -1656,8 +1659,8 @@ impl Default for ImDrawList {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawListPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImDrawList,
 }
 impl Default for ImVector_ImDrawListPtr {
@@ -1673,9 +1676,9 @@ impl Default for ImVector_ImDrawListPtr {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImDrawData {
     pub Valid: bool,
-    pub CmdListsCount: cty::c_int,
-    pub TotalIdxCount: cty::c_int,
-    pub TotalVtxCount: cty::c_int,
+    pub CmdListsCount: core::ffi::c_int,
+    pub TotalIdxCount: core::ffi::c_int,
+    pub TotalVtxCount: core::ffi::c_int,
     pub CmdLists: ImVector_ImDrawListPtr,
     pub DisplayPos: ImVec2,
     pub DisplaySize: ImVec2,
@@ -1694,13 +1697,13 @@ impl Default for ImDrawData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontConfig {
-    pub FontData: *mut cty::c_void,
-    pub FontDataSize: cty::c_int,
+    pub FontData: *mut core::ffi::c_void,
+    pub FontDataSize: core::ffi::c_int,
     pub FontDataOwnedByAtlas: bool,
-    pub FontNo: cty::c_int,
+    pub FontNo: core::ffi::c_int,
     pub SizePixels: f32,
-    pub OversampleH: cty::c_int,
-    pub OversampleV: cty::c_int,
+    pub OversampleH: core::ffi::c_int,
+    pub OversampleV: core::ffi::c_int,
     pub PixelSnapH: bool,
     pub GlyphExtraSpacing: ImVec2,
     pub GlyphOffset: ImVec2,
@@ -1708,11 +1711,11 @@ pub struct ImFontConfig {
     pub GlyphMinAdvanceX: f32,
     pub GlyphMaxAdvanceX: f32,
     pub MergeMode: bool,
-    pub FontBuilderFlags: cty::c_uint,
+    pub FontBuilderFlags: core::ffi::c_uint,
     pub RasterizerMultiply: f32,
     pub RasterizerDensity: f32,
     pub EllipsisChar: ImWchar,
-    pub Name: [cty::c_char; 40usize],
+    pub Name: [core::ffi::c_char; 40usize],
     pub DstFont: *mut ImFont,
 }
 impl Default for ImFontConfig {
@@ -1741,33 +1744,33 @@ pub struct ImFontGlyph {
 }
 impl ImFontGlyph {
     #[inline]
-    pub fn Colored(&self) -> cty::c_uint {
+    pub fn Colored(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Colored(&mut self, val: cty::c_uint) {
+    pub fn set_Colored(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Visible(&self) -> cty::c_uint {
+    pub fn Visible(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Visible(&mut self, val: cty::c_uint) {
+    pub fn set_Visible(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(1usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Codepoint(&self) -> cty::c_uint {
+    pub fn Codepoint(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
     }
     #[inline]
-    pub fn set_Codepoint(&mut self, val: cty::c_uint) {
+    pub fn set_Codepoint(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(2usize, 30u8, val as u64)
@@ -1775,9 +1778,9 @@ impl ImFontGlyph {
     }
     #[inline]
     pub fn new_bitfield_1(
-        Colored: cty::c_uint,
-        Visible: cty::c_uint,
-        Codepoint: cty::c_uint,
+        Colored: core::ffi::c_uint,
+        Visible: core::ffi::c_uint,
+        Codepoint: core::ffi::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1798,8 +1801,8 @@ impl ImFontGlyph {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImU32 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImU32,
 }
 impl Default for ImVector_ImU32 {
@@ -1828,11 +1831,11 @@ impl Default for ImFontGlyphRangesBuilder {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontAtlasCustomRect {
-    pub Width: cty::c_ushort,
-    pub Height: cty::c_ushort,
-    pub X: cty::c_ushort,
-    pub Y: cty::c_ushort,
-    pub GlyphID: cty::c_uint,
+    pub Width: core::ffi::c_ushort,
+    pub Height: core::ffi::c_ushort,
+    pub X: core::ffi::c_ushort,
+    pub Y: core::ffi::c_ushort,
+    pub GlyphID: core::ffi::c_uint,
     pub GlyphAdvanceX: f32,
     pub GlyphOffset: ImVec2,
     pub Font: *mut ImFont,
@@ -1850,12 +1853,12 @@ pub const ImFontAtlasFlags_None: ImFontAtlasFlags_ = 0;
 pub const ImFontAtlasFlags_NoPowerOfTwoHeight: ImFontAtlasFlags_ = 1;
 pub const ImFontAtlasFlags_NoMouseCursors: ImFontAtlasFlags_ = 2;
 pub const ImFontAtlasFlags_NoBakedLines: ImFontAtlasFlags_ = 4;
-pub type ImFontAtlasFlags_ = cty::c_uint;
+pub type ImFontAtlasFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImFont,
 }
 impl Default for ImVector_ImFontPtr {
@@ -1870,8 +1873,8 @@ impl Default for ImVector_ImFontPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontAtlasCustomRect {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontAtlasCustomRect,
 }
 impl Default for ImVector_ImFontAtlasCustomRect {
@@ -1886,8 +1889,8 @@ impl Default for ImVector_ImFontAtlasCustomRect {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontConfig {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontConfig,
 }
 impl Default for ImVector_ImFontConfig {
@@ -1904,16 +1907,16 @@ impl Default for ImVector_ImFontConfig {
 pub struct ImFontAtlas {
     pub Flags: ImFontAtlasFlags,
     pub TexID: ImTextureID,
-    pub TexDesiredWidth: cty::c_int,
-    pub TexGlyphPadding: cty::c_int,
+    pub TexDesiredWidth: core::ffi::c_int,
+    pub TexGlyphPadding: core::ffi::c_int,
     pub Locked: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub TexReady: bool,
     pub TexPixelsUseColors: bool,
-    pub TexPixelsAlpha8: *mut cty::c_uchar,
-    pub TexPixelsRGBA32: *mut cty::c_uint,
-    pub TexWidth: cty::c_int,
-    pub TexHeight: cty::c_int,
+    pub TexPixelsAlpha8: *mut core::ffi::c_uchar,
+    pub TexPixelsRGBA32: *mut core::ffi::c_uint,
+    pub TexWidth: core::ffi::c_int,
+    pub TexHeight: core::ffi::c_int,
     pub TexUvScale: ImVec2,
     pub TexUvWhitePixel: ImVec2,
     pub Fonts: ImVector_ImFontPtr,
@@ -1921,9 +1924,9 @@ pub struct ImFontAtlas {
     pub ConfigData: ImVector_ImFontConfig,
     pub TexUvLines: [ImVec4; 64usize],
     pub FontBuilderIO: *const ImFontBuilderIO,
-    pub FontBuilderFlags: cty::c_uint,
-    pub PackIdMouseCursors: cty::c_int,
-    pub PackIdLines: cty::c_int,
+    pub FontBuilderFlags: core::ffi::c_uint,
+    pub PackIdMouseCursors: core::ffi::c_int,
+    pub PackIdLines: core::ffi::c_int,
 }
 impl Default for ImFontAtlas {
     fn default() -> Self {
@@ -1937,8 +1940,8 @@ impl Default for ImFontAtlas {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_float {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut f32,
 }
 impl Default for ImVector_float {
@@ -1953,8 +1956,8 @@ impl Default for ImVector_float {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontGlyph {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontGlyph,
 }
 impl Default for ImVector_ImFontGlyph {
@@ -1977,17 +1980,17 @@ pub struct ImFont {
     pub FallbackGlyph: *const ImFontGlyph,
     pub ContainerAtlas: *mut ImFontAtlas,
     pub ConfigData: *const ImFontConfig,
-    pub ConfigDataCount: cty::c_short,
+    pub ConfigDataCount: core::ffi::c_short,
     pub FallbackChar: ImWchar,
     pub EllipsisChar: ImWchar,
-    pub EllipsisCharCount: cty::c_short,
+    pub EllipsisCharCount: core::ffi::c_short,
     pub EllipsisWidth: f32,
     pub EllipsisCharStep: f32,
     pub DirtyLookupTables: bool,
     pub Scale: f32,
     pub Ascent: f32,
     pub Descent: f32,
-    pub MetricsTotalSurface: cty::c_int,
+    pub MetricsTotalSurface: core::ffi::c_int,
     pub Used4kPagesMap: [ImU8; 34usize],
 }
 impl Default for ImFont {
@@ -2003,7 +2006,7 @@ pub const ImGuiViewportFlags_None: ImGuiViewportFlags_ = 0;
 pub const ImGuiViewportFlags_IsPlatformWindow: ImGuiViewportFlags_ = 1;
 pub const ImGuiViewportFlags_IsPlatformMonitor: ImGuiViewportFlags_ = 2;
 pub const ImGuiViewportFlags_OwnedByApp: ImGuiViewportFlags_ = 4;
-pub type ImGuiViewportFlags_ = cty::c_uint;
+pub type ImGuiViewportFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiViewport {
@@ -2013,8 +2016,8 @@ pub struct ImGuiViewport {
     pub Size: ImVec2,
     pub WorkPos: ImVec2,
     pub WorkSize: ImVec2,
-    pub PlatformHandle: *mut cty::c_void,
-    pub PlatformHandleRaw: *mut cty::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
+    pub PlatformHandleRaw: *mut core::ffi::c_void,
 }
 impl Default for ImGuiViewport {
     fn default() -> Self {
@@ -2028,16 +2031,17 @@ impl Default for ImGuiViewport {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPlatformIO {
-    pub Platform_GetClipboardTextFn:
-        ::core::option::Option<unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const cty::c_char>,
+    pub Platform_GetClipboardTextFn: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const core::ffi::c_char,
+    >,
     pub Platform_SetClipboardTextFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const cty::c_char),
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const core::ffi::c_char),
     >,
-    pub Platform_ClipboardUserData: *mut cty::c_void,
+    pub Platform_ClipboardUserData: *mut core::ffi::c_void,
     pub Platform_OpenInShellFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const cty::c_char) -> bool,
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const core::ffi::c_char) -> bool,
     >,
-    pub Platform_OpenInShellUserData: *mut cty::c_void,
+    pub Platform_OpenInShellUserData: *mut core::ffi::c_void,
     pub Platform_SetImeDataFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
@@ -2045,7 +2049,7 @@ pub struct ImGuiPlatformIO {
             data: *mut ImGuiPlatformImeData,
         ),
     >,
-    pub Platform_ImeUserData: *mut cty::c_void,
+    pub Platform_ImeUserData: *mut core::ffi::c_void,
     pub Platform_LocaleDecimalPoint: ImWchar,
 }
 impl Default for ImGuiPlatformIO {
@@ -2158,11 +2162,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShowStyleSelector(label: *const cty::c_char) -> bool;
+    pub fn igShowStyleSelector(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShowFontSelector(label: *const cty::c_char);
+    pub fn igShowFontSelector(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2170,7 +2174,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetVersion() -> *const cty::c_char;
+    pub fn igGetVersion() -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2186,7 +2190,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBegin(name: *const cty::c_char, p_open: *mut bool, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBegin(
+        name: *const core::ffi::c_char,
+        p_open: *mut bool,
+        flags: ImGuiWindowFlags,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2195,7 +2203,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginChild_Str(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         child_flags: ImGuiChildFlags,
         window_flags: ImGuiWindowFlags,
@@ -2264,7 +2272,7 @@ extern "C" {
         size_min: ImVec2,
         size_max: ImVec2,
         custom_callback: ImGuiSizeCallback,
-        custom_callback_data: *mut cty::c_void,
+        custom_callback_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -2309,19 +2317,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowPos_Str(name: *const cty::c_char, pos: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowPos_Str(name: *const core::ffi::c_char, pos: ImVec2, cond: ImGuiCond);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowSize_Str(name: *const cty::c_char, size: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowSize_Str(name: *const core::ffi::c_char, size: ImVec2, cond: ImGuiCond);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowCollapsed_Str(name: *const cty::c_char, collapsed: bool, cond: ImGuiCond);
+    pub fn igSetWindowCollapsed_Str(
+        name: *const core::ffi::c_char,
+        collapsed: bool,
+        cond: ImGuiCond,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowFocus_Str(name: *const cty::c_char);
+    pub fn igSetWindowFocus_Str(name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2381,7 +2393,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPopStyleColor(count: cty::c_int);
+    pub fn igPopStyleColor(count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2401,7 +2413,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPopStyleVar(count: cty::c_int);
+    pub fn igPopStyleVar(count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2561,19 +2573,22 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Str(str_id: *const cty::c_char);
+    pub fn igPushID_Str(str_id: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_StrStr(str_id_begin: *const cty::c_char, str_id_end: *const cty::c_char);
+    pub fn igPushID_StrStr(
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Ptr(ptr_id: *const cty::c_void);
+    pub fn igPushID_Ptr(ptr_id: *const core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Int(int_id: cty::c_int);
+    pub fn igPushID_Int(int_id: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2581,110 +2596,110 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Str(str_id: *const cty::c_char) -> ImGuiID;
+    pub fn igGetID_Str(str_id: *const core::ffi::c_char) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igGetID_StrStr(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Ptr(ptr_id: *const cty::c_void) -> ImGuiID;
+    pub fn igGetID_Ptr(ptr_id: *const core::ffi::c_void) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Int(int_id: cty::c_int) -> ImGuiID;
+    pub fn igGetID_Int(int_id: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextUnformatted(text: *const cty::c_char, text_end: *const cty::c_char);
+    pub fn igTextUnformatted(text: *const core::ffi::c_char, text_end: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igText(fmt: *const cty::c_char, ...);
+    pub fn igText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextColored(col: ImVec4, fmt: *const cty::c_char, ...);
+    pub fn igTextColored(col: ImVec4, fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextDisabled(fmt: *const cty::c_char, ...);
+    pub fn igTextDisabled(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextWrapped(fmt: *const cty::c_char, ...);
+    pub fn igTextWrapped(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLabelText(label: *const cty::c_char, fmt: *const cty::c_char, ...);
+    pub fn igLabelText(label: *const core::ffi::c_char, fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBulletText(fmt: *const cty::c_char, ...);
+    pub fn igBulletText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSeparatorText(label: *const cty::c_char);
+    pub fn igSeparatorText(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igButton(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igButton(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSmallButton(label: *const cty::c_char) -> bool;
+    pub fn igSmallButton(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInvisibleButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         flags: ImGuiButtonFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igArrowButton(str_id: *const cty::c_char, dir: ImGuiDir) -> bool;
+    pub fn igArrowButton(str_id: *const core::ffi::c_char, dir: ImGuiDir) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igCheckbox(label: *const cty::c_char, v: *mut bool) -> bool;
+    pub fn igCheckbox(label: *const core::ffi::c_char, v: *mut bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_IntPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_int,
-        flags_value: cty::c_int,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_int,
+        flags_value: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_UintPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_uint,
-        flags_value: cty::c_uint,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_uint,
+        flags_value: core::ffi::c_uint,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igRadioButton_Bool(label: *const cty::c_char, active: bool) -> bool;
+    pub fn igRadioButton_Bool(label: *const core::ffi::c_char, active: bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igRadioButton_IntPtr(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_button: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_button: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const cty::c_char);
+    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2692,11 +2707,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextLink(label: *const cty::c_char) -> bool;
+    pub fn igTextLink(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextLinkOpenURL(label: *const cty::c_char, url: *const cty::c_char);
+    pub fn igTextLinkOpenURL(label: *const core::ffi::c_char, url: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2712,7 +2727,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImageButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         user_texture_id: ImTextureID,
         image_size: ImVec2,
         uv0: ImVec2,
@@ -2724,8 +2739,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginCombo(
-        label: *const cty::c_char,
-        preview_value: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        preview_value: *const core::ffi::c_char,
         flags: ImGuiComboFlags,
     ) -> bool;
 }
@@ -2736,497 +2751,497 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_Str(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items_separated_by_zeros: *const cty::c_char,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items_separated_by_zeros: *const core::ffi::c_char,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloatRange2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_current_min: *mut f32,
         v_current_max: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragIntRange2(
-        label: *const cty::c_char,
-        v_current_min: *mut cty::c_int,
-        v_current_max: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v_current_min: *mut core::ffi::c_int,
+        v_current_max: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderAngle(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_rad: *mut f32,
         v_degrees_min: f32,
         v_degrees_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderInt(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputText(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextMultiline(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         size: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextWithHint(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         step: f32,
         step_fast: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        step: cty::c_int,
-        step_fast: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        step: core::ffi::c_int,
+        step_fast: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputDouble(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f64,
         step: f64,
         step_fast: f64,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorEdit3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -3234,7 +3249,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorEdit4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -3242,7 +3257,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorPicker3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -3250,7 +3265,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorPicker4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
         ref_col: *const f32,
@@ -3259,7 +3274,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorButton(
-        desc_id: *const cty::c_char,
+        desc_id: *const core::ffi::c_char,
         col: ImVec4,
         flags: ImGuiColorEditFlags,
         size: ImVec2,
@@ -3271,45 +3286,53 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_Str(label: *const cty::c_char) -> bool;
+    pub fn igTreeNode_Str(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_StrStr(str_id: *const cty::c_char, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_StrStr(
+        str_id: *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_Ptr(ptr_id: *const cty::c_void, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_Ptr(
+        ptr_id: *const core::ffi::c_void,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNodeEx_Str(label: *const cty::c_char, flags: ImGuiTreeNodeFlags) -> bool;
+    pub fn igTreeNodeEx_Str(label: *const core::ffi::c_char, flags: ImGuiTreeNodeFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTreeNodeEx_StrStr(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTreeNodeEx_Ptr(
-        ptr_id: *const cty::c_void,
+        ptr_id: *const core::ffi::c_void,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreePush_Str(str_id: *const cty::c_char);
+    pub fn igTreePush_Str(str_id: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreePush_Ptr(ptr_id: *const cty::c_void);
+    pub fn igTreePush_Ptr(ptr_id: *const core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3322,14 +3345,14 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCollapsingHeader_TreeNodeFlags(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCollapsingHeader_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_visible: *mut bool,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
@@ -3345,7 +3368,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSelectable_Bool(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         selected: bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -3354,7 +3377,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSelectable_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_selected: *mut bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -3364,8 +3387,8 @@ extern "C" {
 extern "C" {
     pub fn igBeginMultiSelect(
         flags: ImGuiMultiSelectFlags,
-        selection_size: cty::c_int,
-        items_count: cty::c_int,
+        selection_size: core::ffi::c_int,
+        items_count: core::ffi::c_int,
     ) -> *mut ImGuiMultiSelectIO;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -3382,7 +3405,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginListBox(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igBeginListBox(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3391,54 +3414,54 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igListBox_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igListBox_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotLines_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotLines_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -3447,28 +3470,28 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotHistogram_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotHistogram_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -3476,19 +3499,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Bool(prefix: *const cty::c_char, b: bool);
+    pub fn igValue_Bool(prefix: *const core::ffi::c_char, b: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Int(prefix: *const cty::c_char, v: cty::c_int);
+    pub fn igValue_Int(prefix: *const core::ffi::c_char, v: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Uint(prefix: *const cty::c_char, v: cty::c_uint);
+    pub fn igValue_Uint(prefix: *const core::ffi::c_char, v: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Float(prefix: *const cty::c_char, v: f32, float_format: *const cty::c_char);
+    pub fn igValue_Float(
+        prefix: *const core::ffi::c_char,
+        v: f32,
+        float_format: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3508,7 +3535,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginMenu(label: *const cty::c_char, enabled: bool) -> bool;
+    pub fn igBeginMenu(label: *const core::ffi::c_char, enabled: bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3517,8 +3544,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItem_Bool(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
@@ -3526,8 +3553,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItem_BoolPtr(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         p_selected: *mut bool,
         enabled: bool,
     ) -> bool;
@@ -3542,7 +3569,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetTooltip(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3550,16 +3577,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetItemTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetItemTooltip(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginPopup(str_id: *const cty::c_char, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBeginPopup(str_id: *const core::ffi::c_char, flags: ImGuiWindowFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupModal(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiWindowFlags,
     ) -> bool;
@@ -3570,7 +3597,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igOpenPopup_Str(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopup_Str(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3578,7 +3605,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igOpenPopupOnItemClick(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopupOnItemClick(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3587,33 +3614,33 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextItem(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextWindow(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextVoid(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igIsPopupOpen(str_id: *const cty::c_char, flags: ImGuiPopupFlags) -> bool;
+    pub fn igIsPopupOpen(str_id: *const core::ffi::c_char, flags: ImGuiPopupFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTable(
-        str_id: *const cty::c_char,
-        columns: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        columns: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -3633,12 +3660,12 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnIndex(column_n: cty::c_int) -> bool;
+    pub fn igTableSetColumnIndex(column_n: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableSetupColumn(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTableColumnFlags,
         init_width_or_weight: f32,
         user_id: ImGuiID,
@@ -3646,11 +3673,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetupScrollFreeze(cols: cty::c_int, rows: cty::c_int);
+    pub fn igTableSetupScrollFreeze(cols: core::ffi::c_int, rows: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableHeader(label: *const cty::c_char);
+    pub fn igTableHeader(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3666,39 +3693,39 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnCount() -> cty::c_int;
+    pub fn igTableGetColumnCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnIndex() -> cty::c_int;
+    pub fn igTableGetColumnIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetRowIndex() -> cty::c_int;
+    pub fn igTableGetRowIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnName(column_n: cty::c_int) -> *const cty::c_char;
+    pub fn igTableGetColumnName(column_n: core::ffi::c_int) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnFlags(column_n: cty::c_int) -> ImGuiTableColumnFlags;
+    pub fn igTableGetColumnFlags(column_n: core::ffi::c_int) -> ImGuiTableColumnFlags;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnEnabled(column_n: cty::c_int, v: bool);
+    pub fn igTableSetColumnEnabled(column_n: core::ffi::c_int, v: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetHoveredColumn() -> cty::c_int;
+    pub fn igTableGetHoveredColumn() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: cty::c_int);
+    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igColumns(count: cty::c_int, id: *const cty::c_char, borders: bool);
+    pub fn igColumns(count: core::ffi::c_int, id: *const core::ffi::c_char, borders: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3706,31 +3733,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnIndex() -> cty::c_int;
+    pub fn igGetColumnIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnWidth(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnWidth(column_index: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetColumnWidth(column_index: cty::c_int, width: f32);
+    pub fn igSetColumnWidth(column_index: core::ffi::c_int, width: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnOffset(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnOffset(column_index: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetColumnOffset(column_index: cty::c_int, offset_x: f32);
+    pub fn igSetColumnOffset(column_index: core::ffi::c_int, offset_x: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnsCount() -> cty::c_int;
+    pub fn igGetColumnsCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginTabBar(str_id: *const cty::c_char, flags: ImGuiTabBarFlags) -> bool;
+    pub fn igBeginTabBar(str_id: *const core::ffi::c_char, flags: ImGuiTabBarFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3739,7 +3766,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTabItem(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
     ) -> bool;
@@ -3750,23 +3777,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTabItemButton(label: *const cty::c_char, flags: ImGuiTabItemFlags) -> bool;
+    pub fn igTabItemButton(label: *const core::ffi::c_char, flags: ImGuiTabItemFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const cty::c_char);
+    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToTTY(auto_open_depth: cty::c_int);
+    pub fn igLogToTTY(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToFile(auto_open_depth: cty::c_int, filename: *const cty::c_char);
+    pub fn igLogToFile(auto_open_depth: core::ffi::c_int, filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToClipboard(auto_open_depth: cty::c_int);
+    pub fn igLogToClipboard(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3783,8 +3810,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSetDragDropPayload(
-        type_: *const cty::c_char,
-        data: *const cty::c_void,
+        type_: *const core::ffi::c_char,
+        data: *const core::ffi::c_void,
         sz: usize,
         cond: ImGuiCond,
     ) -> bool;
@@ -3800,7 +3827,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igAcceptDragDropPayload(
-        type_: *const cty::c_char,
+        type_: *const core::ffi::c_char,
         flags: ImGuiDragDropFlags,
     ) -> *const ImGuiPayload;
 }
@@ -3838,7 +3865,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetKeyboardFocusHere(offset: cty::c_int);
+    pub fn igSetKeyboardFocusHere(offset: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3938,7 +3965,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetFrameCount() -> cty::c_int;
+    pub fn igGetFrameCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3946,7 +3973,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const cty::c_char;
+    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3960,8 +3987,8 @@ extern "C" {
 extern "C" {
     pub fn igCalcTextSize(
         pOut: *mut ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_double_hash: bool,
         wrap_width: f32,
     );
@@ -4014,11 +4041,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> cty::c_int;
+    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyName(key: ImGuiKey) -> *const cty::c_char;
+    pub fn igGetKeyName(key: ImGuiKey) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4054,7 +4081,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> cty::c_int;
+    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4102,31 +4129,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetClipboardText() -> *const cty::c_char;
+    pub fn igGetClipboardText() -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetClipboardText(text: *const cty::c_char);
+    pub fn igSetClipboardText(text: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLoadIniSettingsFromDisk(ini_filename: *const cty::c_char);
+    pub fn igLoadIniSettingsFromDisk(ini_filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLoadIniSettingsFromMemory(ini_data: *const cty::c_char, ini_size: usize);
+    pub fn igLoadIniSettingsFromMemory(ini_data: *const core::ffi::c_char, ini_size: usize);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSaveIniSettingsToDisk(ini_filename: *const cty::c_char);
+    pub fn igSaveIniSettingsToDisk(ini_filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const cty::c_char;
+    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugTextEncoding(text: *const cty::c_char);
+    pub fn igDebugTextEncoding(text: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4139,7 +4166,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugCheckVersionAndDataLayout(
-        version_str: *const cty::c_char,
+        version_str: *const core::ffi::c_char,
         sz_io: usize,
         sz_style: usize,
         sz_vec2: usize,
@@ -4150,14 +4177,14 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugLog(fmt: *const cty::c_char, ...);
+    pub fn igDebugLog(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSetAllocatorFunctions(
         alloc_func: ImGuiMemAllocFunc,
         free_func: ImGuiMemFreeFunc,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4165,16 +4192,16 @@ extern "C" {
     pub fn igGetAllocatorFunctions(
         p_alloc_func: *mut ImGuiMemAllocFunc,
         p_free_func: *mut ImGuiMemFreeFunc,
-        p_user_data: *mut *mut cty::c_void,
+        p_user_data: *mut *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igMemAlloc(size: usize) -> *mut cty::c_void;
+    pub fn igMemAlloc(size: usize) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igMemFree(ptr: *mut cty::c_void);
+    pub fn igMemFree(ptr: *mut core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4218,7 +4245,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: cty::c_int, down: bool);
+    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: core::ffi::c_int, down: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4234,7 +4261,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: cty::c_uint);
+    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4242,16 +4269,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const cty::c_char);
+    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiIO_SetKeyEventNativeData(
         self_: *mut ImGuiIO,
         key: ImGuiKey,
-        native_keycode: cty::c_int,
-        native_scancode: cty::c_int,
-        native_legacy_index: cty::c_int,
+        native_keycode: core::ffi::c_int,
+        native_scancode: core::ffi::c_int,
+        native_legacy_index: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4290,17 +4317,17 @@ extern "C" {
 extern "C" {
     pub fn ImGuiInputTextCallbackData_DeleteChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        bytes_count: cty::c_int,
+        pos: core::ffi::c_int,
+        bytes_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiInputTextCallbackData_InsertChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        pos: core::ffi::c_int,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4329,7 +4356,10 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiPayload_IsDataType(self_: *mut ImGuiPayload, type_: *const cty::c_char) -> bool;
+    pub fn ImGuiPayload_IsDataType(
+        self_: *mut ImGuiPayload,
+        type_: *const core::ffi::c_char,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4350,7 +4380,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextFilter_ImGuiTextFilter(
-        default_filter: *const cty::c_char,
+        default_filter: *const core::ffi::c_char,
     ) -> *mut ImGuiTextFilter;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4361,7 +4391,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_Draw(
         self_: *mut ImGuiTextFilter,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         width: f32,
     ) -> bool;
 }
@@ -4369,8 +4399,8 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_PassFilter(
         self_: *mut ImGuiTextFilter,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4396,8 +4426,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextRange_ImGuiTextRange_Str(
-        _b: *const cty::c_char,
-        _e: *const cty::c_char,
+        _b: *const core::ffi::c_char,
+        _e: *const core::ffi::c_char,
     ) -> *mut ImGuiTextRange;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4408,7 +4438,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextRange_split(
         self_: *mut ImGuiTextRange,
-        separator: cty::c_char,
+        separator: core::ffi::c_char,
         out: *mut ImVector_ImGuiTextRange,
     );
 }
@@ -4422,15 +4452,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> cty::c_int;
+    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4442,25 +4472,25 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: cty::c_int);
+    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextBuffer_append(
         self_: *mut ImGuiTextBuffer,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Int(
         _key: ImGuiID,
-        _val: cty::c_int,
+        _val: core::ffi::c_int,
     ) -> *mut ImGuiStoragePair;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4478,7 +4508,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Ptr(
         _key: ImGuiID,
-        _val: *mut cty::c_void,
+        _val: *mut core::ffi::c_void,
     ) -> *mut ImGuiStoragePair;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4490,12 +4520,12 @@ extern "C" {
     pub fn ImGuiStorage_GetInt(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: cty::c_int);
+    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4515,19 +4545,26 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_GetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID) -> *mut cty::c_void;
+    pub fn ImGuiStorage_GetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+    ) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID, val: *mut cty::c_void);
+    pub fn ImGuiStorage_SetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+        val: *mut core::ffi::c_void,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiStorage_GetIntRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> *mut cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> *mut core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4550,8 +4587,8 @@ extern "C" {
     pub fn ImGuiStorage_GetVoidPtrRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: *mut cty::c_void,
-    ) -> *mut *mut cty::c_void;
+        default_val: *mut core::ffi::c_void,
+    ) -> *mut *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4559,7 +4596,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: cty::c_int);
+    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4573,7 +4610,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_Begin(
         self_: *mut ImGuiListClipper,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         items_height: f32,
     );
 }
@@ -4589,20 +4626,23 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemByIndex(
         self_: *mut ImGuiListClipper,
-        item_index: cty::c_int,
+        item_index: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemsByIndex(
         self_: *mut ImGuiListClipper,
-        item_begin: cty::c_int,
-        item_end: cty::c_int,
+        item_begin: core::ffi::c_int,
+        item_end: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiListClipper_SeekCursorForItem(self_: *mut ImGuiListClipper, item_index: cty::c_int);
+    pub fn ImGuiListClipper_SeekCursorForItem(
+        self_: *mut ImGuiListClipper,
+        item_index: core::ffi::c_int,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4623,10 +4663,10 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImColor_ImColor_Int(
-        r: cty::c_int,
-        g: cty::c_int,
-        b: cty::c_int,
-        a: cty::c_int,
+        r: core::ffi::c_int,
+        g: core::ffi::c_int,
+        b: core::ffi::c_int,
+        a: core::ffi::c_int,
     ) -> *mut ImColor;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4686,7 +4726,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetNextSelectedItem(
         self_: *mut ImGuiSelectionBasicStorage,
-        opaque_it: *mut *mut cty::c_void,
+        opaque_it: *mut *mut core::ffi::c_void,
         out_id: *mut ImGuiID,
     ) -> bool;
 }
@@ -4694,7 +4734,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetStorageIdFromIndex(
         self_: *mut ImGuiSelectionBasicStorage,
-        idx: cty::c_int,
+        idx: core::ffi::c_int,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4746,7 +4786,7 @@ extern "C" {
     pub fn ImDrawListSplitter_Split(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        count: cty::c_int,
+        count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4758,7 +4798,7 @@ extern "C" {
     pub fn ImDrawListSplitter_SetCurrentChannel(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        channel_idx: cty::c_int,
+        channel_idx: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4898,7 +4938,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4909,7 +4949,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4919,7 +4959,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4930,7 +4970,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4941,7 +4981,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4953,7 +4993,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4962,8 +5002,8 @@ extern "C" {
         self_: *mut ImDrawList,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4974,8 +5014,8 @@ extern "C" {
         font_size: f32,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip_rect: *const ImVec4,
     );
@@ -4990,7 +5030,7 @@ extern "C" {
         p4: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5002,7 +5042,7 @@ extern "C" {
         p3: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5010,7 +5050,7 @@ extern "C" {
     pub fn ImDrawList_AddPolyline(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
         flags: ImDrawFlags,
         thickness: f32,
@@ -5021,7 +5061,7 @@ extern "C" {
     pub fn ImDrawList_AddConvexPolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -5030,7 +5070,7 @@ extern "C" {
     pub fn ImDrawList_AddConcavePolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -5113,7 +5153,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5122,8 +5162,8 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_of_12: cty::c_int,
-        a_max_of_12: cty::c_int,
+        a_min_of_12: core::ffi::c_int,
+        a_max_of_12: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5135,7 +5175,7 @@ extern "C" {
         rot: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5145,7 +5185,7 @@ extern "C" {
         p2: ImVec2,
         p3: ImVec2,
         p4: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5154,7 +5194,7 @@ extern "C" {
         self_: *mut ImDrawList,
         p2: ImVec2,
         p3: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5172,7 +5212,7 @@ extern "C" {
     pub fn ImDrawList_AddCallback(
         self_: *mut ImDrawList,
         callback: ImDrawCallback,
-        callback_data: *mut cty::c_void,
+        callback_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5185,7 +5225,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: cty::c_int);
+    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5193,22 +5233,22 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: cty::c_int);
+    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImDrawList_PrimReserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImDrawList_PrimUnreserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5290,7 +5330,7 @@ extern "C" {
     pub fn ImDrawList__CalcCircleAutoSegmentCount(
         self_: *mut ImDrawList,
         radius: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5298,9 +5338,9 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_sample: cty::c_int,
-        a_max_sample: cty::c_int,
-        a_step: cty::c_int,
+        a_min_sample: core::ffi::c_int,
+        a_max_sample: core::ffi::c_int,
+        a_step: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5311,7 +5351,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5374,8 +5414,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontGlyphRangesBuilder_AddText(
         self_: *mut ImFontGlyphRangesBuilder,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5430,7 +5470,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromFileTTF(
         self_: *mut ImFontAtlas,
-        filename: *const cty::c_char,
+        filename: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -5440,8 +5480,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryTTF(
         self_: *mut ImFontAtlas,
-        font_data: *mut cty::c_void,
-        font_data_size: cty::c_int,
+        font_data: *mut core::ffi::c_void,
+        font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -5451,8 +5491,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedTTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data: *const cty::c_void,
-        compressed_font_data_size: cty::c_int,
+        compressed_font_data: *const core::ffi::c_void,
+        compressed_font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -5462,7 +5502,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data_base85: *const cty::c_char,
+        compressed_font_data_base85: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -5492,20 +5532,20 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsAlpha8(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsRGBA32(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5558,9 +5598,9 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectRegular(
         self_: *mut ImFontAtlas,
-        width: cty::c_int,
-        height: cty::c_int,
-    ) -> cty::c_int;
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5568,17 +5608,17 @@ extern "C" {
         self_: *mut ImFontAtlas,
         font: *mut ImFont,
         id: ImWchar,
-        width: cty::c_int,
-        height: cty::c_int,
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
         advance_x: f32,
         offset: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImFontAtlas_GetCustomRectByIndex(
         self_: *mut ImFontAtlas,
-        index: cty::c_int,
+        index: core::ffi::c_int,
     ) -> *mut ImFontAtlasCustomRect;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5627,7 +5667,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const cty::c_char;
+    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5637,9 +5677,9 @@ extern "C" {
         size: f32,
         max_width: f32,
         wrap_width: f32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
-        remaining: *mut *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        remaining: *mut *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5647,10 +5687,10 @@ extern "C" {
     pub fn ImFont_CalcWordWrapPositionA(
         self_: *mut ImFont,
         scale: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5672,8 +5712,8 @@ extern "C" {
         pos: ImVec2,
         col: ImU32,
         clip_rect: ImVec4,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip: bool,
     );
@@ -5688,7 +5728,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: cty::c_int);
+    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5719,8 +5759,8 @@ extern "C" {
 extern "C" {
     pub fn ImFont_IsGlyphRangeUnused(
         self_: *mut ImFont,
-        c_begin: cty::c_uint,
-        c_last: cty::c_uint,
+        c_begin: core::ffi::c_uint,
+        c_last: core::ffi::c_uint,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5757,9 +5797,13 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogText(fmt: *const cty::c_char, ...);
+    pub fn igLogText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_appendf(buffer: *mut ImGuiTextBuffer, fmt: *const cty::c_char, ...);
+    pub fn ImGuiTextBuffer_appendf(
+        buffer: *mut ImGuiTextBuffer,
+        fmt: *const core::ffi::c_char,
+        ...
+    );
 }

--- a/imgui-sys/src/wasm_docking_bindings.rs
+++ b/imgui-sys/src/wasm_docking_bindings.rs
@@ -82,14 +82,14 @@ where
         }
     }
 }
-pub type __int64_t = cty::c_longlong;
+pub type __int64_t = core::ffi::c_longlong;
 pub type __darwin_off_t = __int64_t;
 pub type fpos_t = __darwin_off_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct __sbuf {
-    pub _base: *mut cty::c_uchar,
-    pub _size: cty::c_int,
+    pub _base: *mut core::ffi::c_uchar,
+    pub _size: core::ffi::c_int,
 }
 impl Default for __sbuf {
     fn default() -> Self {
@@ -108,39 +108,45 @@ pub struct __sFILEX {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct __sFILE {
-    pub _p: *mut cty::c_uchar,
-    pub _r: cty::c_int,
-    pub _w: cty::c_int,
-    pub _flags: cty::c_short,
-    pub _file: cty::c_short,
+    pub _p: *mut core::ffi::c_uchar,
+    pub _r: core::ffi::c_int,
+    pub _w: core::ffi::c_int,
+    pub _flags: core::ffi::c_short,
+    pub _file: core::ffi::c_short,
     pub _bf: __sbuf,
-    pub _lbfsize: cty::c_int,
-    pub _cookie: *mut cty::c_void,
-    pub _close: ::core::option::Option<unsafe extern "C" fn(arg1: *mut cty::c_void) -> cty::c_int>,
+    pub _lbfsize: core::ffi::c_int,
+    pub _cookie: *mut core::ffi::c_void,
+    pub _close: ::core::option::Option<
+        unsafe extern "C" fn(arg1: *mut core::ffi::c_void) -> core::ffi::c_int,
+    >,
     pub _read: ::core::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cty::c_void,
-            arg2: *mut cty::c_char,
-            arg3: cty::c_int,
-        ) -> cty::c_int,
+            arg1: *mut core::ffi::c_void,
+            arg2: *mut core::ffi::c_char,
+            arg3: core::ffi::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub _seek: ::core::option::Option<
-        unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: fpos_t, arg3: cty::c_int) -> fpos_t,
+        unsafe extern "C" fn(
+            arg1: *mut core::ffi::c_void,
+            arg2: fpos_t,
+            arg3: core::ffi::c_int,
+        ) -> fpos_t,
     >,
     pub _write: ::core::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cty::c_void,
-            arg2: *const cty::c_char,
-            arg3: cty::c_int,
-        ) -> cty::c_int,
+            arg1: *mut core::ffi::c_void,
+            arg2: *const core::ffi::c_char,
+            arg3: core::ffi::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub _ub: __sbuf,
     pub _extra: *mut __sFILEX,
-    pub _ur: cty::c_int,
-    pub _ubuf: [cty::c_uchar; 3usize],
-    pub _nbuf: [cty::c_uchar; 1usize],
+    pub _ur: core::ffi::c_int,
+    pub _ubuf: [core::ffi::c_uchar; 3usize],
+    pub _nbuf: [core::ffi::c_uchar; 1usize],
     pub _lb: __sbuf,
-    pub _blksize: cty::c_int,
+    pub _blksize: core::ffi::c_int,
     pub _offset: fpos_t,
 }
 impl Default for __sFILE {
@@ -171,9 +177,9 @@ pub struct STB_TexteditState {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_const_charPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut *const cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut *const core::ffi::c_char,
 }
 impl Default for ImVector_const_charPtr {
     fn default() -> Self {
@@ -184,67 +190,67 @@ impl Default for ImVector_const_charPtr {
         }
     }
 }
-pub type ImGuiID = cty::c_uint;
-pub type ImS8 = cty::c_schar;
-pub type ImU8 = cty::c_uchar;
-pub type ImS16 = cty::c_short;
-pub type ImU16 = cty::c_ushort;
-pub type ImS32 = cty::c_int;
-pub type ImU32 = cty::c_uint;
-pub type ImS64 = cty::c_longlong;
-pub type ImU64 = cty::c_ulonglong;
-pub type ImGuiCol = cty::c_int;
-pub type ImGuiCond = cty::c_int;
-pub type ImGuiDataType = cty::c_int;
-pub type ImGuiMouseButton = cty::c_int;
-pub type ImGuiMouseCursor = cty::c_int;
-pub type ImGuiStyleVar = cty::c_int;
-pub type ImGuiTableBgTarget = cty::c_int;
-pub type ImDrawFlags = cty::c_int;
-pub type ImDrawListFlags = cty::c_int;
-pub type ImFontAtlasFlags = cty::c_int;
-pub type ImGuiBackendFlags = cty::c_int;
-pub type ImGuiButtonFlags = cty::c_int;
-pub type ImGuiChildFlags = cty::c_int;
-pub type ImGuiColorEditFlags = cty::c_int;
-pub type ImGuiConfigFlags = cty::c_int;
-pub type ImGuiComboFlags = cty::c_int;
-pub type ImGuiDockNodeFlags = cty::c_int;
-pub type ImGuiDragDropFlags = cty::c_int;
-pub type ImGuiFocusedFlags = cty::c_int;
-pub type ImGuiHoveredFlags = cty::c_int;
-pub type ImGuiInputFlags = cty::c_int;
-pub type ImGuiInputTextFlags = cty::c_int;
-pub type ImGuiItemFlags = cty::c_int;
-pub type ImGuiKeyChord = cty::c_int;
-pub type ImGuiPopupFlags = cty::c_int;
-pub type ImGuiMultiSelectFlags = cty::c_int;
-pub type ImGuiSelectableFlags = cty::c_int;
-pub type ImGuiSliderFlags = cty::c_int;
-pub type ImGuiTabBarFlags = cty::c_int;
-pub type ImGuiTabItemFlags = cty::c_int;
-pub type ImGuiTableFlags = cty::c_int;
-pub type ImGuiTableColumnFlags = cty::c_int;
-pub type ImGuiTableRowFlags = cty::c_int;
-pub type ImGuiTreeNodeFlags = cty::c_int;
-pub type ImGuiViewportFlags = cty::c_int;
-pub type ImGuiWindowFlags = cty::c_int;
-pub type ImTextureID = *mut cty::c_void;
-pub type ImDrawIdx = cty::c_ushort;
-pub type ImWchar32 = cty::c_uint;
-pub type ImWchar16 = cty::c_ushort;
+pub type ImGuiID = core::ffi::c_uint;
+pub type ImS8 = core::ffi::c_schar;
+pub type ImU8 = core::ffi::c_uchar;
+pub type ImS16 = core::ffi::c_short;
+pub type ImU16 = core::ffi::c_ushort;
+pub type ImS32 = core::ffi::c_int;
+pub type ImU32 = core::ffi::c_uint;
+pub type ImS64 = core::ffi::c_longlong;
+pub type ImU64 = core::ffi::c_ulonglong;
+pub type ImGuiCol = core::ffi::c_int;
+pub type ImGuiCond = core::ffi::c_int;
+pub type ImGuiDataType = core::ffi::c_int;
+pub type ImGuiMouseButton = core::ffi::c_int;
+pub type ImGuiMouseCursor = core::ffi::c_int;
+pub type ImGuiStyleVar = core::ffi::c_int;
+pub type ImGuiTableBgTarget = core::ffi::c_int;
+pub type ImDrawFlags = core::ffi::c_int;
+pub type ImDrawListFlags = core::ffi::c_int;
+pub type ImFontAtlasFlags = core::ffi::c_int;
+pub type ImGuiBackendFlags = core::ffi::c_int;
+pub type ImGuiButtonFlags = core::ffi::c_int;
+pub type ImGuiChildFlags = core::ffi::c_int;
+pub type ImGuiColorEditFlags = core::ffi::c_int;
+pub type ImGuiConfigFlags = core::ffi::c_int;
+pub type ImGuiComboFlags = core::ffi::c_int;
+pub type ImGuiDockNodeFlags = core::ffi::c_int;
+pub type ImGuiDragDropFlags = core::ffi::c_int;
+pub type ImGuiFocusedFlags = core::ffi::c_int;
+pub type ImGuiHoveredFlags = core::ffi::c_int;
+pub type ImGuiInputFlags = core::ffi::c_int;
+pub type ImGuiInputTextFlags = core::ffi::c_int;
+pub type ImGuiItemFlags = core::ffi::c_int;
+pub type ImGuiKeyChord = core::ffi::c_int;
+pub type ImGuiPopupFlags = core::ffi::c_int;
+pub type ImGuiMultiSelectFlags = core::ffi::c_int;
+pub type ImGuiSelectableFlags = core::ffi::c_int;
+pub type ImGuiSliderFlags = core::ffi::c_int;
+pub type ImGuiTabBarFlags = core::ffi::c_int;
+pub type ImGuiTabItemFlags = core::ffi::c_int;
+pub type ImGuiTableFlags = core::ffi::c_int;
+pub type ImGuiTableColumnFlags = core::ffi::c_int;
+pub type ImGuiTableRowFlags = core::ffi::c_int;
+pub type ImGuiTreeNodeFlags = core::ffi::c_int;
+pub type ImGuiViewportFlags = core::ffi::c_int;
+pub type ImGuiWindowFlags = core::ffi::c_int;
+pub type ImTextureID = *mut core::ffi::c_void;
+pub type ImDrawIdx = core::ffi::c_ushort;
+pub type ImWchar32 = core::ffi::c_uint;
+pub type ImWchar16 = core::ffi::c_ushort;
 pub type ImWchar = ImWchar32;
 pub type ImGuiSelectionUserData = ImS64;
 pub type ImGuiInputTextCallback = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> cty::c_int,
+    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> core::ffi::c_int,
 >;
 pub type ImGuiSizeCallback =
     ::core::option::Option<unsafe extern "C" fn(data: *mut ImGuiSizeCallbackData)>;
 pub type ImGuiMemAllocFunc = ::core::option::Option<
-    unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+    unsafe extern "C" fn(sz: usize, user_data: *mut core::ffi::c_void) -> *mut core::ffi::c_void,
 >;
 pub type ImGuiMemFreeFunc = ::core::option::Option<
-    unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+    unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -290,7 +296,7 @@ pub const ImGuiWindowFlags_Popup: ImGuiWindowFlags_ = 67108864;
 pub const ImGuiWindowFlags_Modal: ImGuiWindowFlags_ = 134217728;
 pub const ImGuiWindowFlags_ChildMenu: ImGuiWindowFlags_ = 268435456;
 pub const ImGuiWindowFlags_DockNodeHost: ImGuiWindowFlags_ = 536870912;
-pub type ImGuiWindowFlags_ = cty::c_uint;
+pub type ImGuiWindowFlags_ = core::ffi::c_uint;
 pub const ImGuiChildFlags_None: ImGuiChildFlags_ = 0;
 pub const ImGuiChildFlags_Borders: ImGuiChildFlags_ = 1;
 pub const ImGuiChildFlags_AlwaysUseWindowPadding: ImGuiChildFlags_ = 2;
@@ -301,7 +307,7 @@ pub const ImGuiChildFlags_AutoResizeY: ImGuiChildFlags_ = 32;
 pub const ImGuiChildFlags_AlwaysAutoResize: ImGuiChildFlags_ = 64;
 pub const ImGuiChildFlags_FrameStyle: ImGuiChildFlags_ = 128;
 pub const ImGuiChildFlags_NavFlattened: ImGuiChildFlags_ = 256;
-pub type ImGuiChildFlags_ = cty::c_uint;
+pub type ImGuiChildFlags_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_None: ImGuiItemFlags_ = 0;
 pub const ImGuiItemFlags_NoTabStop: ImGuiItemFlags_ = 1;
 pub const ImGuiItemFlags_NoNav: ImGuiItemFlags_ = 2;
@@ -309,7 +315,7 @@ pub const ImGuiItemFlags_NoNavDefaultFocus: ImGuiItemFlags_ = 4;
 pub const ImGuiItemFlags_ButtonRepeat: ImGuiItemFlags_ = 8;
 pub const ImGuiItemFlags_AutoClosePopups: ImGuiItemFlags_ = 16;
 pub const ImGuiItemFlags_AllowDuplicateId: ImGuiItemFlags_ = 32;
-pub type ImGuiItemFlags_ = cty::c_uint;
+pub type ImGuiItemFlags_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_None: ImGuiInputTextFlags_ = 0;
 pub const ImGuiInputTextFlags_CharsDecimal: ImGuiInputTextFlags_ = 1;
 pub const ImGuiInputTextFlags_CharsHexadecimal: ImGuiInputTextFlags_ = 2;
@@ -334,7 +340,7 @@ pub const ImGuiInputTextFlags_CallbackAlways: ImGuiInputTextFlags_ = 524288;
 pub const ImGuiInputTextFlags_CallbackCharFilter: ImGuiInputTextFlags_ = 1048576;
 pub const ImGuiInputTextFlags_CallbackResize: ImGuiInputTextFlags_ = 2097152;
 pub const ImGuiInputTextFlags_CallbackEdit: ImGuiInputTextFlags_ = 4194304;
-pub type ImGuiInputTextFlags_ = cty::c_uint;
+pub type ImGuiInputTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_None: ImGuiTreeNodeFlags_ = 0;
 pub const ImGuiTreeNodeFlags_Selected: ImGuiTreeNodeFlags_ = 1;
 pub const ImGuiTreeNodeFlags_Framed: ImGuiTreeNodeFlags_ = 2;
@@ -353,7 +359,7 @@ pub const ImGuiTreeNodeFlags_SpanTextWidth: ImGuiTreeNodeFlags_ = 8192;
 pub const ImGuiTreeNodeFlags_SpanAllColumns: ImGuiTreeNodeFlags_ = 16384;
 pub const ImGuiTreeNodeFlags_NavLeftJumpsBackHere: ImGuiTreeNodeFlags_ = 32768;
 pub const ImGuiTreeNodeFlags_CollapsingHeader: ImGuiTreeNodeFlags_ = 26;
-pub type ImGuiTreeNodeFlags_ = cty::c_uint;
+pub type ImGuiTreeNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiPopupFlags_None: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonLeft: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonRight: ImGuiPopupFlags_ = 1;
@@ -366,7 +372,7 @@ pub const ImGuiPopupFlags_NoOpenOverItems: ImGuiPopupFlags_ = 256;
 pub const ImGuiPopupFlags_AnyPopupId: ImGuiPopupFlags_ = 1024;
 pub const ImGuiPopupFlags_AnyPopupLevel: ImGuiPopupFlags_ = 2048;
 pub const ImGuiPopupFlags_AnyPopup: ImGuiPopupFlags_ = 3072;
-pub type ImGuiPopupFlags_ = cty::c_uint;
+pub type ImGuiPopupFlags_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_None: ImGuiSelectableFlags_ = 0;
 pub const ImGuiSelectableFlags_NoAutoClosePopups: ImGuiSelectableFlags_ = 1;
 pub const ImGuiSelectableFlags_SpanAllColumns: ImGuiSelectableFlags_ = 2;
@@ -374,7 +380,7 @@ pub const ImGuiSelectableFlags_AllowDoubleClick: ImGuiSelectableFlags_ = 4;
 pub const ImGuiSelectableFlags_Disabled: ImGuiSelectableFlags_ = 8;
 pub const ImGuiSelectableFlags_AllowOverlap: ImGuiSelectableFlags_ = 16;
 pub const ImGuiSelectableFlags_Highlight: ImGuiSelectableFlags_ = 32;
-pub type ImGuiSelectableFlags_ = cty::c_uint;
+pub type ImGuiSelectableFlags_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_None: ImGuiComboFlags_ = 0;
 pub const ImGuiComboFlags_PopupAlignLeft: ImGuiComboFlags_ = 1;
 pub const ImGuiComboFlags_HeightSmall: ImGuiComboFlags_ = 2;
@@ -385,7 +391,7 @@ pub const ImGuiComboFlags_NoArrowButton: ImGuiComboFlags_ = 32;
 pub const ImGuiComboFlags_NoPreview: ImGuiComboFlags_ = 64;
 pub const ImGuiComboFlags_WidthFitPreview: ImGuiComboFlags_ = 128;
 pub const ImGuiComboFlags_HeightMask_: ImGuiComboFlags_ = 30;
-pub type ImGuiComboFlags_ = cty::c_uint;
+pub type ImGuiComboFlags_ = core::ffi::c_uint;
 pub const ImGuiTabBarFlags_None: ImGuiTabBarFlags_ = 0;
 pub const ImGuiTabBarFlags_Reorderable: ImGuiTabBarFlags_ = 1;
 pub const ImGuiTabBarFlags_AutoSelectNewTabs: ImGuiTabBarFlags_ = 2;
@@ -398,7 +404,7 @@ pub const ImGuiTabBarFlags_FittingPolicyResizeDown: ImGuiTabBarFlags_ = 128;
 pub const ImGuiTabBarFlags_FittingPolicyScroll: ImGuiTabBarFlags_ = 256;
 pub const ImGuiTabBarFlags_FittingPolicyMask_: ImGuiTabBarFlags_ = 384;
 pub const ImGuiTabBarFlags_FittingPolicyDefault_: ImGuiTabBarFlags_ = 128;
-pub type ImGuiTabBarFlags_ = cty::c_uint;
+pub type ImGuiTabBarFlags_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_None: ImGuiTabItemFlags_ = 0;
 pub const ImGuiTabItemFlags_UnsavedDocument: ImGuiTabItemFlags_ = 1;
 pub const ImGuiTabItemFlags_SetSelected: ImGuiTabItemFlags_ = 2;
@@ -409,7 +415,7 @@ pub const ImGuiTabItemFlags_NoReorder: ImGuiTabItemFlags_ = 32;
 pub const ImGuiTabItemFlags_Leading: ImGuiTabItemFlags_ = 64;
 pub const ImGuiTabItemFlags_Trailing: ImGuiTabItemFlags_ = 128;
 pub const ImGuiTabItemFlags_NoAssumedClosure: ImGuiTabItemFlags_ = 256;
-pub type ImGuiTabItemFlags_ = cty::c_uint;
+pub type ImGuiTabItemFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusedFlags_None: ImGuiFocusedFlags_ = 0;
 pub const ImGuiFocusedFlags_ChildWindows: ImGuiFocusedFlags_ = 1;
 pub const ImGuiFocusedFlags_RootWindow: ImGuiFocusedFlags_ = 2;
@@ -417,7 +423,7 @@ pub const ImGuiFocusedFlags_AnyWindow: ImGuiFocusedFlags_ = 4;
 pub const ImGuiFocusedFlags_NoPopupHierarchy: ImGuiFocusedFlags_ = 8;
 pub const ImGuiFocusedFlags_DockHierarchy: ImGuiFocusedFlags_ = 16;
 pub const ImGuiFocusedFlags_RootAndChildWindows: ImGuiFocusedFlags_ = 3;
-pub type ImGuiFocusedFlags_ = cty::c_uint;
+pub type ImGuiFocusedFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_None: ImGuiHoveredFlags_ = 0;
 pub const ImGuiHoveredFlags_ChildWindows: ImGuiHoveredFlags_ = 1;
 pub const ImGuiHoveredFlags_RootWindow: ImGuiHoveredFlags_ = 2;
@@ -439,7 +445,7 @@ pub const ImGuiHoveredFlags_DelayNone: ImGuiHoveredFlags_ = 16384;
 pub const ImGuiHoveredFlags_DelayShort: ImGuiHoveredFlags_ = 32768;
 pub const ImGuiHoveredFlags_DelayNormal: ImGuiHoveredFlags_ = 65536;
 pub const ImGuiHoveredFlags_NoSharedDelay: ImGuiHoveredFlags_ = 131072;
-pub type ImGuiHoveredFlags_ = cty::c_uint;
+pub type ImGuiHoveredFlags_ = core::ffi::c_uint;
 pub const ImGuiDockNodeFlags_None: ImGuiDockNodeFlags_ = 0;
 pub const ImGuiDockNodeFlags_KeepAliveOnly: ImGuiDockNodeFlags_ = 1;
 pub const ImGuiDockNodeFlags_NoDockingOverCentralNode: ImGuiDockNodeFlags_ = 4;
@@ -448,7 +454,7 @@ pub const ImGuiDockNodeFlags_NoDockingSplit: ImGuiDockNodeFlags_ = 16;
 pub const ImGuiDockNodeFlags_NoResize: ImGuiDockNodeFlags_ = 32;
 pub const ImGuiDockNodeFlags_AutoHideTabBar: ImGuiDockNodeFlags_ = 64;
 pub const ImGuiDockNodeFlags_NoUndocking: ImGuiDockNodeFlags_ = 128;
-pub type ImGuiDockNodeFlags_ = cty::c_uint;
+pub type ImGuiDockNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiDragDropFlags_None: ImGuiDragDropFlags_ = 0;
 pub const ImGuiDragDropFlags_SourceNoPreviewTooltip: ImGuiDragDropFlags_ = 1;
 pub const ImGuiDragDropFlags_SourceNoDisableHover: ImGuiDragDropFlags_ = 2;
@@ -462,7 +468,7 @@ pub const ImGuiDragDropFlags_AcceptBeforeDelivery: ImGuiDragDropFlags_ = 1024;
 pub const ImGuiDragDropFlags_AcceptNoDrawDefaultRect: ImGuiDragDropFlags_ = 2048;
 pub const ImGuiDragDropFlags_AcceptNoPreviewTooltip: ImGuiDragDropFlags_ = 4096;
 pub const ImGuiDragDropFlags_AcceptPeekOnly: ImGuiDragDropFlags_ = 3072;
-pub type ImGuiDragDropFlags_ = cty::c_uint;
+pub type ImGuiDragDropFlags_ = core::ffi::c_uint;
 pub const ImGuiDataType_S8: ImGuiDataType_ = 0;
 pub const ImGuiDataType_U8: ImGuiDataType_ = 1;
 pub const ImGuiDataType_S16: ImGuiDataType_ = 2;
@@ -475,18 +481,18 @@ pub const ImGuiDataType_Float: ImGuiDataType_ = 8;
 pub const ImGuiDataType_Double: ImGuiDataType_ = 9;
 pub const ImGuiDataType_Bool: ImGuiDataType_ = 10;
 pub const ImGuiDataType_COUNT: ImGuiDataType_ = 11;
-pub type ImGuiDataType_ = cty::c_uint;
+pub type ImGuiDataType_ = core::ffi::c_uint;
 pub const ImGuiDir_None: ImGuiDir = -1;
 pub const ImGuiDir_Left: ImGuiDir = 0;
 pub const ImGuiDir_Right: ImGuiDir = 1;
 pub const ImGuiDir_Up: ImGuiDir = 2;
 pub const ImGuiDir_Down: ImGuiDir = 3;
 pub const ImGuiDir_COUNT: ImGuiDir = 4;
-pub type ImGuiDir = cty::c_int;
+pub type ImGuiDir = core::ffi::c_int;
 pub const ImGuiSortDirection_None: ImGuiSortDirection = 0;
 pub const ImGuiSortDirection_Ascending: ImGuiSortDirection = 1;
 pub const ImGuiSortDirection_Descending: ImGuiSortDirection = 2;
-pub type ImGuiSortDirection = cty::c_uint;
+pub type ImGuiSortDirection = core::ffi::c_uint;
 pub const ImGuiKey_None: ImGuiKey = 0;
 pub const ImGuiKey_Tab: ImGuiKey = 512;
 pub const ImGuiKey_LeftArrow: ImGuiKey = 513;
@@ -654,7 +660,7 @@ pub const ImGuiKey_NamedKey_END: ImGuiKey = 666;
 pub const ImGuiKey_NamedKey_COUNT: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_SIZE: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_OFFSET: ImGuiKey = 512;
-pub type ImGuiKey = cty::c_uint;
+pub type ImGuiKey = core::ffi::c_uint;
 pub const ImGuiInputFlags_None: ImGuiInputFlags_ = 0;
 pub const ImGuiInputFlags_Repeat: ImGuiInputFlags_ = 1;
 pub const ImGuiInputFlags_RouteActive: ImGuiInputFlags_ = 1024;
@@ -666,7 +672,7 @@ pub const ImGuiInputFlags_RouteOverActive: ImGuiInputFlags_ = 32768;
 pub const ImGuiInputFlags_RouteUnlessBgFocused: ImGuiInputFlags_ = 65536;
 pub const ImGuiInputFlags_RouteFromRootWindow: ImGuiInputFlags_ = 131072;
 pub const ImGuiInputFlags_Tooltip: ImGuiInputFlags_ = 262144;
-pub type ImGuiInputFlags_ = cty::c_uint;
+pub type ImGuiInputFlags_ = core::ffi::c_uint;
 pub const ImGuiConfigFlags_None: ImGuiConfigFlags_ = 0;
 pub const ImGuiConfigFlags_NavEnableKeyboard: ImGuiConfigFlags_ = 1;
 pub const ImGuiConfigFlags_NavEnableGamepad: ImGuiConfigFlags_ = 2;
@@ -681,7 +687,7 @@ pub const ImGuiConfigFlags_DpiEnableScaleViewports: ImGuiConfigFlags_ = 16384;
 pub const ImGuiConfigFlags_DpiEnableScaleFonts: ImGuiConfigFlags_ = 32768;
 pub const ImGuiConfigFlags_IsSRGB: ImGuiConfigFlags_ = 1048576;
 pub const ImGuiConfigFlags_IsTouchScreen: ImGuiConfigFlags_ = 2097152;
-pub type ImGuiConfigFlags_ = cty::c_uint;
+pub type ImGuiConfigFlags_ = core::ffi::c_uint;
 pub const ImGuiBackendFlags_None: ImGuiBackendFlags_ = 0;
 pub const ImGuiBackendFlags_HasGamepad: ImGuiBackendFlags_ = 1;
 pub const ImGuiBackendFlags_HasMouseCursors: ImGuiBackendFlags_ = 2;
@@ -690,7 +696,7 @@ pub const ImGuiBackendFlags_RendererHasVtxOffset: ImGuiBackendFlags_ = 8;
 pub const ImGuiBackendFlags_PlatformHasViewports: ImGuiBackendFlags_ = 1024;
 pub const ImGuiBackendFlags_HasMouseHoveredViewport: ImGuiBackendFlags_ = 2048;
 pub const ImGuiBackendFlags_RendererHasViewports: ImGuiBackendFlags_ = 4096;
-pub type ImGuiBackendFlags_ = cty::c_uint;
+pub type ImGuiBackendFlags_ = core::ffi::c_uint;
 pub const ImGuiCol_Text: ImGuiCol_ = 0;
 pub const ImGuiCol_TextDisabled: ImGuiCol_ = 1;
 pub const ImGuiCol_WindowBg: ImGuiCol_ = 2;
@@ -750,7 +756,7 @@ pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 55;
 pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 56;
 pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 57;
 pub const ImGuiCol_COUNT: ImGuiCol_ = 58;
-pub type ImGuiCol_ = cty::c_uint;
+pub type ImGuiCol_ = core::ffi::c_uint;
 pub const ImGuiStyleVar_Alpha: ImGuiStyleVar_ = 0;
 pub const ImGuiStyleVar_DisabledAlpha: ImGuiStyleVar_ = 1;
 pub const ImGuiStyleVar_WindowPadding: ImGuiStyleVar_ = 2;
@@ -786,13 +792,13 @@ pub const ImGuiStyleVar_SeparatorTextAlign: ImGuiStyleVar_ = 31;
 pub const ImGuiStyleVar_SeparatorTextPadding: ImGuiStyleVar_ = 32;
 pub const ImGuiStyleVar_DockingSeparatorSize: ImGuiStyleVar_ = 33;
 pub const ImGuiStyleVar_COUNT: ImGuiStyleVar_ = 34;
-pub type ImGuiStyleVar_ = cty::c_uint;
+pub type ImGuiStyleVar_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_None: ImGuiButtonFlags_ = 0;
 pub const ImGuiButtonFlags_MouseButtonLeft: ImGuiButtonFlags_ = 1;
 pub const ImGuiButtonFlags_MouseButtonRight: ImGuiButtonFlags_ = 2;
 pub const ImGuiButtonFlags_MouseButtonMiddle: ImGuiButtonFlags_ = 4;
 pub const ImGuiButtonFlags_MouseButtonMask_: ImGuiButtonFlags_ = 7;
-pub type ImGuiButtonFlags_ = cty::c_uint;
+pub type ImGuiButtonFlags_ = core::ffi::c_uint;
 pub const ImGuiColorEditFlags_None: ImGuiColorEditFlags_ = 0;
 pub const ImGuiColorEditFlags_NoAlpha: ImGuiColorEditFlags_ = 2;
 pub const ImGuiColorEditFlags_NoPicker: ImGuiColorEditFlags_ = 4;
@@ -822,7 +828,7 @@ pub const ImGuiColorEditFlags_DisplayMask_: ImGuiColorEditFlags_ = 7340032;
 pub const ImGuiColorEditFlags_DataTypeMask_: ImGuiColorEditFlags_ = 25165824;
 pub const ImGuiColorEditFlags_PickerMask_: ImGuiColorEditFlags_ = 100663296;
 pub const ImGuiColorEditFlags_InputMask_: ImGuiColorEditFlags_ = 402653184;
-pub type ImGuiColorEditFlags_ = cty::c_uint;
+pub type ImGuiColorEditFlags_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_None: ImGuiSliderFlags_ = 0;
 pub const ImGuiSliderFlags_Logarithmic: ImGuiSliderFlags_ = 32;
 pub const ImGuiSliderFlags_NoRoundToFormat: ImGuiSliderFlags_ = 64;
@@ -832,12 +838,12 @@ pub const ImGuiSliderFlags_ClampOnInput: ImGuiSliderFlags_ = 512;
 pub const ImGuiSliderFlags_ClampZeroRange: ImGuiSliderFlags_ = 1024;
 pub const ImGuiSliderFlags_AlwaysClamp: ImGuiSliderFlags_ = 1536;
 pub const ImGuiSliderFlags_InvalidMask_: ImGuiSliderFlags_ = 1879048207;
-pub type ImGuiSliderFlags_ = cty::c_uint;
+pub type ImGuiSliderFlags_ = core::ffi::c_uint;
 pub const ImGuiMouseButton_Left: ImGuiMouseButton_ = 0;
 pub const ImGuiMouseButton_Right: ImGuiMouseButton_ = 1;
 pub const ImGuiMouseButton_Middle: ImGuiMouseButton_ = 2;
 pub const ImGuiMouseButton_COUNT: ImGuiMouseButton_ = 5;
-pub type ImGuiMouseButton_ = cty::c_uint;
+pub type ImGuiMouseButton_ = core::ffi::c_uint;
 pub const ImGuiMouseCursor_None: ImGuiMouseCursor_ = -1;
 pub const ImGuiMouseCursor_Arrow: ImGuiMouseCursor_ = 0;
 pub const ImGuiMouseCursor_TextInput: ImGuiMouseCursor_ = 1;
@@ -849,18 +855,18 @@ pub const ImGuiMouseCursor_ResizeNWSE: ImGuiMouseCursor_ = 6;
 pub const ImGuiMouseCursor_Hand: ImGuiMouseCursor_ = 7;
 pub const ImGuiMouseCursor_NotAllowed: ImGuiMouseCursor_ = 8;
 pub const ImGuiMouseCursor_COUNT: ImGuiMouseCursor_ = 9;
-pub type ImGuiMouseCursor_ = cty::c_int;
+pub type ImGuiMouseCursor_ = core::ffi::c_int;
 pub const ImGuiMouseSource_Mouse: ImGuiMouseSource = 0;
 pub const ImGuiMouseSource_TouchScreen: ImGuiMouseSource = 1;
 pub const ImGuiMouseSource_Pen: ImGuiMouseSource = 2;
 pub const ImGuiMouseSource_COUNT: ImGuiMouseSource = 3;
-pub type ImGuiMouseSource = cty::c_uint;
+pub type ImGuiMouseSource = core::ffi::c_uint;
 pub const ImGuiCond_None: ImGuiCond_ = 0;
 pub const ImGuiCond_Always: ImGuiCond_ = 1;
 pub const ImGuiCond_Once: ImGuiCond_ = 2;
 pub const ImGuiCond_FirstUseEver: ImGuiCond_ = 4;
 pub const ImGuiCond_Appearing: ImGuiCond_ = 8;
-pub type ImGuiCond_ = cty::c_uint;
+pub type ImGuiCond_ = core::ffi::c_uint;
 pub const ImGuiTableFlags_None: ImGuiTableFlags_ = 0;
 pub const ImGuiTableFlags_Resizable: ImGuiTableFlags_ = 1;
 pub const ImGuiTableFlags_Reorderable: ImGuiTableFlags_ = 2;
@@ -898,7 +904,7 @@ pub const ImGuiTableFlags_SortMulti: ImGuiTableFlags_ = 67108864;
 pub const ImGuiTableFlags_SortTristate: ImGuiTableFlags_ = 134217728;
 pub const ImGuiTableFlags_HighlightHoveredColumn: ImGuiTableFlags_ = 268435456;
 pub const ImGuiTableFlags_SizingMask_: ImGuiTableFlags_ = 57344;
-pub type ImGuiTableFlags_ = cty::c_uint;
+pub type ImGuiTableFlags_ = core::ffi::c_uint;
 pub const ImGuiTableColumnFlags_None: ImGuiTableColumnFlags_ = 0;
 pub const ImGuiTableColumnFlags_Disabled: ImGuiTableColumnFlags_ = 1;
 pub const ImGuiTableColumnFlags_DefaultHide: ImGuiTableColumnFlags_ = 2;
@@ -927,20 +933,20 @@ pub const ImGuiTableColumnFlags_WidthMask_: ImGuiTableColumnFlags_ = 24;
 pub const ImGuiTableColumnFlags_IndentMask_: ImGuiTableColumnFlags_ = 196608;
 pub const ImGuiTableColumnFlags_StatusMask_: ImGuiTableColumnFlags_ = 251658240;
 pub const ImGuiTableColumnFlags_NoDirectResize_: ImGuiTableColumnFlags_ = 1073741824;
-pub type ImGuiTableColumnFlags_ = cty::c_uint;
+pub type ImGuiTableColumnFlags_ = core::ffi::c_uint;
 pub const ImGuiTableRowFlags_None: ImGuiTableRowFlags_ = 0;
 pub const ImGuiTableRowFlags_Headers: ImGuiTableRowFlags_ = 1;
-pub type ImGuiTableRowFlags_ = cty::c_uint;
+pub type ImGuiTableRowFlags_ = core::ffi::c_uint;
 pub const ImGuiTableBgTarget_None: ImGuiTableBgTarget_ = 0;
 pub const ImGuiTableBgTarget_RowBg0: ImGuiTableBgTarget_ = 1;
 pub const ImGuiTableBgTarget_RowBg1: ImGuiTableBgTarget_ = 2;
 pub const ImGuiTableBgTarget_CellBg: ImGuiTableBgTarget_ = 3;
-pub type ImGuiTableBgTarget_ = cty::c_uint;
+pub type ImGuiTableBgTarget_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTableSortSpecs {
     pub Specs: *const ImGuiTableColumnSortSpecs,
-    pub SpecsCount: cty::c_int,
+    pub SpecsCount: core::ffi::c_int,
     pub SpecsDirty: bool,
 }
 impl Default for ImGuiTableSortSpecs {
@@ -1047,8 +1053,8 @@ pub struct ImGuiKeyData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImWchar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImWchar,
 }
 impl Default for ImVector_ImWchar {
@@ -1068,9 +1074,9 @@ pub struct ImGuiIO {
     pub DisplaySize: ImVec2,
     pub DeltaTime: f32,
     pub IniSavingRate: f32,
-    pub IniFilename: *const cty::c_char,
-    pub LogFilename: *const cty::c_char,
-    pub UserData: *mut cty::c_void,
+    pub IniFilename: *const core::ffi::c_char,
+    pub LogFilename: *const core::ffi::c_char,
+    pub UserData: *mut core::ffi::c_void,
     pub Fonts: *mut ImFontAtlas,
     pub FontGlobalScale: f32,
     pub FontAllowUserScaling: bool,
@@ -1110,11 +1116,11 @@ pub struct ImGuiIO {
     pub ConfigDebugBeginReturnValueLoop: bool,
     pub ConfigDebugIgnoreFocusLoss: bool,
     pub ConfigDebugIniSettings: bool,
-    pub BackendPlatformName: *const cty::c_char,
-    pub BackendRendererName: *const cty::c_char,
-    pub BackendPlatformUserData: *mut cty::c_void,
-    pub BackendRendererUserData: *mut cty::c_void,
-    pub BackendLanguageUserData: *mut cty::c_void,
+    pub BackendPlatformName: *const core::ffi::c_char,
+    pub BackendRendererName: *const core::ffi::c_char,
+    pub BackendPlatformUserData: *mut core::ffi::c_void,
+    pub BackendRendererUserData: *mut core::ffi::c_void,
+    pub BackendLanguageUserData: *mut core::ffi::c_void,
     pub WantCaptureMouse: bool,
     pub WantCaptureKeyboard: bool,
     pub WantTextInput: bool,
@@ -1123,10 +1129,10 @@ pub struct ImGuiIO {
     pub NavActive: bool,
     pub NavVisible: bool,
     pub Framerate: f32,
-    pub MetricsRenderVertices: cty::c_int,
-    pub MetricsRenderIndices: cty::c_int,
-    pub MetricsRenderWindows: cty::c_int,
-    pub MetricsActiveWindows: cty::c_int,
+    pub MetricsRenderVertices: core::ffi::c_int,
+    pub MetricsRenderIndices: core::ffi::c_int,
+    pub MetricsRenderWindows: core::ffi::c_int,
+    pub MetricsActiveWindows: core::ffi::c_int,
     pub MouseDelta: ImVec2,
     pub Ctx: *mut ImGuiContext,
     pub MousePos: ImVec2,
@@ -1181,16 +1187,16 @@ pub struct ImGuiInputTextCallbackData {
     pub Ctx: *mut ImGuiContext,
     pub EventFlag: ImGuiInputTextFlags,
     pub Flags: ImGuiInputTextFlags,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub EventChar: ImWchar,
     pub EventKey: ImGuiKey,
-    pub Buf: *mut cty::c_char,
-    pub BufTextLen: cty::c_int,
-    pub BufSize: cty::c_int,
+    pub Buf: *mut core::ffi::c_char,
+    pub BufTextLen: core::ffi::c_int,
+    pub BufSize: core::ffi::c_int,
     pub BufDirty: bool,
-    pub CursorPos: cty::c_int,
-    pub SelectionStart: cty::c_int,
-    pub SelectionEnd: cty::c_int,
+    pub CursorPos: core::ffi::c_int,
+    pub SelectionStart: core::ffi::c_int,
+    pub SelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextCallbackData {
     fn default() -> Self {
@@ -1204,7 +1210,7 @@ impl Default for ImGuiInputTextCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiSizeCallbackData {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub Pos: ImVec2,
     pub CurrentSize: ImVec2,
     pub DesiredSize: ImVec2,
@@ -1234,12 +1240,12 @@ pub struct ImGuiWindowClass {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPayload {
-    pub Data: *mut cty::c_void,
-    pub DataSize: cty::c_int,
+    pub Data: *mut core::ffi::c_void,
+    pub DataSize: core::ffi::c_int,
     pub SourceId: ImGuiID,
     pub SourceParentId: ImGuiID,
-    pub DataFrameCount: cty::c_int,
-    pub DataType: [cty::c_char; 33usize],
+    pub DataFrameCount: core::ffi::c_int,
+    pub DataType: [core::ffi::c_char; 33usize],
     pub Preview: bool,
     pub Delivery: bool,
 }
@@ -1255,13 +1261,13 @@ impl Default for ImGuiPayload {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiOnceUponAFrame {
-    pub RefFrame: cty::c_int,
+    pub RefFrame: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextRange {
-    pub b: *const cty::c_char,
-    pub e: *const cty::c_char,
+    pub b: *const core::ffi::c_char,
+    pub e: *const core::ffi::c_char,
 }
 impl Default for ImGuiTextRange {
     fn default() -> Self {
@@ -1275,8 +1281,8 @@ impl Default for ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTextRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTextRange,
 }
 impl Default for ImVector_ImGuiTextRange {
@@ -1291,9 +1297,9 @@ impl Default for ImVector_ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextFilter {
-    pub InputBuf: [cty::c_char; 256usize],
+    pub InputBuf: [core::ffi::c_char; 256usize],
     pub Filters: ImVector_ImGuiTextRange,
-    pub CountGrep: cty::c_int,
+    pub CountGrep: core::ffi::c_int,
 }
 impl Default for ImGuiTextFilter {
     fn default() -> Self {
@@ -1307,9 +1313,9 @@ impl Default for ImGuiTextFilter {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_char,
 }
 impl Default for ImVector_char {
     fn default() -> Self {
@@ -1343,9 +1349,9 @@ pub struct ImGuiStoragePair {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStoragePair__bindgen_ty_1 {
-    pub val_i: cty::c_int,
+    pub val_i: core::ffi::c_int,
     pub val_f: f32,
-    pub val_p: *mut cty::c_void,
+    pub val_p: *mut core::ffi::c_void,
 }
 impl Default for ImGuiStoragePair__bindgen_ty_1 {
     fn default() -> Self {
@@ -1382,8 +1388,8 @@ impl ::core::fmt::Debug for ImGuiStoragePair {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStoragePair {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStoragePair,
 }
 impl Default for ImVector_ImGuiStoragePair {
@@ -1413,13 +1419,13 @@ impl Default for ImGuiStorage {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiListClipper {
     pub Ctx: *mut ImGuiContext,
-    pub DisplayStart: cty::c_int,
-    pub DisplayEnd: cty::c_int,
-    pub ItemsCount: cty::c_int,
+    pub DisplayStart: core::ffi::c_int,
+    pub DisplayEnd: core::ffi::c_int,
+    pub ItemsCount: core::ffi::c_int,
     pub ItemsHeight: f32,
     pub StartPosY: f32,
     pub StartSeekOffsetY: f64,
-    pub TempData: *mut cty::c_void,
+    pub TempData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiListClipper {
     fn default() -> Self {
@@ -1452,12 +1458,12 @@ pub const ImGuiMultiSelectFlags_ScopeRect: ImGuiMultiSelectFlags_ = 4096;
 pub const ImGuiMultiSelectFlags_SelectOnClick: ImGuiMultiSelectFlags_ = 8192;
 pub const ImGuiMultiSelectFlags_SelectOnClickRelease: ImGuiMultiSelectFlags_ = 16384;
 pub const ImGuiMultiSelectFlags_NavWrapX: ImGuiMultiSelectFlags_ = 65536;
-pub type ImGuiMultiSelectFlags_ = cty::c_uint;
+pub type ImGuiMultiSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSelectionRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSelectionRequest,
 }
 impl Default for ImVector_ImGuiSelectionRequest {
@@ -1477,7 +1483,7 @@ pub struct ImGuiMultiSelectIO {
     pub NavIdItem: ImGuiSelectionUserData,
     pub NavIdSelected: bool,
     pub RangeSrcReset: bool,
-    pub ItemsCount: cty::c_int,
+    pub ItemsCount: core::ffi::c_int,
 }
 impl Default for ImGuiMultiSelectIO {
     fn default() -> Self {
@@ -1491,7 +1497,7 @@ impl Default for ImGuiMultiSelectIO {
 pub const ImGuiSelectionRequestType_None: ImGuiSelectionRequestType = 0;
 pub const ImGuiSelectionRequestType_SetAll: ImGuiSelectionRequestType = 1;
 pub const ImGuiSelectionRequestType_SetRange: ImGuiSelectionRequestType = 2;
-pub type ImGuiSelectionRequestType = cty::c_uint;
+pub type ImGuiSelectionRequestType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionRequest {
@@ -1513,13 +1519,16 @@ impl Default for ImGuiSelectionRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionBasicStorage {
-    pub Size: cty::c_int,
+    pub Size: core::ffi::c_int,
     pub PreserveOrder: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterIndexToStorageId: ::core::option::Option<
-        unsafe extern "C" fn(self_: *mut ImGuiSelectionBasicStorage, idx: cty::c_int) -> ImGuiID,
+        unsafe extern "C" fn(
+            self_: *mut ImGuiSelectionBasicStorage,
+            idx: core::ffi::c_int,
+        ) -> ImGuiID,
     >,
-    pub _SelectionOrder: cty::c_int,
+    pub _SelectionOrder: core::ffi::c_int,
     pub _Storage: ImGuiStorage,
 }
 impl Default for ImGuiSelectionBasicStorage {
@@ -1534,11 +1543,11 @@ impl Default for ImGuiSelectionBasicStorage {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionExternalStorage {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterSetItemSelected: ::core::option::Option<
         unsafe extern "C" fn(
             self_: *mut ImGuiSelectionExternalStorage,
-            idx: cty::c_int,
+            idx: core::ffi::c_int,
             selected: bool,
         ),
     >,
@@ -1560,11 +1569,11 @@ pub type ImDrawCallback = ::core::option::Option<
 pub struct ImDrawCmd {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
-    pub IdxOffset: cty::c_uint,
-    pub ElemCount: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
+    pub IdxOffset: core::ffi::c_uint,
+    pub ElemCount: core::ffi::c_uint,
     pub UserCallback: ImDrawCallback,
-    pub UserCallbackData: *mut cty::c_void,
+    pub UserCallbackData: *mut core::ffi::c_void,
 }
 impl Default for ImDrawCmd {
     fn default() -> Self {
@@ -1587,7 +1596,7 @@ pub struct ImDrawVert {
 pub struct ImDrawCmdHeader {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
 }
 impl Default for ImDrawCmdHeader {
     fn default() -> Self {
@@ -1601,8 +1610,8 @@ impl Default for ImDrawCmdHeader {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawCmd {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawCmd,
 }
 impl Default for ImVector_ImDrawCmd {
@@ -1617,8 +1626,8 @@ impl Default for ImVector_ImDrawCmd {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawIdx {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawIdx,
 }
 impl Default for ImVector_ImDrawIdx {
@@ -1648,8 +1657,8 @@ impl Default for ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawChannel {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawChannel,
 }
 impl Default for ImVector_ImDrawChannel {
@@ -1664,8 +1673,8 @@ impl Default for ImVector_ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImDrawListSplitter {
-    pub _Current: cty::c_int,
-    pub _Count: cty::c_int,
+    pub _Current: core::ffi::c_int,
+    pub _Count: core::ffi::c_int,
     pub _Channels: ImVector_ImDrawChannel,
 }
 impl Default for ImDrawListSplitter {
@@ -1691,18 +1700,18 @@ pub const ImDrawFlags_RoundCornersRight: ImDrawFlags_ = 160;
 pub const ImDrawFlags_RoundCornersAll: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersDefault_: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersMask_: ImDrawFlags_ = 496;
-pub type ImDrawFlags_ = cty::c_uint;
+pub type ImDrawFlags_ = core::ffi::c_uint;
 pub const ImDrawListFlags_None: ImDrawListFlags_ = 0;
 pub const ImDrawListFlags_AntiAliasedLines: ImDrawListFlags_ = 1;
 pub const ImDrawListFlags_AntiAliasedLinesUseTex: ImDrawListFlags_ = 2;
 pub const ImDrawListFlags_AntiAliasedFill: ImDrawListFlags_ = 4;
 pub const ImDrawListFlags_AllowVtxOffset: ImDrawListFlags_ = 8;
-pub type ImDrawListFlags_ = cty::c_uint;
+pub type ImDrawListFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawVert {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawVert,
 }
 impl Default for ImVector_ImDrawVert {
@@ -1717,8 +1726,8 @@ impl Default for ImVector_ImDrawVert {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec2 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec2,
 }
 impl Default for ImVector_ImVec2 {
@@ -1733,8 +1742,8 @@ impl Default for ImVector_ImVec2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec4 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec4,
 }
 impl Default for ImVector_ImVec4 {
@@ -1749,8 +1758,8 @@ impl Default for ImVector_ImVec4 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImTextureID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImTextureID,
 }
 impl Default for ImVector_ImTextureID {
@@ -1769,7 +1778,7 @@ pub struct ImDrawList {
     pub IdxBuffer: ImVector_ImDrawIdx,
     pub VtxBuffer: ImVector_ImDrawVert,
     pub Flags: ImDrawListFlags,
-    pub _VtxCurrentIdx: cty::c_uint,
+    pub _VtxCurrentIdx: core::ffi::c_uint,
     pub _Data: *mut ImDrawListSharedData,
     pub _VtxWritePtr: *mut ImDrawVert,
     pub _IdxWritePtr: *mut ImDrawIdx,
@@ -1779,7 +1788,7 @@ pub struct ImDrawList {
     pub _ClipRectStack: ImVector_ImVec4,
     pub _TextureIdStack: ImVector_ImTextureID,
     pub _FringeScale: f32,
-    pub _OwnerName: *const cty::c_char,
+    pub _OwnerName: *const core::ffi::c_char,
 }
 impl Default for ImDrawList {
     fn default() -> Self {
@@ -1793,8 +1802,8 @@ impl Default for ImDrawList {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawListPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImDrawList,
 }
 impl Default for ImVector_ImDrawListPtr {
@@ -1810,9 +1819,9 @@ impl Default for ImVector_ImDrawListPtr {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImDrawData {
     pub Valid: bool,
-    pub CmdListsCount: cty::c_int,
-    pub TotalIdxCount: cty::c_int,
-    pub TotalVtxCount: cty::c_int,
+    pub CmdListsCount: core::ffi::c_int,
+    pub TotalIdxCount: core::ffi::c_int,
+    pub TotalVtxCount: core::ffi::c_int,
     pub CmdLists: ImVector_ImDrawListPtr,
     pub DisplayPos: ImVec2,
     pub DisplaySize: ImVec2,
@@ -1831,13 +1840,13 @@ impl Default for ImDrawData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontConfig {
-    pub FontData: *mut cty::c_void,
-    pub FontDataSize: cty::c_int,
+    pub FontData: *mut core::ffi::c_void,
+    pub FontDataSize: core::ffi::c_int,
     pub FontDataOwnedByAtlas: bool,
-    pub FontNo: cty::c_int,
+    pub FontNo: core::ffi::c_int,
     pub SizePixels: f32,
-    pub OversampleH: cty::c_int,
-    pub OversampleV: cty::c_int,
+    pub OversampleH: core::ffi::c_int,
+    pub OversampleV: core::ffi::c_int,
     pub PixelSnapH: bool,
     pub GlyphExtraSpacing: ImVec2,
     pub GlyphOffset: ImVec2,
@@ -1845,11 +1854,11 @@ pub struct ImFontConfig {
     pub GlyphMinAdvanceX: f32,
     pub GlyphMaxAdvanceX: f32,
     pub MergeMode: bool,
-    pub FontBuilderFlags: cty::c_uint,
+    pub FontBuilderFlags: core::ffi::c_uint,
     pub RasterizerMultiply: f32,
     pub RasterizerDensity: f32,
     pub EllipsisChar: ImWchar,
-    pub Name: [cty::c_char; 40usize],
+    pub Name: [core::ffi::c_char; 40usize],
     pub DstFont: *mut ImFont,
 }
 impl Default for ImFontConfig {
@@ -1878,33 +1887,33 @@ pub struct ImFontGlyph {
 }
 impl ImFontGlyph {
     #[inline]
-    pub fn Colored(&self) -> cty::c_uint {
+    pub fn Colored(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Colored(&mut self, val: cty::c_uint) {
+    pub fn set_Colored(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Visible(&self) -> cty::c_uint {
+    pub fn Visible(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Visible(&mut self, val: cty::c_uint) {
+    pub fn set_Visible(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(1usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Codepoint(&self) -> cty::c_uint {
+    pub fn Codepoint(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
     }
     #[inline]
-    pub fn set_Codepoint(&mut self, val: cty::c_uint) {
+    pub fn set_Codepoint(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(2usize, 30u8, val as u64)
@@ -1912,9 +1921,9 @@ impl ImFontGlyph {
     }
     #[inline]
     pub fn new_bitfield_1(
-        Colored: cty::c_uint,
-        Visible: cty::c_uint,
-        Codepoint: cty::c_uint,
+        Colored: core::ffi::c_uint,
+        Visible: core::ffi::c_uint,
+        Codepoint: core::ffi::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1935,8 +1944,8 @@ impl ImFontGlyph {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImU32 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImU32,
 }
 impl Default for ImVector_ImU32 {
@@ -1965,11 +1974,11 @@ impl Default for ImFontGlyphRangesBuilder {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontAtlasCustomRect {
-    pub Width: cty::c_ushort,
-    pub Height: cty::c_ushort,
-    pub X: cty::c_ushort,
-    pub Y: cty::c_ushort,
-    pub GlyphID: cty::c_uint,
+    pub Width: core::ffi::c_ushort,
+    pub Height: core::ffi::c_ushort,
+    pub X: core::ffi::c_ushort,
+    pub Y: core::ffi::c_ushort,
+    pub GlyphID: core::ffi::c_uint,
     pub GlyphAdvanceX: f32,
     pub GlyphOffset: ImVec2,
     pub Font: *mut ImFont,
@@ -1987,12 +1996,12 @@ pub const ImFontAtlasFlags_None: ImFontAtlasFlags_ = 0;
 pub const ImFontAtlasFlags_NoPowerOfTwoHeight: ImFontAtlasFlags_ = 1;
 pub const ImFontAtlasFlags_NoMouseCursors: ImFontAtlasFlags_ = 2;
 pub const ImFontAtlasFlags_NoBakedLines: ImFontAtlasFlags_ = 4;
-pub type ImFontAtlasFlags_ = cty::c_uint;
+pub type ImFontAtlasFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImFont,
 }
 impl Default for ImVector_ImFontPtr {
@@ -2007,8 +2016,8 @@ impl Default for ImVector_ImFontPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontAtlasCustomRect {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontAtlasCustomRect,
 }
 impl Default for ImVector_ImFontAtlasCustomRect {
@@ -2023,8 +2032,8 @@ impl Default for ImVector_ImFontAtlasCustomRect {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontConfig {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontConfig,
 }
 impl Default for ImVector_ImFontConfig {
@@ -2041,16 +2050,16 @@ impl Default for ImVector_ImFontConfig {
 pub struct ImFontAtlas {
     pub Flags: ImFontAtlasFlags,
     pub TexID: ImTextureID,
-    pub TexDesiredWidth: cty::c_int,
-    pub TexGlyphPadding: cty::c_int,
+    pub TexDesiredWidth: core::ffi::c_int,
+    pub TexGlyphPadding: core::ffi::c_int,
     pub Locked: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub TexReady: bool,
     pub TexPixelsUseColors: bool,
-    pub TexPixelsAlpha8: *mut cty::c_uchar,
-    pub TexPixelsRGBA32: *mut cty::c_uint,
-    pub TexWidth: cty::c_int,
-    pub TexHeight: cty::c_int,
+    pub TexPixelsAlpha8: *mut core::ffi::c_uchar,
+    pub TexPixelsRGBA32: *mut core::ffi::c_uint,
+    pub TexWidth: core::ffi::c_int,
+    pub TexHeight: core::ffi::c_int,
     pub TexUvScale: ImVec2,
     pub TexUvWhitePixel: ImVec2,
     pub Fonts: ImVector_ImFontPtr,
@@ -2058,9 +2067,9 @@ pub struct ImFontAtlas {
     pub ConfigData: ImVector_ImFontConfig,
     pub TexUvLines: [ImVec4; 64usize],
     pub FontBuilderIO: *const ImFontBuilderIO,
-    pub FontBuilderFlags: cty::c_uint,
-    pub PackIdMouseCursors: cty::c_int,
-    pub PackIdLines: cty::c_int,
+    pub FontBuilderFlags: core::ffi::c_uint,
+    pub PackIdMouseCursors: core::ffi::c_int,
+    pub PackIdLines: core::ffi::c_int,
 }
 impl Default for ImFontAtlas {
     fn default() -> Self {
@@ -2074,8 +2083,8 @@ impl Default for ImFontAtlas {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_float {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut f32,
 }
 impl Default for ImVector_float {
@@ -2090,8 +2099,8 @@ impl Default for ImVector_float {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontGlyph {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontGlyph,
 }
 impl Default for ImVector_ImFontGlyph {
@@ -2114,17 +2123,17 @@ pub struct ImFont {
     pub FallbackGlyph: *const ImFontGlyph,
     pub ContainerAtlas: *mut ImFontAtlas,
     pub ConfigData: *const ImFontConfig,
-    pub ConfigDataCount: cty::c_short,
+    pub ConfigDataCount: core::ffi::c_short,
     pub FallbackChar: ImWchar,
     pub EllipsisChar: ImWchar,
-    pub EllipsisCharCount: cty::c_short,
+    pub EllipsisCharCount: core::ffi::c_short,
     pub EllipsisWidth: f32,
     pub EllipsisCharStep: f32,
     pub DirtyLookupTables: bool,
     pub Scale: f32,
     pub Ascent: f32,
     pub Descent: f32,
-    pub MetricsTotalSurface: cty::c_int,
+    pub MetricsTotalSurface: core::ffi::c_int,
     pub Used4kPagesMap: [ImU8; 34usize],
 }
 impl Default for ImFont {
@@ -2151,7 +2160,7 @@ pub const ImGuiViewportFlags_TopMost: ImGuiViewportFlags_ = 1024;
 pub const ImGuiViewportFlags_CanHostOtherWindows: ImGuiViewportFlags_ = 2048;
 pub const ImGuiViewportFlags_IsMinimized: ImGuiViewportFlags_ = 4096;
 pub const ImGuiViewportFlags_IsFocused: ImGuiViewportFlags_ = 8192;
-pub type ImGuiViewportFlags_ = cty::c_uint;
+pub type ImGuiViewportFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiViewport {
@@ -2164,10 +2173,10 @@ pub struct ImGuiViewport {
     pub DpiScale: f32,
     pub ParentViewportId: ImGuiID,
     pub DrawData: *mut ImDrawData,
-    pub RendererUserData: *mut cty::c_void,
-    pub PlatformUserData: *mut cty::c_void,
-    pub PlatformHandle: *mut cty::c_void,
-    pub PlatformHandleRaw: *mut cty::c_void,
+    pub RendererUserData: *mut core::ffi::c_void,
+    pub PlatformUserData: *mut core::ffi::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
+    pub PlatformHandleRaw: *mut core::ffi::c_void,
     pub PlatformWindowCreated: bool,
     pub PlatformRequestMove: bool,
     pub PlatformRequestResize: bool,
@@ -2185,8 +2194,8 @@ impl Default for ImGuiViewport {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPlatformMonitor {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPlatformMonitor,
 }
 impl Default for ImVector_ImGuiPlatformMonitor {
@@ -2201,8 +2210,8 @@ impl Default for ImVector_ImGuiPlatformMonitor {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiViewportPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiViewport,
 }
 impl Default for ImVector_ImGuiViewportPtr {
@@ -2217,16 +2226,17 @@ impl Default for ImVector_ImGuiViewportPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPlatformIO {
-    pub Platform_GetClipboardTextFn:
-        ::core::option::Option<unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const cty::c_char>,
+    pub Platform_GetClipboardTextFn: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const core::ffi::c_char,
+    >,
     pub Platform_SetClipboardTextFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const cty::c_char),
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const core::ffi::c_char),
     >,
-    pub Platform_ClipboardUserData: *mut cty::c_void,
+    pub Platform_ClipboardUserData: *mut core::ffi::c_void,
     pub Platform_OpenInShellFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const cty::c_char) -> bool,
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const core::ffi::c_char) -> bool,
     >,
-    pub Platform_OpenInShellUserData: *mut cty::c_void,
+    pub Platform_OpenInShellUserData: *mut core::ffi::c_void,
     pub Platform_SetImeDataFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
@@ -2234,7 +2244,7 @@ pub struct ImGuiPlatformIO {
             data: *mut ImGuiPlatformImeData,
         ),
     >,
-    pub Platform_ImeUserData: *mut cty::c_void,
+    pub Platform_ImeUserData: *mut core::ffi::c_void,
     pub Platform_LocaleDecimalPoint: ImWchar,
     pub Platform_CreateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Platform_DestroyWindow:
@@ -2255,16 +2265,16 @@ pub struct ImGuiPlatformIO {
     pub Platform_GetWindowMinimized:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> bool>,
     pub Platform_SetWindowTitle: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, str_: *const cty::c_char),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, str_: *const core::ffi::c_char),
     >,
     pub Platform_SetWindowAlpha:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, alpha: f32)>,
     pub Platform_UpdateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Platform_RenderWindow: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Platform_SwapBuffers: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Platform_GetWindowDpiScale:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> f32>,
@@ -2276,9 +2286,9 @@ pub struct ImGuiPlatformIO {
         unsafe extern "C" fn(
             vp: *mut ImGuiViewport,
             vk_inst: ImU64,
-            vk_allocators: *const cty::c_void,
+            vk_allocators: *const core::ffi::c_void,
             out_vk_surface: *mut ImU64,
-        ) -> cty::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub Renderer_CreateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Renderer_DestroyWindow:
@@ -2286,10 +2296,10 @@ pub struct ImGuiPlatformIO {
     pub Renderer_SetWindowSize:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, size: ImVec2)>,
     pub Renderer_RenderWindow: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Renderer_SwapBuffers: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Monitors: ImVector_ImGuiPlatformMonitor,
     pub Viewports: ImVector_ImGuiViewportPtr,
@@ -2311,7 +2321,7 @@ pub struct ImGuiPlatformMonitor {
     pub WorkPos: ImVec2,
     pub WorkSize: ImVec2,
     pub DpiScale: f32,
-    pub PlatformHandle: *mut cty::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
 }
 impl Default for ImGuiPlatformMonitor {
     fn default() -> Self {
@@ -2329,23 +2339,23 @@ pub struct ImGuiPlatformImeData {
     pub InputPos: ImVec2,
     pub InputLineHeight: f32,
 }
-pub type ImGuiDataAuthority = cty::c_int;
-pub type ImGuiLayoutType = cty::c_int;
-pub type ImGuiActivateFlags = cty::c_int;
-pub type ImGuiDebugLogFlags = cty::c_int;
-pub type ImGuiFocusRequestFlags = cty::c_int;
-pub type ImGuiItemStatusFlags = cty::c_int;
-pub type ImGuiOldColumnFlags = cty::c_int;
-pub type ImGuiNavHighlightFlags = cty::c_int;
-pub type ImGuiNavMoveFlags = cty::c_int;
-pub type ImGuiNextItemDataFlags = cty::c_int;
-pub type ImGuiNextWindowDataFlags = cty::c_int;
-pub type ImGuiScrollFlags = cty::c_int;
-pub type ImGuiSeparatorFlags = cty::c_int;
-pub type ImGuiTextFlags = cty::c_int;
-pub type ImGuiTooltipFlags = cty::c_int;
-pub type ImGuiTypingSelectFlags = cty::c_int;
-pub type ImGuiWindowRefreshFlags = cty::c_int;
+pub type ImGuiDataAuthority = core::ffi::c_int;
+pub type ImGuiLayoutType = core::ffi::c_int;
+pub type ImGuiActivateFlags = core::ffi::c_int;
+pub type ImGuiDebugLogFlags = core::ffi::c_int;
+pub type ImGuiFocusRequestFlags = core::ffi::c_int;
+pub type ImGuiItemStatusFlags = core::ffi::c_int;
+pub type ImGuiOldColumnFlags = core::ffi::c_int;
+pub type ImGuiNavHighlightFlags = core::ffi::c_int;
+pub type ImGuiNavMoveFlags = core::ffi::c_int;
+pub type ImGuiNextItemDataFlags = core::ffi::c_int;
+pub type ImGuiNextWindowDataFlags = core::ffi::c_int;
+pub type ImGuiScrollFlags = core::ffi::c_int;
+pub type ImGuiSeparatorFlags = core::ffi::c_int;
+pub type ImGuiTextFlags = core::ffi::c_int;
+pub type ImGuiTooltipFlags = core::ffi::c_int;
+pub type ImGuiTypingSelectFlags = core::ffi::c_int;
+pub type ImGuiWindowRefreshFlags = core::ffi::c_int;
 pub type ImFileHandle = *mut FILE;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -2355,8 +2365,8 @@ pub struct ImVec1 {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVec2ih {
-    pub x: cty::c_short,
-    pub y: cty::c_short,
+    pub x: core::ffi::c_short,
+    pub y: core::ffi::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -2379,13 +2389,13 @@ impl Default for ImBitVector {
         }
     }
 }
-pub type ImPoolIdx = cty::c_int;
+pub type ImPoolIdx = core::ffi::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_int {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_int,
 }
 impl Default for ImVector_int {
     fn default() -> Self {
@@ -2400,7 +2410,7 @@ impl Default for ImVector_int {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextIndex {
     pub LineOffsets: ImVector_int,
-    pub EndOffset: cty::c_int,
+    pub EndOffset: core::ffi::c_int,
 }
 impl Default for ImGuiTextIndex {
     fn default() -> Self {
@@ -2468,9 +2478,9 @@ pub struct ImGuiDataTypeStorage {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDataTypeInfo {
     pub Size: usize,
-    pub Name: *const cty::c_char,
-    pub PrintFmt: *const cty::c_char,
-    pub ScanFmt: *const cty::c_char,
+    pub Name: *const core::ffi::c_char,
+    pub PrintFmt: *const core::ffi::c_char,
+    pub ScanFmt: *const core::ffi::c_char,
 }
 impl Default for ImGuiDataTypeInfo {
     fn default() -> Self {
@@ -2484,7 +2494,7 @@ impl Default for ImGuiDataTypeInfo {
 pub const ImGuiDataType_String: ImGuiDataTypePrivate_ = 12;
 pub const ImGuiDataType_Pointer: ImGuiDataTypePrivate_ = 13;
 pub const ImGuiDataType_ID: ImGuiDataTypePrivate_ = 14;
-pub type ImGuiDataTypePrivate_ = cty::c_uint;
+pub type ImGuiDataTypePrivate_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_Disabled: ImGuiItemFlagsPrivate_ = 1024;
 pub const ImGuiItemFlags_ReadOnly: ImGuiItemFlagsPrivate_ = 2048;
 pub const ImGuiItemFlags_MixedValue: ImGuiItemFlagsPrivate_ = 4096;
@@ -2494,7 +2504,7 @@ pub const ImGuiItemFlags_Inputable: ImGuiItemFlagsPrivate_ = 1048576;
 pub const ImGuiItemFlags_HasSelectionUserData: ImGuiItemFlagsPrivate_ = 2097152;
 pub const ImGuiItemFlags_IsMultiSelect: ImGuiItemFlagsPrivate_ = 4194304;
 pub const ImGuiItemFlags_Default_: ImGuiItemFlagsPrivate_ = 16;
-pub type ImGuiItemFlagsPrivate_ = cty::c_uint;
+pub type ImGuiItemFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiItemStatusFlags_None: ImGuiItemStatusFlags_ = 0;
 pub const ImGuiItemStatusFlags_HoveredRect: ImGuiItemStatusFlags_ = 1;
 pub const ImGuiItemStatusFlags_HasDisplayRect: ImGuiItemStatusFlags_ = 2;
@@ -2507,16 +2517,16 @@ pub const ImGuiItemStatusFlags_HoveredWindow: ImGuiItemStatusFlags_ = 128;
 pub const ImGuiItemStatusFlags_Visible: ImGuiItemStatusFlags_ = 256;
 pub const ImGuiItemStatusFlags_HasClipRect: ImGuiItemStatusFlags_ = 512;
 pub const ImGuiItemStatusFlags_HasShortcut: ImGuiItemStatusFlags_ = 1024;
-pub type ImGuiItemStatusFlags_ = cty::c_uint;
+pub type ImGuiItemStatusFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_DelayMask_: ImGuiHoveredFlagsPrivate_ = 245760;
 pub const ImGuiHoveredFlags_AllowedMaskForIsWindowHovered: ImGuiHoveredFlagsPrivate_ = 12479;
 pub const ImGuiHoveredFlags_AllowedMaskForIsItemHovered: ImGuiHoveredFlagsPrivate_ = 262048;
-pub type ImGuiHoveredFlagsPrivate_ = cty::c_uint;
+pub type ImGuiHoveredFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_Multiline: ImGuiInputTextFlagsPrivate_ = 67108864;
 pub const ImGuiInputTextFlags_NoMarkEdited: ImGuiInputTextFlagsPrivate_ = 134217728;
 pub const ImGuiInputTextFlags_MergedItem: ImGuiInputTextFlagsPrivate_ = 268435456;
 pub const ImGuiInputTextFlags_LocalizeDecimalPoint: ImGuiInputTextFlagsPrivate_ = 536870912;
-pub type ImGuiInputTextFlagsPrivate_ = cty::c_uint;
+pub type ImGuiInputTextFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_PressedOnClick: ImGuiButtonFlagsPrivate_ = 16;
 pub const ImGuiButtonFlags_PressedOnClickRelease: ImGuiButtonFlagsPrivate_ = 32;
 pub const ImGuiButtonFlags_PressedOnClickReleaseAnywhere: ImGuiButtonFlagsPrivate_ = 64;
@@ -2536,12 +2546,12 @@ pub const ImGuiButtonFlags_NoSetKeyOwner: ImGuiButtonFlagsPrivate_ = 1048576;
 pub const ImGuiButtonFlags_NoTestKeyOwner: ImGuiButtonFlagsPrivate_ = 2097152;
 pub const ImGuiButtonFlags_PressedOnMask_: ImGuiButtonFlagsPrivate_ = 1008;
 pub const ImGuiButtonFlags_PressedOnDefault_: ImGuiButtonFlagsPrivate_ = 32;
-pub type ImGuiButtonFlagsPrivate_ = cty::c_uint;
+pub type ImGuiButtonFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_CustomPreview: ImGuiComboFlagsPrivate_ = 1048576;
-pub type ImGuiComboFlagsPrivate_ = cty::c_uint;
+pub type ImGuiComboFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_Vertical: ImGuiSliderFlagsPrivate_ = 1048576;
 pub const ImGuiSliderFlags_ReadOnly: ImGuiSliderFlagsPrivate_ = 2097152;
-pub type ImGuiSliderFlagsPrivate_ = cty::c_uint;
+pub type ImGuiSliderFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_NoHoldingActiveID: ImGuiSelectableFlagsPrivate_ = 1048576;
 pub const ImGuiSelectableFlags_SelectOnNav: ImGuiSelectableFlagsPrivate_ = 2097152;
 pub const ImGuiSelectableFlags_SelectOnClick: ImGuiSelectableFlagsPrivate_ = 4194304;
@@ -2550,42 +2560,42 @@ pub const ImGuiSelectableFlags_SpanAvailWidth: ImGuiSelectableFlagsPrivate_ = 16
 pub const ImGuiSelectableFlags_SetNavIdOnHover: ImGuiSelectableFlagsPrivate_ = 33554432;
 pub const ImGuiSelectableFlags_NoPadWithHalfSpacing: ImGuiSelectableFlagsPrivate_ = 67108864;
 pub const ImGuiSelectableFlags_NoSetKeyOwner: ImGuiSelectableFlagsPrivate_ = 134217728;
-pub type ImGuiSelectableFlagsPrivate_ = cty::c_uint;
+pub type ImGuiSelectableFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_ClipLabelForTrailingButton: ImGuiTreeNodeFlagsPrivate_ = 268435456;
 pub const ImGuiTreeNodeFlags_UpsideDownArrow: ImGuiTreeNodeFlagsPrivate_ = 536870912;
 pub const ImGuiTreeNodeFlags_OpenOnMask_: ImGuiTreeNodeFlagsPrivate_ = 192;
-pub type ImGuiTreeNodeFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTreeNodeFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSeparatorFlags_None: ImGuiSeparatorFlags_ = 0;
 pub const ImGuiSeparatorFlags_Horizontal: ImGuiSeparatorFlags_ = 1;
 pub const ImGuiSeparatorFlags_Vertical: ImGuiSeparatorFlags_ = 2;
 pub const ImGuiSeparatorFlags_SpanAllColumns: ImGuiSeparatorFlags_ = 4;
-pub type ImGuiSeparatorFlags_ = cty::c_uint;
+pub type ImGuiSeparatorFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusRequestFlags_None: ImGuiFocusRequestFlags_ = 0;
 pub const ImGuiFocusRequestFlags_RestoreFocusedChild: ImGuiFocusRequestFlags_ = 1;
 pub const ImGuiFocusRequestFlags_UnlessBelowModal: ImGuiFocusRequestFlags_ = 2;
-pub type ImGuiFocusRequestFlags_ = cty::c_uint;
+pub type ImGuiFocusRequestFlags_ = core::ffi::c_uint;
 pub const ImGuiTextFlags_None: ImGuiTextFlags_ = 0;
 pub const ImGuiTextFlags_NoWidthForLargeClippedText: ImGuiTextFlags_ = 1;
-pub type ImGuiTextFlags_ = cty::c_uint;
+pub type ImGuiTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTooltipFlags_None: ImGuiTooltipFlags_ = 0;
 pub const ImGuiTooltipFlags_OverridePrevious: ImGuiTooltipFlags_ = 2;
-pub type ImGuiTooltipFlags_ = cty::c_uint;
+pub type ImGuiTooltipFlags_ = core::ffi::c_uint;
 pub const ImGuiLayoutType_Horizontal: ImGuiLayoutType_ = 0;
 pub const ImGuiLayoutType_Vertical: ImGuiLayoutType_ = 1;
-pub type ImGuiLayoutType_ = cty::c_uint;
+pub type ImGuiLayoutType_ = core::ffi::c_uint;
 pub const ImGuiLogType_None: ImGuiLogType = 0;
 pub const ImGuiLogType_TTY: ImGuiLogType = 1;
 pub const ImGuiLogType_File: ImGuiLogType = 2;
 pub const ImGuiLogType_Buffer: ImGuiLogType = 3;
 pub const ImGuiLogType_Clipboard: ImGuiLogType = 4;
-pub type ImGuiLogType = cty::c_uint;
+pub type ImGuiLogType = core::ffi::c_uint;
 pub const ImGuiAxis_None: ImGuiAxis = -1;
 pub const ImGuiAxis_X: ImGuiAxis = 0;
 pub const ImGuiAxis_Y: ImGuiAxis = 1;
-pub type ImGuiAxis = cty::c_int;
+pub type ImGuiAxis = core::ffi::c_int;
 pub const ImGuiPlotType_Lines: ImGuiPlotType = 0;
 pub const ImGuiPlotType_Histogram: ImGuiPlotType = 1;
-pub type ImGuiPlotType = cty::c_uint;
+pub type ImGuiPlotType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiColorMod {
@@ -2601,7 +2611,7 @@ pub struct ImGuiStyleMod {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStyleMod__bindgen_ty_1 {
-    pub BackupInt: [cty::c_int; 2usize],
+    pub BackupInt: [core::ffi::c_int; 2usize],
     pub BackupFloat: [f32; 2usize],
 }
 impl Default for ImGuiStyleMod__bindgen_ty_1 {
@@ -2697,11 +2707,11 @@ pub struct ImGuiInputTextState {
     pub Ctx: *mut ImGuiContext,
     pub Stb: *mut ImStbTexteditState,
     pub ID: ImGuiID,
-    pub CurLenA: cty::c_int,
+    pub CurLenA: core::ffi::c_int,
     pub TextA: ImVector_char,
     pub InitialTextA: ImVector_char,
     pub CallbackTextBackup: ImVector_char,
-    pub BufCapacityA: cty::c_int,
+    pub BufCapacityA: core::ffi::c_int,
     pub Scroll: ImVec2,
     pub CursorAnim: f32,
     pub CursorFollow: bool,
@@ -2709,8 +2719,8 @@ pub struct ImGuiInputTextState {
     pub Edited: bool,
     pub Flags: ImGuiInputTextFlags,
     pub ReloadUserBuf: bool,
-    pub ReloadSelectionStart: cty::c_int,
-    pub ReloadSelectionEnd: cty::c_int,
+    pub ReloadSelectionStart: core::ffi::c_int,
+    pub ReloadSelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextState {
     fn default() -> Self {
@@ -2725,7 +2735,7 @@ pub const ImGuiWindowRefreshFlags_None: ImGuiWindowRefreshFlags_ = 0;
 pub const ImGuiWindowRefreshFlags_TryToAvoidRefresh: ImGuiWindowRefreshFlags_ = 1;
 pub const ImGuiWindowRefreshFlags_RefreshOnHover: ImGuiWindowRefreshFlags_ = 2;
 pub const ImGuiWindowRefreshFlags_RefreshOnFocus: ImGuiWindowRefreshFlags_ = 4;
-pub type ImGuiWindowRefreshFlags_ = cty::c_uint;
+pub type ImGuiWindowRefreshFlags_ = core::ffi::c_uint;
 pub const ImGuiNextWindowDataFlags_None: ImGuiNextWindowDataFlags_ = 0;
 pub const ImGuiNextWindowDataFlags_HasPos: ImGuiNextWindowDataFlags_ = 1;
 pub const ImGuiNextWindowDataFlags_HasSize: ImGuiNextWindowDataFlags_ = 2;
@@ -2740,7 +2750,7 @@ pub const ImGuiNextWindowDataFlags_HasRefreshPolicy: ImGuiNextWindowDataFlags_ =
 pub const ImGuiNextWindowDataFlags_HasViewport: ImGuiNextWindowDataFlags_ = 1024;
 pub const ImGuiNextWindowDataFlags_HasDock: ImGuiNextWindowDataFlags_ = 2048;
 pub const ImGuiNextWindowDataFlags_HasWindowClass: ImGuiNextWindowDataFlags_ = 4096;
-pub type ImGuiNextWindowDataFlags_ = cty::c_uint;
+pub type ImGuiNextWindowDataFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiNextWindowData {
@@ -2759,7 +2769,7 @@ pub struct ImGuiNextWindowData {
     pub CollapsedVal: bool,
     pub SizeConstraintRect: ImRect,
     pub SizeCallback: ImGuiSizeCallback,
-    pub SizeCallbackUserData: *mut cty::c_void,
+    pub SizeCallbackUserData: *mut core::ffi::c_void,
     pub BgAlphaVal: f32,
     pub ViewportId: ImGuiID,
     pub DockId: ImGuiID,
@@ -2782,7 +2792,7 @@ pub const ImGuiNextItemDataFlags_HasOpen: ImGuiNextItemDataFlags_ = 2;
 pub const ImGuiNextItemDataFlags_HasShortcut: ImGuiNextItemDataFlags_ = 4;
 pub const ImGuiNextItemDataFlags_HasRefVal: ImGuiNextItemDataFlags_ = 8;
 pub const ImGuiNextItemDataFlags_HasStorageID: ImGuiNextItemDataFlags_ = 16;
-pub type ImGuiNextItemDataFlags_ = cty::c_uint;
+pub type ImGuiNextItemDataFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiNextItemData {
@@ -2821,17 +2831,17 @@ pub struct ImGuiTreeNodeStackData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiErrorRecoveryState {
-    pub SizeOfWindowStack: cty::c_short,
-    pub SizeOfIDStack: cty::c_short,
-    pub SizeOfTreeStack: cty::c_short,
-    pub SizeOfColorStack: cty::c_short,
-    pub SizeOfStyleVarStack: cty::c_short,
-    pub SizeOfFontStack: cty::c_short,
-    pub SizeOfFocusScopeStack: cty::c_short,
-    pub SizeOfGroupStack: cty::c_short,
-    pub SizeOfItemFlagsStack: cty::c_short,
-    pub SizeOfBeginPopupStack: cty::c_short,
-    pub SizeOfDisabledStack: cty::c_short,
+    pub SizeOfWindowStack: core::ffi::c_short,
+    pub SizeOfIDStack: core::ffi::c_short,
+    pub SizeOfTreeStack: core::ffi::c_short,
+    pub SizeOfColorStack: core::ffi::c_short,
+    pub SizeOfStyleVarStack: core::ffi::c_short,
+    pub SizeOfFontStack: core::ffi::c_short,
+    pub SizeOfFocusScopeStack: core::ffi::c_short,
+    pub SizeOfGroupStack: core::ffi::c_short,
+    pub SizeOfItemFlagsStack: core::ffi::c_short,
+    pub SizeOfBeginPopupStack: core::ffi::c_short,
+    pub SizeOfDisabledStack: core::ffi::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -2853,15 +2863,15 @@ impl Default for ImGuiWindowStackData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiShrinkWidthItem {
-    pub Index: cty::c_int,
+    pub Index: core::ffi::c_int,
     pub Width: f32,
     pub InitialWidth: f32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPtrOrIndex {
-    pub Ptr: *mut cty::c_void,
-    pub Index: cty::c_int,
+    pub Ptr: *mut core::ffi::c_void,
+    pub Index: core::ffi::c_int,
 }
 impl Default for ImGuiPtrOrIndex {
     fn default() -> Self {
@@ -2875,15 +2885,15 @@ impl Default for ImGuiPtrOrIndex {
 pub const ImGuiPopupPositionPolicy_Default: ImGuiPopupPositionPolicy = 0;
 pub const ImGuiPopupPositionPolicy_ComboBox: ImGuiPopupPositionPolicy = 1;
 pub const ImGuiPopupPositionPolicy_Tooltip: ImGuiPopupPositionPolicy = 2;
-pub type ImGuiPopupPositionPolicy = cty::c_uint;
+pub type ImGuiPopupPositionPolicy = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiPopupData {
     pub PopupId: ImGuiID,
     pub Window: *mut ImGuiWindow,
     pub RestoreNavWindow: *mut ImGuiWindow,
-    pub ParentNavLayer: cty::c_int,
-    pub OpenFrameCount: cty::c_int,
+    pub ParentNavLayer: core::ffi::c_int,
+    pub OpenFrameCount: core::ffi::c_int,
     pub OpenParentId: ImGuiID,
     pub OpenPopupPos: ImVec2,
     pub OpenMousePos: ImVec2,
@@ -2912,13 +2922,13 @@ pub const ImGuiInputEventType_Key: ImGuiInputEventType = 5;
 pub const ImGuiInputEventType_Text: ImGuiInputEventType = 6;
 pub const ImGuiInputEventType_Focus: ImGuiInputEventType = 7;
 pub const ImGuiInputEventType_COUNT: ImGuiInputEventType = 8;
-pub type ImGuiInputEventType = cty::c_uint;
+pub type ImGuiInputEventType = core::ffi::c_uint;
 pub const ImGuiInputSource_None: ImGuiInputSource = 0;
 pub const ImGuiInputSource_Mouse: ImGuiInputSource = 1;
 pub const ImGuiInputSource_Keyboard: ImGuiInputSource = 2;
 pub const ImGuiInputSource_Gamepad: ImGuiInputSource = 3;
 pub const ImGuiInputSource_COUNT: ImGuiInputSource = 4;
-pub type ImGuiInputSource = cty::c_uint;
+pub type ImGuiInputSource = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiInputEventMousePos {
@@ -2954,7 +2964,7 @@ impl Default for ImGuiInputEventMouseWheel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiInputEventMouseButton {
-    pub Button: cty::c_int,
+    pub Button: core::ffi::c_int,
     pub Down: bool,
     pub MouseSource: ImGuiMouseSource,
 }
@@ -2991,7 +3001,7 @@ impl Default for ImGuiInputEventKey {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiInputEventText {
-    pub Char: cty::c_uint,
+    pub Char: core::ffi::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -3060,8 +3070,8 @@ pub struct ImGuiKeyRoutingData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiKeyRoutingData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiKeyRoutingData,
 }
 impl Default for ImVector_ImGuiKeyRoutingData {
@@ -3121,12 +3131,12 @@ pub const ImGuiInputFlags_SupportedByShortcut: ImGuiInputFlagsPrivate_ = 261375;
 pub const ImGuiInputFlags_SupportedBySetNextItemShortcut: ImGuiInputFlagsPrivate_ = 523519;
 pub const ImGuiInputFlags_SupportedBySetKeyOwner: ImGuiInputFlagsPrivate_ = 3145728;
 pub const ImGuiInputFlags_SupportedBySetItemKeyOwner: ImGuiInputFlagsPrivate_ = 15728640;
-pub type ImGuiInputFlagsPrivate_ = cty::c_uint;
+pub type ImGuiInputFlagsPrivate_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiListClipperRange {
-    pub Min: cty::c_int,
-    pub Max: cty::c_int,
+    pub Min: core::ffi::c_int,
+    pub Max: core::ffi::c_int,
     pub PosToIndexConvert: bool,
     pub PosToIndexOffsetMin: ImS8,
     pub PosToIndexOffsetMax: ImS8,
@@ -3134,8 +3144,8 @@ pub struct ImGuiListClipperRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiListClipperRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiListClipperRange,
 }
 impl Default for ImVector_ImGuiListClipperRange {
@@ -3152,8 +3162,8 @@ impl Default for ImVector_ImGuiListClipperRange {
 pub struct ImGuiListClipperData {
     pub ListClipper: *mut ImGuiListClipper,
     pub LossynessOffset: f32,
-    pub StepNo: cty::c_int,
-    pub ItemsFrozen: cty::c_int,
+    pub StepNo: core::ffi::c_int,
+    pub ItemsFrozen: core::ffi::c_int,
     pub Ranges: ImVector_ImGuiListClipperRange,
 }
 impl Default for ImGuiListClipperData {
@@ -3171,7 +3181,7 @@ pub const ImGuiActivateFlags_PreferTweak: ImGuiActivateFlags_ = 2;
 pub const ImGuiActivateFlags_TryToPreserveState: ImGuiActivateFlags_ = 4;
 pub const ImGuiActivateFlags_FromTabbing: ImGuiActivateFlags_ = 8;
 pub const ImGuiActivateFlags_FromShortcut: ImGuiActivateFlags_ = 16;
-pub type ImGuiActivateFlags_ = cty::c_uint;
+pub type ImGuiActivateFlags_ = core::ffi::c_uint;
 pub const ImGuiScrollFlags_None: ImGuiScrollFlags_ = 0;
 pub const ImGuiScrollFlags_KeepVisibleEdgeX: ImGuiScrollFlags_ = 1;
 pub const ImGuiScrollFlags_KeepVisibleEdgeY: ImGuiScrollFlags_ = 2;
@@ -3182,12 +3192,12 @@ pub const ImGuiScrollFlags_AlwaysCenterY: ImGuiScrollFlags_ = 32;
 pub const ImGuiScrollFlags_NoScrollParent: ImGuiScrollFlags_ = 64;
 pub const ImGuiScrollFlags_MaskX_: ImGuiScrollFlags_ = 21;
 pub const ImGuiScrollFlags_MaskY_: ImGuiScrollFlags_ = 42;
-pub type ImGuiScrollFlags_ = cty::c_uint;
+pub type ImGuiScrollFlags_ = core::ffi::c_uint;
 pub const ImGuiNavHighlightFlags_None: ImGuiNavHighlightFlags_ = 0;
 pub const ImGuiNavHighlightFlags_Compact: ImGuiNavHighlightFlags_ = 2;
 pub const ImGuiNavHighlightFlags_AlwaysDraw: ImGuiNavHighlightFlags_ = 4;
 pub const ImGuiNavHighlightFlags_NoRounding: ImGuiNavHighlightFlags_ = 8;
-pub type ImGuiNavHighlightFlags_ = cty::c_uint;
+pub type ImGuiNavHighlightFlags_ = core::ffi::c_uint;
 pub const ImGuiNavMoveFlags_None: ImGuiNavMoveFlags_ = 0;
 pub const ImGuiNavMoveFlags_LoopX: ImGuiNavMoveFlags_ = 1;
 pub const ImGuiNavMoveFlags_LoopY: ImGuiNavMoveFlags_ = 2;
@@ -3206,11 +3216,11 @@ pub const ImGuiNavMoveFlags_Activate: ImGuiNavMoveFlags_ = 4096;
 pub const ImGuiNavMoveFlags_NoSelect: ImGuiNavMoveFlags_ = 8192;
 pub const ImGuiNavMoveFlags_NoSetNavHighlight: ImGuiNavMoveFlags_ = 16384;
 pub const ImGuiNavMoveFlags_NoClearActiveId: ImGuiNavMoveFlags_ = 32768;
-pub type ImGuiNavMoveFlags_ = cty::c_uint;
+pub type ImGuiNavMoveFlags_ = core::ffi::c_uint;
 pub const ImGuiNavLayer_Main: ImGuiNavLayer = 0;
 pub const ImGuiNavLayer_Menu: ImGuiNavLayer = 1;
 pub const ImGuiNavLayer_COUNT: ImGuiNavLayer = 2;
-pub type ImGuiNavLayer = cty::c_uint;
+pub type ImGuiNavLayer = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiNavItemData {
@@ -3242,13 +3252,13 @@ pub struct ImGuiFocusScopeData {
 pub const ImGuiTypingSelectFlags_None: ImGuiTypingSelectFlags_ = 0;
 pub const ImGuiTypingSelectFlags_AllowBackspace: ImGuiTypingSelectFlags_ = 1;
 pub const ImGuiTypingSelectFlags_AllowSingleCharMode: ImGuiTypingSelectFlags_ = 2;
-pub type ImGuiTypingSelectFlags_ = cty::c_uint;
+pub type ImGuiTypingSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTypingSelectRequest {
     pub Flags: ImGuiTypingSelectFlags,
-    pub SearchBufferLen: cty::c_int,
-    pub SearchBuffer: *const cty::c_char,
+    pub SearchBufferLen: core::ffi::c_int,
+    pub SearchBuffer: *const core::ffi::c_char,
     pub SelectRequest: bool,
     pub SingleCharMode: bool,
     pub SingleCharSize: ImS8,
@@ -3266,9 +3276,9 @@ impl Default for ImGuiTypingSelectRequest {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTypingSelectState {
     pub Request: ImGuiTypingSelectRequest,
-    pub SearchBuffer: [cty::c_char; 64usize],
+    pub SearchBuffer: [core::ffi::c_char; 64usize],
     pub FocusScope: ImGuiID,
-    pub LastRequestFrame: cty::c_int,
+    pub LastRequestFrame: core::ffi::c_int,
     pub LastRequestTime: f32,
     pub SingleCharModeLock: bool,
 }
@@ -3287,7 +3297,7 @@ pub const ImGuiOldColumnFlags_NoResize: ImGuiOldColumnFlags_ = 2;
 pub const ImGuiOldColumnFlags_NoPreserveWidths: ImGuiOldColumnFlags_ = 4;
 pub const ImGuiOldColumnFlags_NoForceWithinWindow: ImGuiOldColumnFlags_ = 8;
 pub const ImGuiOldColumnFlags_GrowParentContentsSize: ImGuiOldColumnFlags_ = 16;
-pub type ImGuiOldColumnFlags_ = cty::c_uint;
+pub type ImGuiOldColumnFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiOldColumnData {
@@ -3299,8 +3309,8 @@ pub struct ImGuiOldColumnData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiOldColumnData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiOldColumnData,
 }
 impl Default for ImVector_ImGuiOldColumnData {
@@ -3319,8 +3329,8 @@ pub struct ImGuiOldColumns {
     pub Flags: ImGuiOldColumnFlags,
     pub IsFirstFrame: bool,
     pub IsBeingResized: bool,
-    pub Current: cty::c_int,
-    pub Count: cty::c_int,
+    pub Current: core::ffi::c_int,
+    pub Count: core::ffi::c_int,
     pub OffMinX: f32,
     pub OffMaxX: f32,
     pub LineMinY: f32,
@@ -3427,8 +3437,8 @@ impl Default for ImGuiMultiSelectTempData {
 pub struct ImGuiMultiSelectState {
     pub Window: *mut ImGuiWindow,
     pub ID: ImGuiID,
-    pub LastFrameActive: cty::c_int,
-    pub LastSelectionSize: cty::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastSelectionSize: core::ffi::c_int,
     pub RangeSelected: ImS8,
     pub NavIdSelected: ImS8,
     pub RangeSrcItem: ImGuiSelectionUserData,
@@ -3461,21 +3471,21 @@ pub const ImGuiDockNodeFlags_SharedFlagsInheritMask_: ImGuiDockNodeFlagsPrivate_
 pub const ImGuiDockNodeFlags_NoResizeFlagsMask_: ImGuiDockNodeFlagsPrivate_ = 196640;
 pub const ImGuiDockNodeFlags_LocalFlagsTransferMask_: ImGuiDockNodeFlagsPrivate_ = 260208;
 pub const ImGuiDockNodeFlags_SavedFlagsMask_: ImGuiDockNodeFlagsPrivate_ = 261152;
-pub type ImGuiDockNodeFlagsPrivate_ = cty::c_int;
+pub type ImGuiDockNodeFlagsPrivate_ = core::ffi::c_int;
 pub const ImGuiDataAuthority_Auto: ImGuiDataAuthority_ = 0;
 pub const ImGuiDataAuthority_DockNode: ImGuiDataAuthority_ = 1;
 pub const ImGuiDataAuthority_Window: ImGuiDataAuthority_ = 2;
-pub type ImGuiDataAuthority_ = cty::c_uint;
+pub type ImGuiDataAuthority_ = core::ffi::c_uint;
 pub const ImGuiDockNodeState_Unknown: ImGuiDockNodeState = 0;
 pub const ImGuiDockNodeState_HostWindowHiddenBecauseSingleWindow: ImGuiDockNodeState = 1;
 pub const ImGuiDockNodeState_HostWindowHiddenBecauseWindowsAreResizing: ImGuiDockNodeState = 2;
 pub const ImGuiDockNodeState_HostWindowVisible: ImGuiDockNodeState = 3;
-pub type ImGuiDockNodeState = cty::c_uint;
+pub type ImGuiDockNodeState = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiWindowPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiWindow,
 }
 impl Default for ImVector_ImGuiWindowPtr {
@@ -3510,10 +3520,10 @@ pub struct ImGuiDockNode {
     pub VisibleWindow: *mut ImGuiWindow,
     pub CentralNode: *mut ImGuiDockNode,
     pub OnlyNodeWithWindows: *mut ImGuiDockNode,
-    pub CountNodeWithWindows: cty::c_int,
-    pub LastFrameAlive: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub LastFrameFocused: cty::c_int,
+    pub CountNodeWithWindows: core::ffi::c_int,
+    pub LastFrameAlive: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFrameFocused: core::ffi::c_int,
     pub LastFocusedNodeId: ImGuiID,
     pub SelectedTabId: ImGuiID,
     pub WantCloseTabId: ImGuiID,
@@ -3774,7 +3784,7 @@ pub const ImGuiWindowDockStyleCol_TabDimmed: ImGuiWindowDockStyleCol = 5;
 pub const ImGuiWindowDockStyleCol_TabDimmedSelected: ImGuiWindowDockStyleCol = 6;
 pub const ImGuiWindowDockStyleCol_TabDimmedSelectedOverline: ImGuiWindowDockStyleCol = 7;
 pub const ImGuiWindowDockStyleCol_COUNT: ImGuiWindowDockStyleCol = 8;
-pub type ImGuiWindowDockStyleCol = cty::c_uint;
+pub type ImGuiWindowDockStyleCol = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiWindowDockStyle {
@@ -3783,8 +3793,8 @@ pub struct ImGuiWindowDockStyle {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiDockRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiDockRequest,
 }
 impl Default for ImVector_ImGuiDockRequest {
@@ -3799,8 +3809,8 @@ impl Default for ImVector_ImGuiDockRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiDockNodeSettings {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiDockNodeSettings,
 }
 impl Default for ImVector_ImGuiDockNodeSettings {
@@ -3834,17 +3844,17 @@ impl Default for ImGuiDockContext {
 pub struct ImGuiViewportP {
     pub _ImGuiViewport: ImGuiViewport,
     pub Window: *mut ImGuiWindow,
-    pub Idx: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub LastFocusedStampCount: cty::c_int,
+    pub Idx: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFocusedStampCount: core::ffi::c_int,
     pub LastNameHash: ImGuiID,
     pub LastPos: ImVec2,
     pub LastSize: ImVec2,
     pub Alpha: f32,
     pub LastAlpha: f32,
     pub LastFocusedHadNavWindow: bool,
-    pub PlatformMonitor: cty::c_short,
-    pub BgFgDrawListsLastFrame: [cty::c_int; 2usize],
+    pub PlatformMonitor: core::ffi::c_short,
+    pub BgFgDrawListsLastFrame: [core::ffi::c_int; 2usize],
     pub BgFgDrawLists: [*mut ImDrawList; 2usize],
     pub DrawDataP: ImDrawData,
     pub DrawDataBuilder: ImDrawDataBuilder,
@@ -3875,7 +3885,7 @@ pub struct ImGuiWindowSettings {
     pub ViewportId: ImGuiID,
     pub DockId: ImGuiID,
     pub ClassId: ImGuiID,
-    pub DockOrder: cty::c_short,
+    pub DockOrder: core::ffi::c_short,
     pub Collapsed: bool,
     pub IsChild: bool,
     pub WantApply: bool,
@@ -3884,7 +3894,7 @@ pub struct ImGuiWindowSettings {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSettingsHandler {
-    pub TypeName: *const cty::c_char,
+    pub TypeName: *const core::ffi::c_char,
     pub TypeHash: ImGuiID,
     pub ClearAllFn: ::core::option::Option<
         unsafe extern "C" fn(ctx: *mut ImGuiContext, handler: *mut ImGuiSettingsHandler),
@@ -3896,15 +3906,15 @@ pub struct ImGuiSettingsHandler {
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
             handler: *mut ImGuiSettingsHandler,
-            name: *const cty::c_char,
-        ) -> *mut cty::c_void,
+            name: *const core::ffi::c_char,
+        ) -> *mut core::ffi::c_void,
     >,
     pub ReadLineFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
             handler: *mut ImGuiSettingsHandler,
-            entry: *mut cty::c_void,
-            line: *const cty::c_char,
+            entry: *mut core::ffi::c_void,
+            line: *const core::ffi::c_char,
         ),
     >,
     pub ApplyAllFn: ::core::option::Option<
@@ -3917,7 +3927,7 @@ pub struct ImGuiSettingsHandler {
             out_buf: *mut ImGuiTextBuffer,
         ),
     >,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiSettingsHandler {
     fn default() -> Self {
@@ -3942,12 +3952,12 @@ pub const ImGuiLocKey_DockingHideTabBar: ImGuiLocKey = 10;
 pub const ImGuiLocKey_DockingHoldShiftToDock: ImGuiLocKey = 11;
 pub const ImGuiLocKey_DockingDragToUndockOrMoveNode: ImGuiLocKey = 12;
 pub const ImGuiLocKey_COUNT: ImGuiLocKey = 13;
-pub type ImGuiLocKey = cty::c_uint;
+pub type ImGuiLocKey = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiLocEntry {
     pub Key: ImGuiLocKey,
-    pub Text: *const cty::c_char,
+    pub Text: *const core::ffi::c_char,
 }
 impl Default for ImGuiLocEntry {
     fn default() -> Self {
@@ -3961,8 +3971,8 @@ impl Default for ImGuiLocEntry {
 pub type ImGuiErrorCallback = ::core::option::Option<
     unsafe extern "C" fn(
         ctx: *mut ImGuiContext,
-        user_data: *mut cty::c_void,
-        msg: *const cty::c_char,
+        user_data: *mut core::ffi::c_void,
+        msg: *const core::ffi::c_char,
     ),
 >;
 pub const ImGuiDebugLogFlags_None: ImGuiDebugLogFlags_ = 0;
@@ -3980,19 +3990,19 @@ pub const ImGuiDebugLogFlags_EventViewport: ImGuiDebugLogFlags_ = 1024;
 pub const ImGuiDebugLogFlags_EventMask_: ImGuiDebugLogFlags_ = 2047;
 pub const ImGuiDebugLogFlags_OutputToTTY: ImGuiDebugLogFlags_ = 1048576;
 pub const ImGuiDebugLogFlags_OutputToTestEngine: ImGuiDebugLogFlags_ = 2097152;
-pub type ImGuiDebugLogFlags_ = cty::c_uint;
+pub type ImGuiDebugLogFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDebugAllocEntry {
-    pub FrameCount: cty::c_int,
+    pub FrameCount: core::ffi::c_int,
     pub AllocCount: ImS16,
     pub FreeCount: ImS16,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDebugAllocInfo {
-    pub TotalAllocCount: cty::c_int,
-    pub TotalFreeCount: cty::c_int,
+    pub TotalAllocCount: core::ffi::c_int,
+    pub TotalFreeCount: core::ffi::c_int,
     pub LastEntriesIdx: ImS16,
     pub LastEntriesBuf: [ImGuiDebugAllocEntry; 6usize],
 }
@@ -4009,9 +4019,9 @@ pub struct ImGuiMetricsConfig {
     pub ShowTextEncodingViewer: bool,
     pub ShowAtlasTintedWithTextColor: bool,
     pub ShowDockingNodes: bool,
-    pub ShowWindowsRectsType: cty::c_int,
-    pub ShowTablesRectsType: cty::c_int,
-    pub HighlightMonitorIdx: cty::c_int,
+    pub ShowWindowsRectsType: core::ffi::c_int,
+    pub ShowTablesRectsType: core::ffi::c_int,
+    pub HighlightMonitorIdx: core::ffi::c_int,
     pub HighlightViewportID: ImGuiID,
 }
 #[repr(C)]
@@ -4022,7 +4032,7 @@ pub struct ImGuiStackLevelInfo {
     pub QuerySuccess: bool,
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub Desc: [cty::c_char; 57usize],
+    pub Desc: [core::ffi::c_char; 57usize],
 }
 impl Default for ImGuiStackLevelInfo {
     fn default() -> Self {
@@ -4058,8 +4068,8 @@ impl ImGuiStackLevelInfo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStackLevelInfo {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStackLevelInfo,
 }
 impl Default for ImVector_ImGuiStackLevelInfo {
@@ -4074,8 +4084,8 @@ impl Default for ImVector_ImGuiStackLevelInfo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiIDStackTool {
-    pub LastActiveFrame: cty::c_int,
-    pub StackLevel: cty::c_int,
+    pub LastActiveFrame: core::ffi::c_int,
+    pub StackLevel: core::ffi::c_int,
     pub QueryId: ImGuiID,
     pub Results: ImVector_ImGuiStackLevelInfo,
     pub CopyToClipboardOnCtrlC: bool,
@@ -4101,7 +4111,7 @@ pub const ImGuiContextHookType_RenderPre: ImGuiContextHookType = 4;
 pub const ImGuiContextHookType_RenderPost: ImGuiContextHookType = 5;
 pub const ImGuiContextHookType_Shutdown: ImGuiContextHookType = 6;
 pub const ImGuiContextHookType_PendingRemoval_: ImGuiContextHookType = 7;
-pub type ImGuiContextHookType = cty::c_uint;
+pub type ImGuiContextHookType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiContextHook {
@@ -4109,7 +4119,7 @@ pub struct ImGuiContextHook {
     pub Type: ImGuiContextHookType,
     pub Owner: ImGuiID,
     pub Callback: ImGuiContextHookCallback,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiContextHook {
     fn default() -> Self {
@@ -4123,8 +4133,8 @@ impl Default for ImGuiContextHook {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiInputEvent {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiInputEvent,
 }
 impl Default for ImVector_ImGuiInputEvent {
@@ -4139,8 +4149,8 @@ impl Default for ImVector_ImGuiInputEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiWindowStackData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiWindowStackData,
 }
 impl Default for ImVector_ImGuiWindowStackData {
@@ -4155,8 +4165,8 @@ impl Default for ImVector_ImGuiWindowStackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiColorMod {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiColorMod,
 }
 impl Default for ImVector_ImGuiColorMod {
@@ -4171,8 +4181,8 @@ impl Default for ImVector_ImGuiColorMod {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStyleMod {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStyleMod,
 }
 impl Default for ImVector_ImGuiStyleMod {
@@ -4187,8 +4197,8 @@ impl Default for ImVector_ImGuiStyleMod {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiFocusScopeData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiFocusScopeData,
 }
 impl Default for ImVector_ImGuiFocusScopeData {
@@ -4203,8 +4213,8 @@ impl Default for ImVector_ImGuiFocusScopeData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiItemFlags {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiItemFlags,
 }
 impl Default for ImVector_ImGuiItemFlags {
@@ -4219,8 +4229,8 @@ impl Default for ImVector_ImGuiItemFlags {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiGroupData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiGroupData,
 }
 impl Default for ImVector_ImGuiGroupData {
@@ -4235,8 +4245,8 @@ impl Default for ImVector_ImGuiGroupData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPopupData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPopupData,
 }
 impl Default for ImVector_ImGuiPopupData {
@@ -4251,8 +4261,8 @@ impl Default for ImVector_ImGuiPopupData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTreeNodeStackData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTreeNodeStackData,
 }
 impl Default for ImVector_ImGuiTreeNodeStackData {
@@ -4267,8 +4277,8 @@ impl Default for ImVector_ImGuiTreeNodeStackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiViewportPPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiViewportP,
 }
 impl Default for ImVector_ImGuiViewportPPtr {
@@ -4283,9 +4293,9 @@ impl Default for ImVector_ImGuiViewportPPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_unsigned_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_uchar,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_uchar,
 }
 impl Default for ImVector_unsigned_char {
     fn default() -> Self {
@@ -4299,8 +4309,8 @@ impl Default for ImVector_unsigned_char {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiListClipperData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiListClipperData,
 }
 impl Default for ImVector_ImGuiListClipperData {
@@ -4315,8 +4325,8 @@ impl Default for ImVector_ImGuiListClipperData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableTempData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableTempData,
 }
 impl Default for ImVector_ImGuiTableTempData {
@@ -4331,8 +4341,8 @@ impl Default for ImVector_ImGuiTableTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTable {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTable,
 }
 impl Default for ImVector_ImGuiTable {
@@ -4364,8 +4374,8 @@ impl Default for ImPool_ImGuiTable {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTabBar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTabBar,
 }
 impl Default for ImVector_ImGuiTabBar {
@@ -4397,8 +4407,8 @@ impl Default for ImPool_ImGuiTabBar {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPtrOrIndex {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPtrOrIndex,
 }
 impl Default for ImVector_ImGuiPtrOrIndex {
@@ -4413,8 +4423,8 @@ impl Default for ImVector_ImGuiPtrOrIndex {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiShrinkWidthItem {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiShrinkWidthItem,
 }
 impl Default for ImVector_ImGuiShrinkWidthItem {
@@ -4429,8 +4439,8 @@ impl Default for ImVector_ImGuiShrinkWidthItem {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiMultiSelectTempData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiMultiSelectTempData,
 }
 impl Default for ImVector_ImGuiMultiSelectTempData {
@@ -4445,8 +4455,8 @@ impl Default for ImVector_ImGuiMultiSelectTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiMultiSelectState {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiMultiSelectState,
 }
 impl Default for ImVector_ImGuiMultiSelectState {
@@ -4478,8 +4488,8 @@ impl Default for ImPool_ImGuiMultiSelectState {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiID,
 }
 impl Default for ImVector_ImGuiID {
@@ -4494,8 +4504,8 @@ impl Default for ImVector_ImGuiID {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSettingsHandler {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSettingsHandler,
 }
 impl Default for ImVector_ImGuiSettingsHandler {
@@ -4538,8 +4548,8 @@ impl Default for ImChunkStream_ImGuiTableSettings {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiContextHook {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiContextHook,
 }
 impl Default for ImVector_ImGuiContextHook {
@@ -4568,17 +4578,17 @@ pub struct ImGuiContext {
     pub CurrentDpiScale: f32,
     pub DrawListSharedData: ImDrawListSharedData,
     pub Time: f64,
-    pub FrameCount: cty::c_int,
-    pub FrameCountEnded: cty::c_int,
-    pub FrameCountPlatformEnded: cty::c_int,
-    pub FrameCountRendered: cty::c_int,
+    pub FrameCount: core::ffi::c_int,
+    pub FrameCountEnded: core::ffi::c_int,
+    pub FrameCountPlatformEnded: core::ffi::c_int,
+    pub FrameCountRendered: core::ffi::c_int,
     pub WithinFrameScope: bool,
     pub WithinFrameScopeWithImplicitWindow: bool,
     pub WithinEndChild: bool,
     pub GcCompactAll: bool,
     pub TestEngineHookItems: bool,
-    pub TestEngine: *mut cty::c_void,
-    pub ContextName: [cty::c_char; 16usize],
+    pub TestEngine: *mut core::ffi::c_void,
+    pub ContextName: [core::ffi::c_char; 16usize],
     pub InputEventsQueue: ImVector_ImGuiInputEvent,
     pub InputEventsTrail: ImVector_ImGuiInputEvent,
     pub InputEventsNextMouseSource: ImGuiMouseSource,
@@ -4588,7 +4598,7 @@ pub struct ImGuiContext {
     pub WindowsTempSortBuffer: ImVector_ImGuiWindowPtr,
     pub CurrentWindowStack: ImVector_ImGuiWindowStackData,
     pub WindowsById: ImGuiStorage,
-    pub WindowsActiveCount: cty::c_int,
+    pub WindowsActiveCount: core::ffi::c_int,
     pub WindowsHoverPadding: ImVec2,
     pub DebugBreakInWindow: ImGuiID,
     pub CurrentWindow: *mut ImGuiWindow,
@@ -4598,8 +4608,8 @@ pub struct ImGuiContext {
     pub MovingWindow: *mut ImGuiWindow,
     pub WheelingWindow: *mut ImGuiWindow,
     pub WheelingWindowRefMousePos: ImVec2,
-    pub WheelingWindowStartFrame: cty::c_int,
-    pub WheelingWindowScrolledFrame: cty::c_int,
+    pub WheelingWindowStartFrame: core::ffi::c_int,
+    pub WheelingWindowScrolledFrame: core::ffi::c_int,
     pub WheelingWindowReleaseTimer: f32,
     pub WheelingWindowWheelRemainder: ImVec2,
     pub WheelingAxisAvg: ImVec2,
@@ -4607,7 +4617,7 @@ pub struct ImGuiContext {
     pub DebugHookIdInfo: ImGuiID,
     pub HoveredId: ImGuiID,
     pub HoveredIdPreviousFrame: ImGuiID,
-    pub HoveredIdPreviousFrameItemCount: cty::c_int,
+    pub HoveredIdPreviousFrameItemCount: core::ffi::c_int,
     pub HoveredIdTimer: f32,
     pub HoveredIdNotActiveTimer: f32,
     pub HoveredIdAllowOverlap: bool,
@@ -4667,9 +4677,9 @@ pub struct ImGuiContext {
     pub PlatformLastFocusedViewportId: ImGuiID,
     pub FallbackMonitor: ImGuiPlatformMonitor,
     pub PlatformMonitorsFullWorkRect: ImRect,
-    pub ViewportCreatedCount: cty::c_int,
-    pub PlatformWindowsCreatedCount: cty::c_int,
-    pub ViewportFocusedStampCount: cty::c_int,
+    pub ViewportCreatedCount: core::ffi::c_int,
+    pub PlatformWindowsCreatedCount: core::ffi::c_int,
+    pub ViewportFocusedStampCount: core::ffi::c_int,
     pub NavWindow: *mut ImGuiWindow,
     pub NavId: ImGuiID,
     pub NavFocusScopeId: ImGuiID,
@@ -4704,9 +4714,9 @@ pub struct ImGuiContext {
     pub NavMoveClipDir: ImGuiDir,
     pub NavScoringRect: ImRect,
     pub NavScoringNoClipRect: ImRect,
-    pub NavScoringDebugCount: cty::c_int,
-    pub NavTabbingDir: cty::c_int,
-    pub NavTabbingCounter: cty::c_int,
+    pub NavScoringDebugCount: core::ffi::c_int,
+    pub NavTabbingDir: core::ffi::c_int,
+    pub NavTabbingCounter: core::ffi::c_int,
     pub NavMoveResultLocal: ImGuiNavItemData,
     pub NavMoveResultLocalVisible: ImGuiNavItemData,
     pub NavMoveResultOther: ImGuiNavItemData,
@@ -4733,8 +4743,8 @@ pub struct ImGuiContext {
     pub DragDropWithinSource: bool,
     pub DragDropWithinTarget: bool,
     pub DragDropSourceFlags: ImGuiDragDropFlags,
-    pub DragDropSourceFrameCount: cty::c_int,
-    pub DragDropMouseButton: cty::c_int,
+    pub DragDropSourceFrameCount: core::ffi::c_int,
+    pub DragDropMouseButton: core::ffi::c_int,
     pub DragDropPayload: ImGuiPayload,
     pub DragDropTargetRect: ImRect,
     pub DragDropTargetClipRect: ImRect,
@@ -4743,15 +4753,15 @@ pub struct ImGuiContext {
     pub DragDropAcceptIdCurrRectSurface: f32,
     pub DragDropAcceptIdCurr: ImGuiID,
     pub DragDropAcceptIdPrev: ImGuiID,
-    pub DragDropAcceptFrameCount: cty::c_int,
+    pub DragDropAcceptFrameCount: core::ffi::c_int,
     pub DragDropHoldJustPressedId: ImGuiID,
     pub DragDropPayloadBufHeap: ImVector_unsigned_char,
-    pub DragDropPayloadBufLocal: [cty::c_uchar; 16usize],
-    pub ClipperTempDataStacked: cty::c_int,
+    pub DragDropPayloadBufLocal: [core::ffi::c_uchar; 16usize],
+    pub ClipperTempDataStacked: core::ffi::c_int,
     pub ClipperTempData: ImVector_ImGuiListClipperData,
     pub CurrentTable: *mut ImGuiTable,
     pub DebugBreakInTable: ImGuiID,
-    pub TablesTempDataStacked: cty::c_int,
+    pub TablesTempDataStacked: core::ffi::c_int,
     pub TablesTempData: ImVector_ImGuiTableTempData,
     pub Tables: ImPool_ImGuiTable,
     pub TablesLastTimeActive: ImVector_float,
@@ -4762,7 +4772,7 @@ pub struct ImGuiContext {
     pub ShrinkWidthBuffer: ImVector_ImGuiShrinkWidthItem,
     pub BoxSelectState: ImGuiBoxSelectState,
     pub CurrentMultiSelect: *mut ImGuiMultiSelectTempData,
-    pub MultiSelectTempDataStacked: cty::c_int,
+    pub MultiSelectTempDataStacked: core::ffi::c_int,
     pub MultiSelectTempData: ImVector_ImGuiMultiSelectTempData,
     pub MultiSelectStorage: ImPool_ImGuiMultiSelectState,
     pub HoverItemDelayId: ImGuiID,
@@ -4779,8 +4789,8 @@ pub struct ImGuiContext {
     pub InputTextPasswordFont: ImFont,
     pub TempInputId: ImGuiID,
     pub DataTypeZeroValue: ImGuiDataTypeStorage,
-    pub BeginMenuDepth: cty::c_int,
-    pub BeginComboDepth: cty::c_int,
+    pub BeginMenuDepth: core::ffi::c_int,
+    pub BeginComboDepth: core::ffi::c_int,
     pub ColorEditOptions: ImGuiColorEditFlags,
     pub ColorEditCurrentID: ImGuiID,
     pub ColorEditSavedID: ImGuiID,
@@ -4791,7 +4801,7 @@ pub struct ImGuiContext {
     pub ComboPreviewData: ImGuiComboPreviewData,
     pub WindowResizeBorderExpectedRect: ImRect,
     pub WindowResizeRelativeMode: bool,
-    pub ScrollbarSeekMode: cty::c_short,
+    pub ScrollbarSeekMode: core::ffi::c_short,
     pub ScrollbarClickDeltaToGrabCenter: f32,
     pub SliderGrabClickOffset: f32,
     pub SliderCurrentAccum: f32,
@@ -4800,9 +4810,9 @@ pub struct ImGuiContext {
     pub DragCurrentAccum: f32,
     pub DragSpeedDefaultRatio: f32,
     pub DisabledAlphaBackup: f32,
-    pub DisabledStackSize: cty::c_short,
-    pub LockMarkEdited: cty::c_short,
-    pub TooltipOverrideCount: cty::c_short,
+    pub DisabledStackSize: core::ffi::c_short,
+    pub LockMarkEdited: core::ffi::c_short,
+    pub TooltipOverrideCount: core::ffi::c_short,
     pub TooltipPreviousWindow: *mut ImGuiWindow,
     pub ClipboardHandlerData: ImVector_char,
     pub MenusIdSubmittedThisFrame: ImVector_ImGuiID,
@@ -4826,30 +4836,30 @@ pub struct ImGuiContext {
     pub SettingsTables: ImChunkStream_ImGuiTableSettings,
     pub Hooks: ImVector_ImGuiContextHook,
     pub HookIdNext: ImGuiID,
-    pub LocalizationTable: [*const cty::c_char; 13usize],
+    pub LocalizationTable: [*const core::ffi::c_char; 13usize],
     pub LogEnabled: bool,
     pub LogType: ImGuiLogType,
     pub LogFile: ImFileHandle,
     pub LogBuffer: ImGuiTextBuffer,
-    pub LogNextPrefix: *const cty::c_char,
-    pub LogNextSuffix: *const cty::c_char,
+    pub LogNextPrefix: *const core::ffi::c_char,
+    pub LogNextSuffix: *const core::ffi::c_char,
     pub LogLinePosY: f32,
     pub LogLineFirstItem: bool,
-    pub LogDepthRef: cty::c_int,
-    pub LogDepthToExpand: cty::c_int,
-    pub LogDepthToExpandDefault: cty::c_int,
+    pub LogDepthRef: core::ffi::c_int,
+    pub LogDepthToExpand: core::ffi::c_int,
+    pub LogDepthToExpandDefault: core::ffi::c_int,
     pub ErrorCallback: ImGuiErrorCallback,
-    pub ErrorCallbackUserData: *mut cty::c_void,
+    pub ErrorCallbackUserData: *mut core::ffi::c_void,
     pub ErrorTooltipLockedPos: ImVec2,
     pub ErrorFirst: bool,
-    pub ErrorCountCurrentFrame: cty::c_int,
+    pub ErrorCountCurrentFrame: core::ffi::c_int,
     pub StackSizesInNewFrame: ImGuiErrorRecoveryState,
     pub StackSizesInBeginForCurrentWindow: *mut ImGuiErrorRecoveryState,
-    pub DebugDrawIdConflictsCount: cty::c_int,
+    pub DebugDrawIdConflictsCount: core::ffi::c_int,
     pub DebugLogFlags: ImGuiDebugLogFlags,
     pub DebugLogBuf: ImGuiTextBuffer,
     pub DebugLogIndex: ImGuiTextIndex,
-    pub DebugLogSkippedErrors: cty::c_int,
+    pub DebugLogSkippedErrors: core::ffi::c_int,
     pub DebugLogAutoDisableFlags: ImGuiDebugLogFlags,
     pub DebugLogAutoDisableFrames: ImU8,
     pub DebugLocateFrames: ImU8,
@@ -4866,14 +4876,14 @@ pub struct ImGuiContext {
     pub DebugAllocInfo: ImGuiDebugAllocInfo,
     pub DebugHoveredDockNode: *mut ImGuiDockNode,
     pub FramerateSecPerFrame: [f32; 60usize],
-    pub FramerateSecPerFrameIdx: cty::c_int,
-    pub FramerateSecPerFrameCount: cty::c_int,
+    pub FramerateSecPerFrameIdx: core::ffi::c_int,
+    pub FramerateSecPerFrameCount: core::ffi::c_int,
     pub FramerateSecPerFrameAccum: f32,
-    pub WantCaptureMouseNextFrame: cty::c_int,
-    pub WantCaptureKeyboardNextFrame: cty::c_int,
-    pub WantTextInputNextFrame: cty::c_int,
+    pub WantCaptureMouseNextFrame: core::ffi::c_int,
+    pub WantCaptureKeyboardNextFrame: core::ffi::c_int,
+    pub WantTextInputNextFrame: core::ffi::c_int,
     pub TempBuffer: ImVector_char,
-    pub TempKeychordName: [cty::c_char; 64usize],
+    pub TempKeychordName: [core::ffi::c_char; 64usize],
 }
 impl Default for ImGuiContext {
     fn default() -> Self {
@@ -4886,18 +4896,20 @@ impl Default for ImGuiContext {
 }
 impl ImGuiContext {
     #[inline]
-    pub fn ActiveIdMouseButton(&self) -> cty::c_int {
+    pub fn ActiveIdMouseButton(&self) -> core::ffi::c_int {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
     }
     #[inline]
-    pub fn set_ActiveIdMouseButton(&mut self, val: cty::c_int) {
+    pub fn set_ActiveIdMouseButton(&mut self, val: core::ffi::c_int) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 8u8, val as u64)
         }
     }
     #[inline]
-    pub fn new_bitfield_1(ActiveIdMouseButton: cty::c_int) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+    pub fn new_bitfield_1(
+        ActiveIdMouseButton: core::ffi::c_int,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 8u8, {
             let ActiveIdMouseButton: u32 = unsafe { ::core::mem::transmute(ActiveIdMouseButton) };
@@ -4925,20 +4937,20 @@ pub struct ImGuiWindowTempData {
     pub GroupOffset: ImVec1,
     pub CursorStartPosLossyness: ImVec2,
     pub NavLayerCurrent: ImGuiNavLayer,
-    pub NavLayersActiveMask: cty::c_short,
-    pub NavLayersActiveMaskNext: cty::c_short,
+    pub NavLayersActiveMask: core::ffi::c_short,
+    pub NavLayersActiveMaskNext: core::ffi::c_short,
     pub NavIsScrollPushableX: bool,
     pub NavHideHighlightOneFrame: bool,
     pub NavWindowHasScrollY: bool,
     pub MenuBarAppending: bool,
     pub MenuBarOffset: ImVec2,
     pub MenuColumns: ImGuiMenuColumns,
-    pub TreeDepth: cty::c_int,
+    pub TreeDepth: core::ffi::c_int,
     pub TreeHasStackDataDepthMask: ImU32,
     pub ChildWindows: ImVector_ImGuiWindowPtr,
     pub StateStorage: *mut ImGuiStorage,
     pub CurrentColumns: *mut ImGuiOldColumns,
-    pub CurrentTableIdx: cty::c_int,
+    pub CurrentTableIdx: core::ffi::c_int,
     pub LayoutType: ImGuiLayoutType,
     pub ParentLayoutType: ImGuiLayoutType,
     pub ModalDimBgColor: ImU32,
@@ -4959,8 +4971,8 @@ impl Default for ImGuiWindowTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiOldColumns {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiOldColumns,
 }
 impl Default for ImVector_ImGuiOldColumns {
@@ -4976,7 +4988,7 @@ impl Default for ImVector_ImGuiOldColumns {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiWindow {
     pub Ctx: *mut ImGuiContext,
-    pub Name: *mut cty::c_char,
+    pub Name: *mut core::ffi::c_char,
     pub ID: ImGuiID,
     pub Flags: ImGuiWindowFlags,
     pub FlagsPreviousFrame: ImGuiWindowFlags,
@@ -4985,7 +4997,7 @@ pub struct ImGuiWindow {
     pub Viewport: *mut ImGuiViewportP,
     pub ViewportId: ImGuiID,
     pub ViewportPos: ImVec2,
-    pub ViewportAllowPlatformMonitorExtend: cty::c_int,
+    pub ViewportAllowPlatformMonitorExtend: core::ffi::c_int,
     pub Pos: ImVec2,
     pub Size: ImVec2,
     pub SizeFull: ImVec2,
@@ -5003,7 +5015,7 @@ pub struct ImGuiWindow {
     pub DecoOuterSizeY2: f32,
     pub DecoInnerSizeX1: f32,
     pub DecoInnerSizeY1: f32,
-    pub NameBufLen: cty::c_int,
+    pub NameBufLen: core::ffi::c_int,
     pub MoveId: ImGuiID,
     pub TabId: ImGuiID,
     pub ChildId: ImGuiID,
@@ -5029,13 +5041,13 @@ pub struct ImGuiWindow {
     pub IsFallbackWindow: bool,
     pub IsExplicitChild: bool,
     pub HasCloseButton: bool,
-    pub ResizeBorderHovered: cty::c_schar,
-    pub ResizeBorderHeld: cty::c_schar,
-    pub BeginCount: cty::c_short,
-    pub BeginCountPreviousFrame: cty::c_short,
-    pub BeginOrderWithinParent: cty::c_short,
-    pub BeginOrderWithinContext: cty::c_short,
-    pub FocusOrder: cty::c_short,
+    pub ResizeBorderHovered: core::ffi::c_schar,
+    pub ResizeBorderHeld: core::ffi::c_schar,
+    pub BeginCount: core::ffi::c_short,
+    pub BeginCountPreviousFrame: core::ffi::c_short,
+    pub BeginOrderWithinParent: core::ffi::c_short,
+    pub BeginOrderWithinContext: core::ffi::c_short,
+    pub FocusOrder: core::ffi::c_short,
     pub AutoFitFramesX: ImS8,
     pub AutoFitFramesY: ImS8,
     pub AutoFitOnlyGrows: bool,
@@ -5059,15 +5071,15 @@ pub struct ImGuiWindow {
     pub ContentRegionRect: ImRect,
     pub HitTestHoleSize: ImVec2ih,
     pub HitTestHoleOffset: ImVec2ih,
-    pub LastFrameActive: cty::c_int,
-    pub LastFrameJustFocused: cty::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFrameJustFocused: core::ffi::c_int,
     pub LastTimeActive: f32,
     pub ItemWidthDefault: f32,
     pub StateStorage: ImGuiStorage,
     pub ColumnsStorage: ImVector_ImGuiOldColumns,
     pub FontWindowScale: f32,
     pub FontDpiScale: f32,
-    pub SettingsOffset: cty::c_int,
+    pub SettingsOffset: core::ffi::c_int,
     pub DrawList: *mut ImDrawList,
     pub DrawListInst: ImDrawList,
     pub ParentWindow: *mut ImGuiWindow,
@@ -5083,12 +5095,12 @@ pub struct ImGuiWindow {
     pub NavRectRel: [ImRect; 2usize],
     pub NavPreferredScoringPosRel: [ImVec2; 2usize],
     pub NavRootFocusScopeId: ImGuiID,
-    pub MemoryDrawListIdxCapacity: cty::c_int,
-    pub MemoryDrawListVtxCapacity: cty::c_int,
+    pub MemoryDrawListIdxCapacity: core::ffi::c_int,
+    pub MemoryDrawListVtxCapacity: core::ffi::c_int,
     pub MemoryCompacted: bool,
     pub _bitfield_align_2: [u8; 0],
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub DockOrder: cty::c_short,
+    pub DockOrder: core::ffi::c_short,
     pub DockStyle: ImGuiWindowDockStyle,
     pub DockNode: *mut ImGuiDockNode,
     pub DockNodeAsHost: *mut ImGuiDockNode,
@@ -5254,20 +5266,20 @@ impl ImGuiWindow {
 pub const ImGuiTabBarFlags_DockNode: ImGuiTabBarFlagsPrivate_ = 1048576;
 pub const ImGuiTabBarFlags_IsFocused: ImGuiTabBarFlagsPrivate_ = 2097152;
 pub const ImGuiTabBarFlags_SaveSettings: ImGuiTabBarFlagsPrivate_ = 4194304;
-pub type ImGuiTabBarFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTabBarFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_SectionMask_: ImGuiTabItemFlagsPrivate_ = 192;
 pub const ImGuiTabItemFlags_NoCloseButton: ImGuiTabItemFlagsPrivate_ = 1048576;
 pub const ImGuiTabItemFlags_Button: ImGuiTabItemFlagsPrivate_ = 2097152;
 pub const ImGuiTabItemFlags_Unsorted: ImGuiTabItemFlagsPrivate_ = 4194304;
-pub type ImGuiTabItemFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTabItemFlagsPrivate_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTabItem {
     pub ID: ImGuiID,
     pub Flags: ImGuiTabItemFlags,
     pub Window: *mut ImGuiWindow,
-    pub LastFrameVisible: cty::c_int,
-    pub LastFrameSelected: cty::c_int,
+    pub LastFrameVisible: core::ffi::c_int,
+    pub LastFrameSelected: core::ffi::c_int,
     pub Offset: f32,
     pub Width: f32,
     pub ContentWidth: f32,
@@ -5289,8 +5301,8 @@ impl Default for ImGuiTabItem {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTabItem {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTabItem,
 }
 impl Default for ImVector_ImGuiTabItem {
@@ -5312,8 +5324,8 @@ pub struct ImGuiTabBar {
     pub SelectedTabId: ImGuiID,
     pub NextSelectedTabId: ImGuiID,
     pub VisibleTabId: ImGuiID,
-    pub CurrFrameVisible: cty::c_int,
-    pub PrevFrameVisible: cty::c_int,
+    pub CurrFrameVisible: core::ffi::c_int,
+    pub PrevFrameVisible: core::ffi::c_int,
     pub BarRect: ImRect,
     pub CurrTabsContentsHeight: f32,
     pub PrevTabsContentsHeight: f32,
@@ -5475,8 +5487,8 @@ pub struct ImGuiTableInstanceData {
     pub LastOuterHeight: f32,
     pub LastTopHeadersRowHeight: f32,
     pub LastFrozenHeight: f32,
-    pub HoveredRowLast: cty::c_int,
-    pub HoveredRowNext: cty::c_int,
+    pub HoveredRowLast: core::ffi::c_int,
+    pub HoveredRowNext: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -5526,8 +5538,8 @@ impl Default for ImSpan_ImGuiTableCellData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableInstanceData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableInstanceData,
 }
 impl Default for ImVector_ImGuiTableInstanceData {
@@ -5542,8 +5554,8 @@ impl Default for ImVector_ImGuiTableInstanceData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableColumnSortSpecs {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableColumnSortSpecs,
 }
 impl Default for ImVector_ImGuiTableColumnSortSpecs {
@@ -5560,7 +5572,7 @@ impl Default for ImVector_ImGuiTableColumnSortSpecs {
 pub struct ImGuiTable {
     pub ID: ImGuiID,
     pub Flags: ImGuiTableFlags,
-    pub RawData: *mut cty::c_void,
+    pub RawData: *mut core::ffi::c_void,
     pub TempData: *mut ImGuiTableTempData,
     pub Columns: ImSpan_ImGuiTableColumn,
     pub DisplayOrderToIndex: ImSpan_ImGuiTableColumnIdx,
@@ -5569,11 +5581,11 @@ pub struct ImGuiTable {
     pub EnabledMaskByIndex: ImBitArrayPtr,
     pub VisibleMaskByIndex: ImBitArrayPtr,
     pub SettingsLoadedFlags: ImGuiTableFlags,
-    pub SettingsOffset: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub ColumnsCount: cty::c_int,
-    pub CurrentRow: cty::c_int,
-    pub CurrentColumn: cty::c_int,
+    pub SettingsOffset: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub ColumnsCount: core::ffi::c_int,
+    pub CurrentRow: core::ffi::c_int,
+    pub CurrentColumn: core::ffi::c_int,
     pub InstanceCurrent: ImS16,
     pub InstanceInteracted: ImS16,
     pub RowPosY1: f32,
@@ -5584,7 +5596,7 @@ pub struct ImGuiTable {
     pub RowIndentOffsetX: f32,
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub RowBgColorCounter: cty::c_int,
+    pub RowBgColorCounter: core::ffi::c_int,
     pub RowBgColor: [ImU32; 2usize],
     pub BorderColorStrong: ImU32,
     pub BorderColorLight: ImU32,
@@ -5723,8 +5735,8 @@ impl ImGuiTable {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableHeaderData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableHeaderData,
 }
 impl Default for ImVector_ImGuiTableHeaderData {
@@ -5739,7 +5751,7 @@ impl Default for ImVector_ImGuiTableHeaderData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTableTempData {
-    pub TableIndex: cty::c_int,
+    pub TableIndex: core::ffi::c_int,
     pub LastTimeActive: f32,
     pub AngledHeadersExtraWidth: f32,
     pub AngledHeadersRequests: ImVector_ImGuiTableHeaderData,
@@ -5752,7 +5764,7 @@ pub struct ImGuiTableTempData {
     pub HostBackupCursorMaxPos: ImVec2,
     pub HostBackupColumnsOffset: ImVec1,
     pub HostBackupItemWidth: f32,
-    pub HostBackupItemWidthStackSize: cty::c_int,
+    pub HostBackupItemWidthStackSize: core::ffi::c_int,
 }
 impl Default for ImGuiTableTempData {
     fn default() -> Self {
@@ -5941,11 +5953,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShowStyleSelector(label: *const cty::c_char) -> bool;
+    pub fn igShowStyleSelector(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShowFontSelector(label: *const cty::c_char);
+    pub fn igShowFontSelector(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5953,7 +5965,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetVersion() -> *const cty::c_char;
+    pub fn igGetVersion() -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5969,7 +5981,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBegin(name: *const cty::c_char, p_open: *mut bool, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBegin(
+        name: *const core::ffi::c_char,
+        p_open: *mut bool,
+        flags: ImGuiWindowFlags,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5978,7 +5994,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginChild_Str(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         child_flags: ImGuiChildFlags,
         window_flags: ImGuiWindowFlags,
@@ -6055,7 +6071,7 @@ extern "C" {
         size_min: ImVec2,
         size_max: ImVec2,
         custom_callback: ImGuiSizeCallback,
-        custom_callback_data: *mut cty::c_void,
+        custom_callback_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -6104,19 +6120,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowPos_Str(name: *const cty::c_char, pos: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowPos_Str(name: *const core::ffi::c_char, pos: ImVec2, cond: ImGuiCond);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowSize_Str(name: *const cty::c_char, size: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowSize_Str(name: *const core::ffi::c_char, size: ImVec2, cond: ImGuiCond);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowCollapsed_Str(name: *const cty::c_char, collapsed: bool, cond: ImGuiCond);
+    pub fn igSetWindowCollapsed_Str(
+        name: *const core::ffi::c_char,
+        collapsed: bool,
+        cond: ImGuiCond,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowFocus_Str(name: *const cty::c_char);
+    pub fn igSetWindowFocus_Str(name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6176,7 +6196,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPopStyleColor(count: cty::c_int);
+    pub fn igPopStyleColor(count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6196,7 +6216,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPopStyleVar(count: cty::c_int);
+    pub fn igPopStyleVar(count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6356,19 +6376,22 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Str(str_id: *const cty::c_char);
+    pub fn igPushID_Str(str_id: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_StrStr(str_id_begin: *const cty::c_char, str_id_end: *const cty::c_char);
+    pub fn igPushID_StrStr(
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Ptr(ptr_id: *const cty::c_void);
+    pub fn igPushID_Ptr(ptr_id: *const core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Int(int_id: cty::c_int);
+    pub fn igPushID_Int(int_id: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6376,110 +6399,110 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Str(str_id: *const cty::c_char) -> ImGuiID;
+    pub fn igGetID_Str(str_id: *const core::ffi::c_char) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igGetID_StrStr(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Ptr(ptr_id: *const cty::c_void) -> ImGuiID;
+    pub fn igGetID_Ptr(ptr_id: *const core::ffi::c_void) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Int(int_id: cty::c_int) -> ImGuiID;
+    pub fn igGetID_Int(int_id: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextUnformatted(text: *const cty::c_char, text_end: *const cty::c_char);
+    pub fn igTextUnformatted(text: *const core::ffi::c_char, text_end: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igText(fmt: *const cty::c_char, ...);
+    pub fn igText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextColored(col: ImVec4, fmt: *const cty::c_char, ...);
+    pub fn igTextColored(col: ImVec4, fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextDisabled(fmt: *const cty::c_char, ...);
+    pub fn igTextDisabled(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextWrapped(fmt: *const cty::c_char, ...);
+    pub fn igTextWrapped(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLabelText(label: *const cty::c_char, fmt: *const cty::c_char, ...);
+    pub fn igLabelText(label: *const core::ffi::c_char, fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBulletText(fmt: *const cty::c_char, ...);
+    pub fn igBulletText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSeparatorText(label: *const cty::c_char);
+    pub fn igSeparatorText(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igButton(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igButton(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSmallButton(label: *const cty::c_char) -> bool;
+    pub fn igSmallButton(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInvisibleButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         flags: ImGuiButtonFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igArrowButton(str_id: *const cty::c_char, dir: ImGuiDir) -> bool;
+    pub fn igArrowButton(str_id: *const core::ffi::c_char, dir: ImGuiDir) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igCheckbox(label: *const cty::c_char, v: *mut bool) -> bool;
+    pub fn igCheckbox(label: *const core::ffi::c_char, v: *mut bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_IntPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_int,
-        flags_value: cty::c_int,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_int,
+        flags_value: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_UintPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_uint,
-        flags_value: cty::c_uint,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_uint,
+        flags_value: core::ffi::c_uint,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igRadioButton_Bool(label: *const cty::c_char, active: bool) -> bool;
+    pub fn igRadioButton_Bool(label: *const core::ffi::c_char, active: bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igRadioButton_IntPtr(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_button: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_button: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const cty::c_char);
+    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6487,11 +6510,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextLink(label: *const cty::c_char) -> bool;
+    pub fn igTextLink(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextLinkOpenURL(label: *const cty::c_char, url: *const cty::c_char);
+    pub fn igTextLinkOpenURL(label: *const core::ffi::c_char, url: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6507,7 +6530,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImageButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         user_texture_id: ImTextureID,
         image_size: ImVec2,
         uv0: ImVec2,
@@ -6519,8 +6542,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginCombo(
-        label: *const cty::c_char,
-        preview_value: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        preview_value: *const core::ffi::c_char,
         flags: ImGuiComboFlags,
     ) -> bool;
 }
@@ -6531,497 +6554,497 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_Str(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items_separated_by_zeros: *const cty::c_char,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items_separated_by_zeros: *const core::ffi::c_char,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloatRange2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_current_min: *mut f32,
         v_current_max: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragIntRange2(
-        label: *const cty::c_char,
-        v_current_min: *mut cty::c_int,
-        v_current_max: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v_current_min: *mut core::ffi::c_int,
+        v_current_max: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderAngle(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_rad: *mut f32,
         v_degrees_min: f32,
         v_degrees_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderInt(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputText(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextMultiline(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         size: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextWithHint(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         step: f32,
         step_fast: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        step: cty::c_int,
-        step_fast: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        step: core::ffi::c_int,
+        step_fast: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputDouble(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f64,
         step: f64,
         step_fast: f64,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorEdit3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -7029,7 +7052,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorEdit4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -7037,7 +7060,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorPicker3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -7045,7 +7068,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorPicker4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
         ref_col: *const f32,
@@ -7054,7 +7077,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorButton(
-        desc_id: *const cty::c_char,
+        desc_id: *const core::ffi::c_char,
         col: ImVec4,
         flags: ImGuiColorEditFlags,
         size: ImVec2,
@@ -7066,45 +7089,53 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_Str(label: *const cty::c_char) -> bool;
+    pub fn igTreeNode_Str(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_StrStr(str_id: *const cty::c_char, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_StrStr(
+        str_id: *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_Ptr(ptr_id: *const cty::c_void, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_Ptr(
+        ptr_id: *const core::ffi::c_void,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNodeEx_Str(label: *const cty::c_char, flags: ImGuiTreeNodeFlags) -> bool;
+    pub fn igTreeNodeEx_Str(label: *const core::ffi::c_char, flags: ImGuiTreeNodeFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTreeNodeEx_StrStr(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTreeNodeEx_Ptr(
-        ptr_id: *const cty::c_void,
+        ptr_id: *const core::ffi::c_void,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreePush_Str(str_id: *const cty::c_char);
+    pub fn igTreePush_Str(str_id: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreePush_Ptr(ptr_id: *const cty::c_void);
+    pub fn igTreePush_Ptr(ptr_id: *const core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7117,14 +7148,14 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCollapsingHeader_TreeNodeFlags(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCollapsingHeader_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_visible: *mut bool,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
@@ -7140,7 +7171,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSelectable_Bool(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         selected: bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -7149,7 +7180,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSelectable_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_selected: *mut bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -7159,8 +7190,8 @@ extern "C" {
 extern "C" {
     pub fn igBeginMultiSelect(
         flags: ImGuiMultiSelectFlags,
-        selection_size: cty::c_int,
-        items_count: cty::c_int,
+        selection_size: core::ffi::c_int,
+        items_count: core::ffi::c_int,
     ) -> *mut ImGuiMultiSelectIO;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -7177,7 +7208,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginListBox(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igBeginListBox(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7186,54 +7217,54 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igListBox_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igListBox_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotLines_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotLines_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -7242,28 +7273,28 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotHistogram_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotHistogram_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -7271,19 +7302,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Bool(prefix: *const cty::c_char, b: bool);
+    pub fn igValue_Bool(prefix: *const core::ffi::c_char, b: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Int(prefix: *const cty::c_char, v: cty::c_int);
+    pub fn igValue_Int(prefix: *const core::ffi::c_char, v: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Uint(prefix: *const cty::c_char, v: cty::c_uint);
+    pub fn igValue_Uint(prefix: *const core::ffi::c_char, v: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Float(prefix: *const cty::c_char, v: f32, float_format: *const cty::c_char);
+    pub fn igValue_Float(
+        prefix: *const core::ffi::c_char,
+        v: f32,
+        float_format: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7303,7 +7338,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginMenu(label: *const cty::c_char, enabled: bool) -> bool;
+    pub fn igBeginMenu(label: *const core::ffi::c_char, enabled: bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7312,8 +7347,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItem_Bool(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
@@ -7321,8 +7356,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItem_BoolPtr(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         p_selected: *mut bool,
         enabled: bool,
     ) -> bool;
@@ -7337,7 +7372,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetTooltip(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7345,16 +7380,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetItemTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetItemTooltip(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginPopup(str_id: *const cty::c_char, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBeginPopup(str_id: *const core::ffi::c_char, flags: ImGuiWindowFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupModal(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiWindowFlags,
     ) -> bool;
@@ -7365,7 +7400,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igOpenPopup_Str(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopup_Str(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7373,7 +7408,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igOpenPopupOnItemClick(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopupOnItemClick(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7382,33 +7417,33 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextItem(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextWindow(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextVoid(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igIsPopupOpen_Str(str_id: *const cty::c_char, flags: ImGuiPopupFlags) -> bool;
+    pub fn igIsPopupOpen_Str(str_id: *const core::ffi::c_char, flags: ImGuiPopupFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTable(
-        str_id: *const cty::c_char,
-        columns: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        columns: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -7428,12 +7463,12 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnIndex(column_n: cty::c_int) -> bool;
+    pub fn igTableSetColumnIndex(column_n: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableSetupColumn(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTableColumnFlags,
         init_width_or_weight: f32,
         user_id: ImGuiID,
@@ -7441,11 +7476,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetupScrollFreeze(cols: cty::c_int, rows: cty::c_int);
+    pub fn igTableSetupScrollFreeze(cols: core::ffi::c_int, rows: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableHeader(label: *const cty::c_char);
+    pub fn igTableHeader(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7461,39 +7496,39 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnCount() -> cty::c_int;
+    pub fn igTableGetColumnCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnIndex() -> cty::c_int;
+    pub fn igTableGetColumnIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetRowIndex() -> cty::c_int;
+    pub fn igTableGetRowIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnName_Int(column_n: cty::c_int) -> *const cty::c_char;
+    pub fn igTableGetColumnName_Int(column_n: core::ffi::c_int) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnFlags(column_n: cty::c_int) -> ImGuiTableColumnFlags;
+    pub fn igTableGetColumnFlags(column_n: core::ffi::c_int) -> ImGuiTableColumnFlags;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnEnabled(column_n: cty::c_int, v: bool);
+    pub fn igTableSetColumnEnabled(column_n: core::ffi::c_int, v: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetHoveredColumn() -> cty::c_int;
+    pub fn igTableGetHoveredColumn() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: cty::c_int);
+    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igColumns(count: cty::c_int, id: *const cty::c_char, borders: bool);
+    pub fn igColumns(count: core::ffi::c_int, id: *const core::ffi::c_char, borders: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7501,31 +7536,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnIndex() -> cty::c_int;
+    pub fn igGetColumnIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnWidth(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnWidth(column_index: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetColumnWidth(column_index: cty::c_int, width: f32);
+    pub fn igSetColumnWidth(column_index: core::ffi::c_int, width: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnOffset(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnOffset(column_index: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetColumnOffset(column_index: cty::c_int, offset_x: f32);
+    pub fn igSetColumnOffset(column_index: core::ffi::c_int, offset_x: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnsCount() -> cty::c_int;
+    pub fn igGetColumnsCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginTabBar(str_id: *const cty::c_char, flags: ImGuiTabBarFlags) -> bool;
+    pub fn igBeginTabBar(str_id: *const core::ffi::c_char, flags: ImGuiTabBarFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7534,7 +7569,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTabItem(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
     ) -> bool;
@@ -7545,11 +7580,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTabItemButton(label: *const cty::c_char, flags: ImGuiTabItemFlags) -> bool;
+    pub fn igTabItemButton(label: *const core::ffi::c_char, flags: ImGuiTabItemFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const cty::c_char);
+    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7587,15 +7622,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToTTY(auto_open_depth: cty::c_int);
+    pub fn igLogToTTY(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToFile(auto_open_depth: cty::c_int, filename: *const cty::c_char);
+    pub fn igLogToFile(auto_open_depth: core::ffi::c_int, filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToClipboard(auto_open_depth: cty::c_int);
+    pub fn igLogToClipboard(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7612,8 +7647,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSetDragDropPayload(
-        type_: *const cty::c_char,
-        data: *const cty::c_void,
+        type_: *const core::ffi::c_char,
+        data: *const core::ffi::c_void,
         sz: usize,
         cond: ImGuiCond,
     ) -> bool;
@@ -7629,7 +7664,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igAcceptDragDropPayload(
-        type_: *const cty::c_char,
+        type_: *const core::ffi::c_char,
         flags: ImGuiDragDropFlags,
     ) -> *const ImGuiPayload;
 }
@@ -7667,7 +7702,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetKeyboardFocusHere(offset: cty::c_int);
+    pub fn igSetKeyboardFocusHere(offset: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7767,7 +7802,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetFrameCount() -> cty::c_int;
+    pub fn igGetFrameCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7775,7 +7810,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const cty::c_char;
+    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7789,8 +7824,8 @@ extern "C" {
 extern "C" {
     pub fn igCalcTextSize(
         pOut: *mut ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_double_hash: bool,
         wrap_width: f32,
     );
@@ -7843,11 +7878,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> cty::c_int;
+    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyName(key: ImGuiKey) -> *const cty::c_char;
+    pub fn igGetKeyName(key: ImGuiKey) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7883,7 +7918,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> cty::c_int;
+    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7931,31 +7966,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetClipboardText() -> *const cty::c_char;
+    pub fn igGetClipboardText() -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetClipboardText(text: *const cty::c_char);
+    pub fn igSetClipboardText(text: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLoadIniSettingsFromDisk(ini_filename: *const cty::c_char);
+    pub fn igLoadIniSettingsFromDisk(ini_filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLoadIniSettingsFromMemory(ini_data: *const cty::c_char, ini_size: usize);
+    pub fn igLoadIniSettingsFromMemory(ini_data: *const core::ffi::c_char, ini_size: usize);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSaveIniSettingsToDisk(ini_filename: *const cty::c_char);
+    pub fn igSaveIniSettingsToDisk(ini_filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const cty::c_char;
+    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugTextEncoding(text: *const cty::c_char);
+    pub fn igDebugTextEncoding(text: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7968,7 +8003,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugCheckVersionAndDataLayout(
-        version_str: *const cty::c_char,
+        version_str: *const core::ffi::c_char,
         sz_io: usize,
         sz_style: usize,
         sz_vec2: usize,
@@ -7979,14 +8014,14 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugLog(fmt: *const cty::c_char, ...);
+    pub fn igDebugLog(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSetAllocatorFunctions(
         alloc_func: ImGuiMemAllocFunc,
         free_func: ImGuiMemFreeFunc,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -7994,16 +8029,16 @@ extern "C" {
     pub fn igGetAllocatorFunctions(
         p_alloc_func: *mut ImGuiMemAllocFunc,
         p_free_func: *mut ImGuiMemFreeFunc,
-        p_user_data: *mut *mut cty::c_void,
+        p_user_data: *mut *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igMemAlloc(size: usize) -> *mut cty::c_void;
+    pub fn igMemAlloc(size: usize) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igMemFree(ptr: *mut cty::c_void);
+    pub fn igMemFree(ptr: *mut core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8012,8 +8047,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igRenderPlatformWindowsDefault(
-        platform_render_arg: *mut cty::c_void,
-        renderer_render_arg: *mut cty::c_void,
+        platform_render_arg: *mut core::ffi::c_void,
+        renderer_render_arg: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8026,7 +8061,9 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igFindViewportByPlatformHandle(platform_handle: *mut cty::c_void) -> *mut ImGuiViewport;
+    pub fn igFindViewportByPlatformHandle(
+        platform_handle: *mut core::ffi::c_void,
+    ) -> *mut ImGuiViewport;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8070,7 +8107,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: cty::c_int, down: bool);
+    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: core::ffi::c_int, down: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8090,7 +8127,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: cty::c_uint);
+    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8098,16 +8135,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const cty::c_char);
+    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiIO_SetKeyEventNativeData(
         self_: *mut ImGuiIO,
         key: ImGuiKey,
-        native_keycode: cty::c_int,
-        native_scancode: cty::c_int,
-        native_legacy_index: cty::c_int,
+        native_keycode: core::ffi::c_int,
+        native_scancode: core::ffi::c_int,
+        native_legacy_index: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8146,17 +8183,17 @@ extern "C" {
 extern "C" {
     pub fn ImGuiInputTextCallbackData_DeleteChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        bytes_count: cty::c_int,
+        pos: core::ffi::c_int,
+        bytes_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiInputTextCallbackData_InsertChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        pos: core::ffi::c_int,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8193,7 +8230,10 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiPayload_IsDataType(self_: *mut ImGuiPayload, type_: *const cty::c_char) -> bool;
+    pub fn ImGuiPayload_IsDataType(
+        self_: *mut ImGuiPayload,
+        type_: *const core::ffi::c_char,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8214,7 +8254,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextFilter_ImGuiTextFilter(
-        default_filter: *const cty::c_char,
+        default_filter: *const core::ffi::c_char,
     ) -> *mut ImGuiTextFilter;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8225,7 +8265,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_Draw(
         self_: *mut ImGuiTextFilter,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         width: f32,
     ) -> bool;
 }
@@ -8233,8 +8273,8 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_PassFilter(
         self_: *mut ImGuiTextFilter,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8260,8 +8300,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextRange_ImGuiTextRange_Str(
-        _b: *const cty::c_char,
-        _e: *const cty::c_char,
+        _b: *const core::ffi::c_char,
+        _e: *const core::ffi::c_char,
     ) -> *mut ImGuiTextRange;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8272,7 +8312,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextRange_split(
         self_: *mut ImGuiTextRange,
-        separator: cty::c_char,
+        separator: core::ffi::c_char,
         out: *mut ImVector_ImGuiTextRange,
     );
 }
@@ -8286,15 +8326,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> cty::c_int;
+    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8306,25 +8346,25 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: cty::c_int);
+    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextBuffer_append(
         self_: *mut ImGuiTextBuffer,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Int(
         _key: ImGuiID,
-        _val: cty::c_int,
+        _val: core::ffi::c_int,
     ) -> *mut ImGuiStoragePair;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8342,7 +8382,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Ptr(
         _key: ImGuiID,
-        _val: *mut cty::c_void,
+        _val: *mut core::ffi::c_void,
     ) -> *mut ImGuiStoragePair;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8354,12 +8394,12 @@ extern "C" {
     pub fn ImGuiStorage_GetInt(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: cty::c_int);
+    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8379,19 +8419,26 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_GetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID) -> *mut cty::c_void;
+    pub fn ImGuiStorage_GetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+    ) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID, val: *mut cty::c_void);
+    pub fn ImGuiStorage_SetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+        val: *mut core::ffi::c_void,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiStorage_GetIntRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> *mut cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> *mut core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8414,8 +8461,8 @@ extern "C" {
     pub fn ImGuiStorage_GetVoidPtrRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: *mut cty::c_void,
-    ) -> *mut *mut cty::c_void;
+        default_val: *mut core::ffi::c_void,
+    ) -> *mut *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8423,7 +8470,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: cty::c_int);
+    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8437,7 +8484,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_Begin(
         self_: *mut ImGuiListClipper,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         items_height: f32,
     );
 }
@@ -8453,20 +8500,23 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemByIndex(
         self_: *mut ImGuiListClipper,
-        item_index: cty::c_int,
+        item_index: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemsByIndex(
         self_: *mut ImGuiListClipper,
-        item_begin: cty::c_int,
-        item_end: cty::c_int,
+        item_begin: core::ffi::c_int,
+        item_end: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiListClipper_SeekCursorForItem(self_: *mut ImGuiListClipper, item_index: cty::c_int);
+    pub fn ImGuiListClipper_SeekCursorForItem(
+        self_: *mut ImGuiListClipper,
+        item_index: core::ffi::c_int,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8487,10 +8537,10 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImColor_ImColor_Int(
-        r: cty::c_int,
-        g: cty::c_int,
-        b: cty::c_int,
-        a: cty::c_int,
+        r: core::ffi::c_int,
+        g: core::ffi::c_int,
+        b: core::ffi::c_int,
+        a: core::ffi::c_int,
     ) -> *mut ImColor;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8550,7 +8600,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetNextSelectedItem(
         self_: *mut ImGuiSelectionBasicStorage,
-        opaque_it: *mut *mut cty::c_void,
+        opaque_it: *mut *mut core::ffi::c_void,
         out_id: *mut ImGuiID,
     ) -> bool;
 }
@@ -8558,7 +8608,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetStorageIdFromIndex(
         self_: *mut ImGuiSelectionBasicStorage,
-        idx: cty::c_int,
+        idx: core::ffi::c_int,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8610,7 +8660,7 @@ extern "C" {
     pub fn ImDrawListSplitter_Split(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        count: cty::c_int,
+        count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8622,7 +8672,7 @@ extern "C" {
     pub fn ImDrawListSplitter_SetCurrentChannel(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        channel_idx: cty::c_int,
+        channel_idx: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8762,7 +8812,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8773,7 +8823,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8783,7 +8833,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8794,7 +8844,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8805,7 +8855,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8817,7 +8867,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8826,8 +8876,8 @@ extern "C" {
         self_: *mut ImDrawList,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8838,8 +8888,8 @@ extern "C" {
         font_size: f32,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip_rect: *const ImVec4,
     );
@@ -8854,7 +8904,7 @@ extern "C" {
         p4: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8866,7 +8916,7 @@ extern "C" {
         p3: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8874,7 +8924,7 @@ extern "C" {
     pub fn ImDrawList_AddPolyline(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
         flags: ImDrawFlags,
         thickness: f32,
@@ -8885,7 +8935,7 @@ extern "C" {
     pub fn ImDrawList_AddConvexPolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -8894,7 +8944,7 @@ extern "C" {
     pub fn ImDrawList_AddConcavePolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -8977,7 +9027,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8986,8 +9036,8 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_of_12: cty::c_int,
-        a_max_of_12: cty::c_int,
+        a_min_of_12: core::ffi::c_int,
+        a_max_of_12: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8999,7 +9049,7 @@ extern "C" {
         rot: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9009,7 +9059,7 @@ extern "C" {
         p2: ImVec2,
         p3: ImVec2,
         p4: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9018,7 +9068,7 @@ extern "C" {
         self_: *mut ImDrawList,
         p2: ImVec2,
         p3: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9036,7 +9086,7 @@ extern "C" {
     pub fn ImDrawList_AddCallback(
         self_: *mut ImDrawList,
         callback: ImDrawCallback,
-        callback_data: *mut cty::c_void,
+        callback_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9049,7 +9099,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: cty::c_int);
+    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9057,22 +9107,22 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: cty::c_int);
+    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImDrawList_PrimReserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImDrawList_PrimUnreserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9154,7 +9204,7 @@ extern "C" {
     pub fn ImDrawList__CalcCircleAutoSegmentCount(
         self_: *mut ImDrawList,
         radius: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9162,9 +9212,9 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_sample: cty::c_int,
-        a_max_sample: cty::c_int,
-        a_step: cty::c_int,
+        a_min_sample: core::ffi::c_int,
+        a_max_sample: core::ffi::c_int,
+        a_step: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9175,7 +9225,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9238,8 +9288,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontGlyphRangesBuilder_AddText(
         self_: *mut ImFontGlyphRangesBuilder,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9294,7 +9344,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromFileTTF(
         self_: *mut ImFontAtlas,
-        filename: *const cty::c_char,
+        filename: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -9304,8 +9354,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryTTF(
         self_: *mut ImFontAtlas,
-        font_data: *mut cty::c_void,
-        font_data_size: cty::c_int,
+        font_data: *mut core::ffi::c_void,
+        font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -9315,8 +9365,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedTTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data: *const cty::c_void,
-        compressed_font_data_size: cty::c_int,
+        compressed_font_data: *const core::ffi::c_void,
+        compressed_font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -9326,7 +9376,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data_base85: *const cty::c_char,
+        compressed_font_data_base85: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -9356,20 +9406,20 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsAlpha8(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsRGBA32(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9422,9 +9472,9 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectRegular(
         self_: *mut ImFontAtlas,
-        width: cty::c_int,
-        height: cty::c_int,
-    ) -> cty::c_int;
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9432,17 +9482,17 @@ extern "C" {
         self_: *mut ImFontAtlas,
         font: *mut ImFont,
         id: ImWchar,
-        width: cty::c_int,
-        height: cty::c_int,
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
         advance_x: f32,
         offset: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImFontAtlas_GetCustomRectByIndex(
         self_: *mut ImFontAtlas,
-        index: cty::c_int,
+        index: core::ffi::c_int,
     ) -> *mut ImFontAtlasCustomRect;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9491,7 +9541,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const cty::c_char;
+    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9501,9 +9551,9 @@ extern "C" {
         size: f32,
         max_width: f32,
         wrap_width: f32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
-        remaining: *mut *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        remaining: *mut *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9511,10 +9561,10 @@ extern "C" {
     pub fn ImFont_CalcWordWrapPositionA(
         self_: *mut ImFont,
         scale: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9536,8 +9586,8 @@ extern "C" {
         pos: ImVec2,
         col: ImU32,
         clip_rect: ImVec4,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip: bool,
     );
@@ -9552,7 +9602,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: cty::c_int);
+    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9583,8 +9633,8 @@ extern "C" {
 extern "C" {
     pub fn ImFont_IsGlyphRangeUnused(
         self_: *mut ImFont,
-        c_begin: cty::c_uint,
-        c_last: cty::c_uint,
+        c_begin: core::ffi::c_uint,
+        c_last: core::ffi::c_uint,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9629,20 +9679,24 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImHashData(data: *const cty::c_void, data_size: usize, seed: ImGuiID) -> ImGuiID;
+    pub fn igImHashData(data: *const core::ffi::c_void, data_size: usize, seed: ImGuiID)
+        -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImHashStr(data: *const cty::c_char, data_size: usize, seed: ImGuiID) -> ImGuiID;
+    pub fn igImHashStr(data: *const core::ffi::c_char, data_size: usize, seed: ImGuiID) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImQsort(
-        base: *mut cty::c_void,
+        base: *mut core::ffi::c_void,
         count: usize,
         size_of_element: usize,
         compare_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *const cty::c_void, arg2: *const cty::c_void) -> cty::c_int,
+            unsafe extern "C" fn(
+                arg1: *const core::ffi::c_void,
+                arg2: *const core::ffi::c_void,
+            ) -> core::ffi::c_int,
         >,
     );
 }
@@ -9652,7 +9706,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImIsPowerOfTwo_Int(v: cty::c_int) -> bool;
+    pub fn igImIsPowerOfTwo_Int(v: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9660,221 +9714,230 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImUpperPowerOfTwo(v: cty::c_int) -> cty::c_int;
+    pub fn igImUpperPowerOfTwo(v: core::ffi::c_int) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStricmp(str1: *const cty::c_char, str2: *const cty::c_char) -> cty::c_int;
+    pub fn igImStricmp(
+        str1: *const core::ffi::c_char,
+        str2: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStrnicmp(
-        str1: *const cty::c_char,
-        str2: *const cty::c_char,
+        str1: *const core::ffi::c_char,
+        str2: *const core::ffi::c_char,
         count: usize,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrncpy(dst: *mut cty::c_char, src: *const cty::c_char, count: usize);
+    pub fn igImStrncpy(dst: *mut core::ffi::c_char, src: *const core::ffi::c_char, count: usize);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrdup(str_: *const cty::c_char) -> *mut cty::c_char;
+    pub fn igImStrdup(str_: *const core::ffi::c_char) -> *mut core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStrdupcpy(
-        dst: *mut cty::c_char,
+        dst: *mut core::ffi::c_char,
         p_dst_size: *mut usize,
-        str_: *const cty::c_char,
-    ) -> *mut cty::c_char;
+        str_: *const core::ffi::c_char,
+    ) -> *mut core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStrchrRange(
-        str_begin: *const cty::c_char,
-        str_end: *const cty::c_char,
-        c: cty::c_char,
-    ) -> *const cty::c_char;
+        str_begin: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
+        c: core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStreolRange(
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStristr(
-        haystack: *const cty::c_char,
-        haystack_end: *const cty::c_char,
-        needle: *const cty::c_char,
-        needle_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        haystack: *const core::ffi::c_char,
+        haystack_end: *const core::ffi::c_char,
+        needle: *const core::ffi::c_char,
+        needle_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrTrimBlanks(str_: *mut cty::c_char);
+    pub fn igImStrTrimBlanks(str_: *mut core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrSkipBlank(str_: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImStrSkipBlank(str_: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrlenW(str_: *const ImWchar) -> cty::c_int;
+    pub fn igImStrlenW(str_: *const ImWchar) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStrbol(
-        buf_mid_line: *const cty::c_char,
-        buf_begin: *const cty::c_char,
-    ) -> *const cty::c_char;
+        buf_mid_line: *const core::ffi::c_char,
+        buf_begin: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImToUpper(c: cty::c_char) -> cty::c_char;
+    pub fn igImToUpper(c: core::ffi::c_char) -> core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImCharIsBlankA(c: cty::c_char) -> bool;
+    pub fn igImCharIsBlankA(c: core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImCharIsBlankW(c: cty::c_uint) -> bool;
+    pub fn igImCharIsBlankW(c: core::ffi::c_uint) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImCharIsXdigitA(c: cty::c_char) -> bool;
+    pub fn igImCharIsXdigitA(c: core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFormatString(
-        buf: *mut cty::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFormatStringToTempBuffer(
-        out_buf: *mut *const cty::c_char,
-        out_buf_end: *mut *const cty::c_char,
-        fmt: *const cty::c_char,
+        out_buf: *mut *const core::ffi::c_char,
+        out_buf_end: *mut *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImParseFormatFindStart(format: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImParseFormatFindStart(format: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImParseFormatFindEnd(format: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImParseFormatFindEnd(format: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImParseFormatTrimDecorations(
-        format: *const cty::c_char,
-        buf: *mut cty::c_char,
+        format: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImParseFormatSanitizeForPrinting(
-        fmt_in: *const cty::c_char,
-        fmt_out: *mut cty::c_char,
+        fmt_in: *const core::ffi::c_char,
+        fmt_out: *mut core::ffi::c_char,
         fmt_out_size: usize,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImParseFormatSanitizeForScanning(
-        fmt_in: *const cty::c_char,
-        fmt_out: *mut cty::c_char,
+        fmt_in: *const core::ffi::c_char,
+        fmt_out: *mut core::ffi::c_char,
         fmt_out_size: usize,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImParseFormatPrecision(
-        format: *const cty::c_char,
-        default_value: cty::c_int,
-    ) -> cty::c_int;
+        format: *const core::ffi::c_char,
+        default_value: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImTextCharToUtf8(out_buf: *mut cty::c_char, c: cty::c_uint) -> *const cty::c_char;
+    pub fn igImTextCharToUtf8(
+        out_buf: *mut core::ffi::c_char,
+        c: core::ffi::c_uint,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextStrToUtf8(
-        out_buf: *mut cty::c_char,
-        out_buf_size: cty::c_int,
+        out_buf: *mut core::ffi::c_char,
+        out_buf_size: core::ffi::c_int,
         in_text: *const ImWchar,
         in_text_end: *const ImWchar,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCharFromUtf8(
-        out_char: *mut cty::c_uint,
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        out_char: *mut core::ffi::c_uint,
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextStrFromUtf8(
         out_buf: *mut ImWchar,
-        out_buf_size: cty::c_int,
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-        in_remaining: *mut *const cty::c_char,
-    ) -> cty::c_int;
+        out_buf_size: core::ffi::c_int,
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+        in_remaining: *mut *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCountCharsFromUtf8(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCountUtf8BytesFromChar(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCountUtf8BytesFromStr(
         in_text: *const ImWchar,
         in_text_end: *const ImWchar,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextFindPreviousUtf8Codepoint(
-        in_text_start: *const cty::c_char,
-        in_text_curr: *const cty::c_char,
-    ) -> *const cty::c_char;
+        in_text_start: *const core::ffi::c_char,
+        in_text_curr: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCountLines(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImFileOpen(filename: *const cty::c_char, mode: *const cty::c_char) -> ImFileHandle;
+    pub fn igImFileOpen(
+        filename: *const core::ffi::c_char,
+        mode: *const core::ffi::c_char,
+    ) -> ImFileHandle;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9887,7 +9950,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFileRead(
-        data: *mut cty::c_void,
+        data: *mut core::ffi::c_void,
         size: ImU64,
         count: ImU64,
         file: ImFileHandle,
@@ -9896,7 +9959,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFileWrite(
-        data: *const cty::c_void,
+        data: *const core::ffi::c_void,
         size: ImU64,
         count: ImU64,
         file: ImFileHandle,
@@ -9905,11 +9968,11 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFileLoadToMemory(
-        filename: *const cty::c_char,
-        mode: *const cty::c_char,
+        filename: *const core::ffi::c_char,
+        mode: *const core::ffi::c_char,
         out_file_size: *mut usize,
-        padding_bytes: cty::c_int,
-    ) -> *mut cty::c_void;
+        padding_bytes: core::ffi::c_int,
+    ) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9929,7 +9992,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImAbs_Int(x: cty::c_int) -> cty::c_int;
+    pub fn igImAbs_Int(x: core::ffi::c_int) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10013,7 +10076,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImModPositive(a: cty::c_int, b: cty::c_int) -> cty::c_int;
+    pub fn igImModPositive(a: core::ffi::c_int, b: core::ffi::c_int) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10041,7 +10104,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImExponentialMovingAverage(avg: f32, sample: f32, n: cty::c_int) -> f32;
+    pub fn igImExponentialMovingAverage(avg: f32, sample: f32, n: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10063,7 +10126,7 @@ extern "C" {
         p3: ImVec2,
         p4: ImVec2,
         p: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10136,7 +10199,8 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImVec2ih_ImVec2ih_short(_x: cty::c_short, _y: cty::c_short) -> *mut ImVec2ih;
+    pub fn ImVec2ih_ImVec2ih_short(_x: core::ffi::c_short, _y: core::ffi::c_short)
+        -> *mut ImVec2ih;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10264,31 +10328,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArrayGetStorageSizeInBytes(bitcount: cty::c_int) -> usize;
+    pub fn igImBitArrayGetStorageSizeInBytes(bitcount: core::ffi::c_int) -> usize;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArrayClearAllBits(arr: *mut ImU32, bitcount: cty::c_int);
+    pub fn igImBitArrayClearAllBits(arr: *mut ImU32, bitcount: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArrayTestBit(arr: *const ImU32, n: cty::c_int) -> bool;
+    pub fn igImBitArrayTestBit(arr: *const ImU32, n: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArrayClearBit(arr: *mut ImU32, n: cty::c_int);
+    pub fn igImBitArrayClearBit(arr: *mut ImU32, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArraySetBit(arr: *mut ImU32, n: cty::c_int);
+    pub fn igImBitArraySetBit(arr: *mut ImU32, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArraySetBitRange(arr: *mut ImU32, n: cty::c_int, n2: cty::c_int);
+    pub fn igImBitArraySetBitRange(arr: *mut ImU32, n: core::ffi::c_int, n2: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImBitVector_Create(self_: *mut ImBitVector, sz: cty::c_int);
+    pub fn ImBitVector_Create(self_: *mut ImBitVector, sz: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10296,15 +10360,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImBitVector_TestBit(self_: *mut ImBitVector, n: cty::c_int) -> bool;
+    pub fn ImBitVector_TestBit(self_: *mut ImBitVector, n: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImBitVector_SetBit(self_: *mut ImBitVector, n: cty::c_int);
+    pub fn ImBitVector_SetBit(self_: *mut ImBitVector, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImBitVector_ClearBit(self_: *mut ImBitVector, n: cty::c_int);
+    pub fn ImBitVector_ClearBit(self_: *mut ImBitVector, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10312,31 +10376,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextIndex_size(self_: *mut ImGuiTextIndex) -> cty::c_int;
+    pub fn ImGuiTextIndex_size(self_: *mut ImGuiTextIndex) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextIndex_get_line_begin(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        n: cty::c_int,
-    ) -> *const cty::c_char;
+        base: *const core::ffi::c_char,
+        n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextIndex_get_line_end(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        n: cty::c_int,
-    ) -> *const cty::c_char;
+        base: *const core::ffi::c_char,
+        n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextIndex_append(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        old_size: cty::c_int,
-        new_size: cty::c_int,
+        base: *const core::ffi::c_char,
+        old_size: core::ffi::c_int,
+        new_size: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10374,13 +10438,15 @@ extern "C" {
 extern "C" {
     pub fn ImGuiDataVarInfo_GetVarPtr(
         self_: *mut ImGuiDataVarInfo,
-        parent: *mut cty::c_void,
-    ) -> *mut cty::c_void;
+        parent: *mut core::ffi::c_void,
+    ) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStyleMod_ImGuiStyleMod_Int(idx: ImGuiStyleVar, v: cty::c_int)
-        -> *mut ImGuiStyleMod;
+    pub fn ImGuiStyleMod_ImGuiStyleMod_Int(
+        idx: ImGuiStyleVar,
+        v: core::ffi::c_int,
+    ) -> *mut ImGuiStyleMod;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10465,11 +10531,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_OnKeyPressed(self_: *mut ImGuiInputTextState, key: cty::c_int);
+    pub fn ImGuiInputTextState_OnKeyPressed(self_: *mut ImGuiInputTextState, key: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_OnCharPressed(self_: *mut ImGuiInputTextState, c: cty::c_uint);
+    pub fn ImGuiInputTextState_OnCharPressed(self_: *mut ImGuiInputTextState, c: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10489,15 +10555,18 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_GetCursorPos(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetCursorPos(self_: *mut ImGuiInputTextState) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_GetSelectionStart(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetSelectionStart(
+        self_: *mut ImGuiInputTextState,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_GetSelectionEnd(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetSelectionEnd(self_: *mut ImGuiInputTextState)
+        -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10557,7 +10626,8 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Ptr(ptr: *mut cty::c_void) -> *mut ImGuiPtrOrIndex;
+    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Ptr(ptr: *mut core::ffi::c_void)
+        -> *mut ImGuiPtrOrIndex;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10565,7 +10635,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Int(index: cty::c_int) -> *mut ImGuiPtrOrIndex;
+    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Int(index: core::ffi::c_int) -> *mut ImGuiPtrOrIndex;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10614,8 +10684,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiListClipperRange_FromIndices(
-        min: cty::c_int,
-        max: cty::c_int,
+        min: core::ffi::c_int,
+        max: core::ffi::c_int,
     ) -> ImGuiListClipperRange;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10623,8 +10693,8 @@ extern "C" {
     pub fn ImGuiListClipperRange_FromPositions(
         y1: f32,
         y2: f32,
-        off_min: cty::c_int,
-        off_max: cty::c_int,
+        off_min: core::ffi::c_int,
+        off_max: core::ffi::c_int,
     ) -> ImGuiListClipperRange;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10833,7 +10903,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiWindowSettings_GetName(self_: *mut ImGuiWindowSettings) -> *mut cty::c_char;
+    pub fn ImGuiWindowSettings_GetName(self_: *mut ImGuiWindowSettings) -> *mut core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10887,7 +10957,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiWindow_ImGuiWindow(
         context: *mut ImGuiContext,
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
     ) -> *mut ImGuiWindow;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10898,17 +10968,18 @@ extern "C" {
 extern "C" {
     pub fn ImGuiWindow_GetID_Str(
         self_: *mut ImGuiWindow,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiWindow_GetID_Ptr(self_: *mut ImGuiWindow, ptr: *const cty::c_void) -> ImGuiID;
+    pub fn ImGuiWindow_GetID_Ptr(self_: *mut ImGuiWindow, ptr: *const core::ffi::c_void)
+        -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiWindow_GetID_Int(self_: *mut ImGuiWindow, n: cty::c_int) -> ImGuiID;
+    pub fn ImGuiWindow_GetID_Int(self_: *mut ImGuiWindow, n: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11018,7 +11089,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igFindWindowByName(name: *const cty::c_char) -> *mut ImGuiWindow;
+    pub fn igFindWindowByName(name: *const core::ffi::c_char) -> *mut ImGuiWindow;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11141,7 +11212,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igFindWindowDisplayIndex(window: *mut ImGuiWindow) -> cty::c_int;
+    pub fn igFindWindowDisplayIndex(window: *mut ImGuiWindow) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11286,15 +11357,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igRemoveSettingsHandler(type_name: *const cty::c_char);
+    pub fn igRemoveSettingsHandler(type_name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igFindSettingsHandler(type_name: *const cty::c_char) -> *mut ImGuiSettingsHandler;
+    pub fn igFindSettingsHandler(type_name: *const core::ffi::c_char) -> *mut ImGuiSettingsHandler;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igCreateNewWindowSettings(name: *const cty::c_char) -> *mut ImGuiWindowSettings;
+    pub fn igCreateNewWindowSettings(name: *const core::ffi::c_char) -> *mut ImGuiWindowSettings;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11306,15 +11377,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igClearWindowSettings(name: *const cty::c_char);
+    pub fn igClearWindowSettings(name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLocalizeRegisterEntries(entries: *const ImGuiLocEntry, count: cty::c_int);
+    pub fn igLocalizeRegisterEntries(entries: *const ImGuiLocEntry, count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLocalizeGetMsg(key: ImGuiLocKey) -> *const cty::c_char;
+    pub fn igLocalizeGetMsg(key: ImGuiLocKey) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11412,14 +11483,14 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igGetIDWithSeed_Str(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
         seed: ImGuiID,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetIDWithSeed_Int(n: cty::c_int, seed: ImGuiID) -> ImGuiID;
+    pub fn igGetIDWithSeed_Int(n: core::ffi::c_int, seed: ImGuiID) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11469,11 +11540,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushMultiItemsWidths(components: cty::c_int, width_full: f32);
+    pub fn igPushMultiItemsWidths(components: core::ffi::c_int, width_full: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShrinkWidths(items: *mut ImGuiShrinkWidthItem, count: cty::c_int, width_excess: f32);
+    pub fn igShrinkWidths(
+        items: *mut ImGuiShrinkWidthItem,
+        count: core::ffi::c_int,
+        width_excess: f32,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11489,28 +11564,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogBegin(type_: ImGuiLogType, auto_open_depth: cty::c_int);
+    pub fn igLogBegin(type_: ImGuiLogType, auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToBuffer(auto_open_depth: cty::c_int);
+    pub fn igLogToBuffer(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igLogRenderedText(
         ref_pos: *const ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogSetNextTextDecoration(prefix: *const cty::c_char, suffix: *const cty::c_char);
+    pub fn igLogSetNextTextDecoration(
+        prefix: *const core::ffi::c_char,
+        suffix: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginChildEx(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         id: ImGuiID,
         size_arg: ImVec2,
         child_flags: ImGuiChildFlags,
@@ -11527,7 +11605,10 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igClosePopupToLevel(remaining: cty::c_int, restore_focus_to_window_under_popup: bool);
+    pub fn igClosePopupToLevel(
+        remaining: core::ffi::c_int,
+        restore_focus_to_window_under_popup: bool,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11590,7 +11671,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginViewportSideBar(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         viewport: *mut ImGuiViewport,
         dir: ImGuiDir,
         size: f32,
@@ -11600,17 +11681,17 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginMenuEx(
-        label: *const cty::c_char,
-        icon: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        icon: *const core::ffi::c_char,
         enabled: bool,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItemEx(
-        label: *const cty::c_char,
-        icon: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        icon: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
@@ -11771,7 +11852,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyChordName(key_chord: ImGuiKeyChord) -> *const cty::c_char;
+    pub fn igGetKeyChordName(key_chord: ImGuiKeyChord) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11802,7 +11883,7 @@ extern "C" {
         t1: f32,
         repeat_delay: f32,
         repeat_rate: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12026,7 +12107,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDockNodeGetDepth(node: *const ImGuiDockNode) -> cty::c_int;
+    pub fn igDockNodeGetDepth(node: *const ImGuiDockNode) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12058,7 +12139,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDockBuilderDockWindow(window_name: *const cty::c_char, node_id: ImGuiID);
+    pub fn igDockBuilderDockWindow(window_name: *const core::ffi::c_char, node_id: ImGuiID);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12121,8 +12202,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDockBuilderCopyWindowSettings(
-        src_name: *const cty::c_char,
-        dst_name: *const cty::c_char,
+        src_name: *const core::ffi::c_char,
+        dst_name: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -12170,36 +12251,45 @@ extern "C" {
 extern "C" {
     pub fn igTypingSelectFindMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        nav_item_idx: cty::c_int,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+        nav_item_idx: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTypingSelectFindNextSingleCharMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        nav_item_idx: cty::c_int,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+        nav_item_idx: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTypingSelectFindBestLeadingMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12235,7 +12325,7 @@ extern "C" {
     pub fn igMultiSelectAddSetRange(
         ms: *mut ImGuiMultiSelectTempData,
         selected: bool,
-        range_dir: cty::c_int,
+        range_dir: core::ffi::c_int,
         first_item: ImGuiSelectionUserData,
         last_item: ImGuiSelectionUserData,
     );
@@ -12255,8 +12345,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginColumns(
-        str_id: *const cty::c_char,
-        count: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        count: core::ffi::c_int,
         flags: ImGuiOldColumnFlags,
     );
 }
@@ -12266,7 +12356,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushColumnClipRect(column_index: cty::c_int);
+    pub fn igPushColumnClipRect(column_index: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12278,7 +12368,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnsID(str_id: *const cty::c_char, count: cty::c_int) -> ImGuiID;
+    pub fn igGetColumnsID(str_id: *const core::ffi::c_char, count: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12294,23 +12384,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableOpenContextMenu(column_n: cty::c_int);
+    pub fn igTableOpenContextMenu(column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnWidth(column_n: cty::c_int, width: f32);
+    pub fn igTableSetColumnWidth(column_n: core::ffi::c_int, width: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableSetColumnSortDirection(
-        column_n: cty::c_int,
+        column_n: core::ffi::c_int,
         sort_direction: ImGuiSortDirection,
         append_to_sort_specs: bool,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetHoveredRow() -> cty::c_int;
+    pub fn igTableGetHoveredRow() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12335,7 +12425,7 @@ extern "C" {
         angle: f32,
         max_label_width: f32,
         data: *const ImGuiTableHeaderData,
-        data_count: cty::c_int,
+        data_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -12349,9 +12439,9 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTableEx(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         id: ImGuiID,
-        columns_count: cty::c_int,
+        columns_count: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -12359,7 +12449,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableBeginInitMemory(table: *mut ImGuiTable, columns_count: cty::c_int);
+    pub fn igTableBeginInitMemory(table: *mut ImGuiTable, columns_count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12404,12 +12494,12 @@ extern "C" {
 extern "C" {
     pub fn igTableGetInstanceData(
         table: *mut ImGuiTable,
-        instance_no: cty::c_int,
+        instance_no: core::ffi::c_int,
     ) -> *mut ImGuiTableInstanceData;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetInstanceID(table: *mut ImGuiTable, instance_no: cty::c_int) -> ImGuiID;
+    pub fn igTableGetInstanceID(table: *mut ImGuiTable, instance_no: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12441,7 +12531,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableBeginCell(table: *mut ImGuiTable, column_n: cty::c_int);
+    pub fn igTableBeginCell(table: *mut ImGuiTable, column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12449,30 +12539,34 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetCellBgRect(pOut: *mut ImRect, table: *const ImGuiTable, column_n: cty::c_int);
+    pub fn igTableGetCellBgRect(
+        pOut: *mut ImRect,
+        table: *const ImGuiTable,
+        column_n: core::ffi::c_int,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableGetColumnName_TablePtr(
         table: *const ImGuiTable,
-        column_n: cty::c_int,
-    ) -> *const cty::c_char;
+        column_n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableGetColumnResizeID(
         table: *mut ImGuiTable,
-        column_n: cty::c_int,
-        instance_no: cty::c_int,
+        column_n: core::ffi::c_int,
+        instance_no: core::ffi::c_int,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableCalcMaxColumnWidth(table: *const ImGuiTable, column_n: cty::c_int) -> f32;
+    pub fn igTableCalcMaxColumnWidth(table: *const ImGuiTable, column_n: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnWidthAutoSingle(table: *mut ImGuiTable, column_n: cty::c_int);
+    pub fn igTableSetColumnWidthAutoSingle(table: *mut ImGuiTable, column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12516,8 +12610,10 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSettingsCreate(id: ImGuiID, columns_count: cty::c_int)
-        -> *mut ImGuiTableSettings;
+    pub fn igTableSettingsCreate(
+        id: ImGuiID,
+        columns_count: core::ffi::c_int,
+    ) -> *mut ImGuiTableSettings;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12539,7 +12635,7 @@ extern "C" {
 extern "C" {
     pub fn igTabBarFindTabByOrder(
         tab_bar: *mut ImGuiTabBar,
-        order: cty::c_int,
+        order: core::ffi::c_int,
     ) -> *mut ImGuiTabItem;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -12554,14 +12650,17 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTabBarGetTabOrder(tab_bar: *mut ImGuiTabBar, tab: *mut ImGuiTabItem) -> cty::c_int;
+    pub fn igTabBarGetTabOrder(
+        tab_bar: *mut ImGuiTabBar,
+        tab: *mut ImGuiTabItem,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTabBarGetTabName(
         tab_bar: *mut ImGuiTabBar,
         tab: *mut ImGuiTabItem,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12585,14 +12684,14 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTabBarQueueFocus_Str(tab_bar: *mut ImGuiTabBar, tab_name: *const cty::c_char);
+    pub fn igTabBarQueueFocus_Str(tab_bar: *mut ImGuiTabBar, tab_name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTabBarQueueReorder(
         tab_bar: *mut ImGuiTabBar,
         tab: *mut ImGuiTabItem,
-        offset: cty::c_int,
+        offset: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -12611,7 +12710,7 @@ extern "C" {
 extern "C" {
     pub fn igTabItemEx(
         tab_bar: *mut ImGuiTabBar,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
         docked_window: *mut ImGuiWindow,
@@ -12621,7 +12720,7 @@ extern "C" {
 extern "C" {
     pub fn igTabItemCalcSize_Str(
         pOut: *mut ImVec2,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         has_close_button_or_unsaved_marker: bool,
     );
 }
@@ -12645,7 +12744,7 @@ extern "C" {
         bb: ImRect,
         flags: ImGuiTabItemFlags,
         frame_padding: ImVec2,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         tab_id: ImGuiID,
         close_button_id: ImGuiID,
         is_contents_visible: bool,
@@ -12657,8 +12756,8 @@ extern "C" {
 extern "C" {
     pub fn igRenderText(
         pos: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_hash: bool,
     );
 }
@@ -12666,8 +12765,8 @@ extern "C" {
 extern "C" {
     pub fn igRenderTextWrapped(
         pos: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
     );
 }
@@ -12676,8 +12775,8 @@ extern "C" {
     pub fn igRenderTextClipped(
         pos_min: ImVec2,
         pos_max: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
         align: ImVec2,
         clip_rect: *const ImRect,
@@ -12689,8 +12788,8 @@ extern "C" {
         draw_list: *mut ImDrawList,
         pos_min: ImVec2,
         pos_max: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
         align: ImVec2,
         clip_rect: *const ImRect,
@@ -12704,8 +12803,8 @@ extern "C" {
         pos_max: ImVec2,
         clip_max_x: f32,
         ellipsis_max_x: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
     );
 }
@@ -12743,9 +12842,9 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igFindRenderedTextEnd(
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12821,17 +12920,24 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextEx(text: *const cty::c_char, text_end: *const cty::c_char, flags: ImGuiTextFlags);
+    pub fn igTextEx(
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        flags: ImGuiTextFlags,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igButtonEx(label: *const cty::c_char, size_arg: ImVec2, flags: ImGuiButtonFlags)
-        -> bool;
+    pub fn igButtonEx(
+        label: *const core::ffi::c_char,
+        size_arg: ImVec2,
+        flags: ImGuiButtonFlags,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igArrowButtonEx(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         dir: ImGuiDir,
         size_arg: ImVec2,
         flags: ImGuiButtonFlags,
@@ -12858,15 +12964,15 @@ extern "C" {
 extern "C" {
     pub fn igSeparatorTextEx(
         id: ImGuiID,
-        label: *const cty::c_char,
-        label_end: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        label_end: *const core::ffi::c_char,
         extra_width: f32,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_S64Ptr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: *mut ImS64,
         flags_value: ImS64,
     ) -> bool;
@@ -12874,7 +12980,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_U64Ptr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: *mut ImU64,
         flags_value: ImU64,
     ) -> bool;
@@ -12913,7 +13019,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetWindowResizeCornerID(window: *mut ImGuiWindow, n: cty::c_int) -> ImGuiID;
+    pub fn igGetWindowResizeCornerID(window: *mut ImGuiWindow, n: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12934,11 +13040,11 @@ extern "C" {
     pub fn igDragBehavior(
         id: ImGuiID,
         data_type: ImGuiDataType,
-        p_v: *mut cty::c_void,
+        p_v: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
@@ -12948,10 +13054,10 @@ extern "C" {
         bb: ImRect,
         id: ImGuiID,
         data_type: ImGuiDataType,
-        p_v: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_v: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
         out_grab_bb: *mut ImRect,
     ) -> bool;
@@ -12976,8 +13082,8 @@ extern "C" {
     pub fn igTreeNodeBehavior(
         id: ImGuiID,
         flags: ImGuiTreeNodeFlags,
-        label: *const cty::c_char,
-        label_end: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        label_end: *const core::ffi::c_char,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13003,65 +13109,65 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeFormatString(
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         data_type: ImGuiDataType,
-        p_data: *const cty::c_void,
-        format: *const cty::c_char,
-    ) -> cty::c_int;
+        p_data: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeApplyOp(
         data_type: ImGuiDataType,
-        op: cty::c_int,
-        output: *mut cty::c_void,
-        arg_1: *const cty::c_void,
-        arg_2: *const cty::c_void,
+        op: core::ffi::c_int,
+        output: *mut core::ffi::c_void,
+        arg_1: *const core::ffi::c_void,
+        arg_2: *const core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeApplyFromText(
-        buf: *const cty::c_char,
+        buf: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        format: *const cty::c_char,
-        p_data_when_empty: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        format: *const core::ffi::c_char,
+        p_data_when_empty: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeCompare(
         data_type: ImGuiDataType,
-        arg_1: *const cty::c_void,
-        arg_2: *const cty::c_void,
-    ) -> cty::c_int;
+        arg_1: *const core::ffi::c_void,
+        arg_2: *const core::ffi::c_void,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeClamp(
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDataTypeIsZero(data_type: ImGuiDataType, p_data: *const cty::c_void) -> bool;
+    pub fn igDataTypeIsZero(data_type: ImGuiDataType, p_data: *const core::ffi::c_void) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextEx(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         size_arg: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13073,9 +13179,9 @@ extern "C" {
     pub fn igTempInputText(
         bb: ImRect,
         id: ImGuiID,
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
@@ -13084,12 +13190,12 @@ extern "C" {
     pub fn igTempInputScalar(
         bb: ImRect,
         id: ImGuiID,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        format: *const cty::c_char,
-        p_clamp_min: *const cty::c_void,
-        p_clamp_max: *const cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        format: *const core::ffi::c_char,
+        p_clamp_min: *const core::ffi::c_void,
+        p_clamp_max: *const core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13102,11 +13208,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetNextItemRefVal(data_type: ImGuiDataType, p_data: *mut cty::c_void);
+    pub fn igSetNextItemRefVal(data_type: ImGuiDataType, p_data: *mut core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igColorTooltip(text: *const cty::c_char, col: *const f32, flags: ImGuiColorEditFlags);
+    pub fn igColorTooltip(
+        text: *const core::ffi::c_char,
+        col: *const f32,
+        flags: ImGuiColorEditFlags,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13120,25 +13230,25 @@ extern "C" {
 extern "C" {
     pub fn igPlotEx(
         plot_type: ImGuiPlotType,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         size_arg: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igShadeVertsLinearColorGradientKeepAlpha(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         gradient_p0: ImVec2,
         gradient_p1: ImVec2,
         col0: ImU32,
@@ -13149,8 +13259,8 @@ extern "C" {
 extern "C" {
     pub fn igShadeVertsLinearUV(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         a: ImVec2,
         b: ImVec2,
         uv_a: ImVec2,
@@ -13162,8 +13272,8 @@ extern "C" {
 extern "C" {
     pub fn igShadeVertsTransformPos(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         pivot_in: ImVec2,
         cos_a: f32,
         sin_a: f32,
@@ -13184,7 +13294,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igErrorLog(msg: *const cty::c_char) -> bool;
+    pub fn igErrorLog(msg: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13218,8 +13328,8 @@ extern "C" {
 extern "C" {
     pub fn igDebugAllocHook(
         info: *mut ImGuiDebugAllocInfo,
-        frame_count: cty::c_int,
-        ptr: *mut cty::c_void,
+        frame_count: core::ffi::c_int,
+        ptr: *mut core::ffi::c_void,
         size: usize,
     );
 }
@@ -13238,8 +13348,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugTextUnformattedWithLocateItem(
-        line_begin: *const cty::c_char,
-        line_end: *const cty::c_char,
+        line_begin: *const core::ffi::c_char,
+        line_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13261,15 +13371,15 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugBreakButton(
-        label: *const cty::c_char,
-        description_of_location: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        description_of_location: *const core::ffi::c_char,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugBreakButtonTooltip(
         keyboard_only: bool,
-        description_of_location: *const cty::c_char,
+        description_of_location: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13281,8 +13391,8 @@ extern "C" {
     pub fn igDebugHookIdInfo(
         id: ImGuiID,
         data_type: ImGuiDataType,
-        data_id: *const cty::c_void,
-        data_id_end: *const cty::c_void,
+        data_id: *const core::ffi::c_void,
+        data_id_end: *const core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13291,7 +13401,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeDockNode(node: *mut ImGuiDockNode, label: *const cty::c_char);
+    pub fn igDebugNodeDockNode(node: *mut ImGuiDockNode, label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13299,7 +13409,7 @@ extern "C" {
         window: *mut ImGuiWindow,
         viewport: *mut ImGuiViewportP,
         draw_list: *const ImDrawList,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13322,11 +13432,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeStorage(storage: *mut ImGuiStorage, label: *const cty::c_char);
+    pub fn igDebugNodeStorage(storage: *mut ImGuiStorage, label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeTabBar(tab_bar: *mut ImGuiTabBar, label: *const cty::c_char);
+    pub fn igDebugNodeTabBar(tab_bar: *mut ImGuiTabBar, label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13350,7 +13460,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeWindow(window: *mut ImGuiWindow, label: *const cty::c_char);
+    pub fn igDebugNodeWindow(window: *mut ImGuiWindow, label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13358,13 +13468,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeWindowsList(windows: *mut ImVector_ImGuiWindowPtr, label: *const cty::c_char);
+    pub fn igDebugNodeWindowsList(
+        windows: *mut ImVector_ImGuiWindowPtr,
+        label: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugNodeWindowsListByBeginStackParent(
         windows: *mut *mut ImGuiWindow,
-        windows_size: cty::c_int,
+        windows_size: core::ffi::c_int,
         parent_in_begin_stack: *mut ImGuiWindow,
     );
 }
@@ -13376,8 +13489,8 @@ extern "C" {
 extern "C" {
     pub fn igDebugNodePlatformMonitor(
         monitor: *mut ImGuiPlatformMonitor,
-        label: *const cty::c_char,
-        idx: cty::c_int,
+        label: *const core::ffi::c_char,
+        idx: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13418,7 +13531,7 @@ extern "C" {
 extern "C" {
     pub fn igImFontAtlasBuildPackCustomRects(
         atlas: *mut ImFontAtlas,
-        stbrp_context_opaque: *mut cty::c_void,
+        stbrp_context_opaque: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13429,52 +13542,56 @@ extern "C" {
 extern "C" {
     pub fn igImFontAtlasBuildRender8bppRectFromString(
         atlas: *mut ImFontAtlas,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        in_str: *const cty::c_char,
-        in_marker_char: cty::c_char,
-        in_marker_pixel_value: cty::c_uchar,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        in_str: *const core::ffi::c_char,
+        in_marker_char: core::ffi::c_char,
+        in_marker_pixel_value: core::ffi::c_uchar,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFontAtlasBuildRender32bppRectFromString(
         atlas: *mut ImFontAtlas,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        in_str: *const cty::c_char,
-        in_marker_char: cty::c_char,
-        in_marker_pixel_value: cty::c_uint,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        in_str: *const core::ffi::c_char,
+        in_marker_char: core::ffi::c_char,
+        in_marker_pixel_value: core::ffi::c_uint,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFontAtlasBuildMultiplyCalcLookupTable(
-        out_table: *mut cty::c_uchar,
+        out_table: *mut core::ffi::c_uchar,
         in_multiply_factor: f32,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFontAtlasBuildMultiplyRectAlpha8(
-        table: *const cty::c_uchar,
-        pixels: *mut cty::c_uchar,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        stride: cty::c_int,
+        table: *const core::ffi::c_uchar,
+        pixels: *mut core::ffi::c_uchar,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogText(fmt: *const cty::c_char, ...);
+    pub fn igLogText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_appendf(buffer: *mut ImGuiTextBuffer, fmt: *const cty::c_char, ...);
+    pub fn ImGuiTextBuffer_appendf(
+        buffer: *mut ImGuiTextBuffer,
+        fmt: *const core::ffi::c_char,
+        ...
+    );
 }

--- a/imgui-sys/src/wasm_docking_freetype_bindings.rs
+++ b/imgui-sys/src/wasm_docking_freetype_bindings.rs
@@ -82,14 +82,14 @@ where
         }
     }
 }
-pub type __int64_t = cty::c_longlong;
+pub type __int64_t = core::ffi::c_longlong;
 pub type __darwin_off_t = __int64_t;
 pub type fpos_t = __darwin_off_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct __sbuf {
-    pub _base: *mut cty::c_uchar,
-    pub _size: cty::c_int,
+    pub _base: *mut core::ffi::c_uchar,
+    pub _size: core::ffi::c_int,
 }
 impl Default for __sbuf {
     fn default() -> Self {
@@ -108,39 +108,45 @@ pub struct __sFILEX {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct __sFILE {
-    pub _p: *mut cty::c_uchar,
-    pub _r: cty::c_int,
-    pub _w: cty::c_int,
-    pub _flags: cty::c_short,
-    pub _file: cty::c_short,
+    pub _p: *mut core::ffi::c_uchar,
+    pub _r: core::ffi::c_int,
+    pub _w: core::ffi::c_int,
+    pub _flags: core::ffi::c_short,
+    pub _file: core::ffi::c_short,
     pub _bf: __sbuf,
-    pub _lbfsize: cty::c_int,
-    pub _cookie: *mut cty::c_void,
-    pub _close: ::core::option::Option<unsafe extern "C" fn(arg1: *mut cty::c_void) -> cty::c_int>,
+    pub _lbfsize: core::ffi::c_int,
+    pub _cookie: *mut core::ffi::c_void,
+    pub _close: ::core::option::Option<
+        unsafe extern "C" fn(arg1: *mut core::ffi::c_void) -> core::ffi::c_int,
+    >,
     pub _read: ::core::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cty::c_void,
-            arg2: *mut cty::c_char,
-            arg3: cty::c_int,
-        ) -> cty::c_int,
+            arg1: *mut core::ffi::c_void,
+            arg2: *mut core::ffi::c_char,
+            arg3: core::ffi::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub _seek: ::core::option::Option<
-        unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: fpos_t, arg3: cty::c_int) -> fpos_t,
+        unsafe extern "C" fn(
+            arg1: *mut core::ffi::c_void,
+            arg2: fpos_t,
+            arg3: core::ffi::c_int,
+        ) -> fpos_t,
     >,
     pub _write: ::core::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cty::c_void,
-            arg2: *const cty::c_char,
-            arg3: cty::c_int,
-        ) -> cty::c_int,
+            arg1: *mut core::ffi::c_void,
+            arg2: *const core::ffi::c_char,
+            arg3: core::ffi::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub _ub: __sbuf,
     pub _extra: *mut __sFILEX,
-    pub _ur: cty::c_int,
-    pub _ubuf: [cty::c_uchar; 3usize],
-    pub _nbuf: [cty::c_uchar; 1usize],
+    pub _ur: core::ffi::c_int,
+    pub _ubuf: [core::ffi::c_uchar; 3usize],
+    pub _nbuf: [core::ffi::c_uchar; 1usize],
     pub _lb: __sbuf,
-    pub _blksize: cty::c_int,
+    pub _blksize: core::ffi::c_int,
     pub _offset: fpos_t,
 }
 impl Default for __sFILE {
@@ -171,9 +177,9 @@ pub struct STB_TexteditState {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_const_charPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut *const cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut *const core::ffi::c_char,
 }
 impl Default for ImVector_const_charPtr {
     fn default() -> Self {
@@ -184,67 +190,67 @@ impl Default for ImVector_const_charPtr {
         }
     }
 }
-pub type ImGuiID = cty::c_uint;
-pub type ImS8 = cty::c_schar;
-pub type ImU8 = cty::c_uchar;
-pub type ImS16 = cty::c_short;
-pub type ImU16 = cty::c_ushort;
-pub type ImS32 = cty::c_int;
-pub type ImU32 = cty::c_uint;
-pub type ImS64 = cty::c_longlong;
-pub type ImU64 = cty::c_ulonglong;
-pub type ImGuiCol = cty::c_int;
-pub type ImGuiCond = cty::c_int;
-pub type ImGuiDataType = cty::c_int;
-pub type ImGuiMouseButton = cty::c_int;
-pub type ImGuiMouseCursor = cty::c_int;
-pub type ImGuiStyleVar = cty::c_int;
-pub type ImGuiTableBgTarget = cty::c_int;
-pub type ImDrawFlags = cty::c_int;
-pub type ImDrawListFlags = cty::c_int;
-pub type ImFontAtlasFlags = cty::c_int;
-pub type ImGuiBackendFlags = cty::c_int;
-pub type ImGuiButtonFlags = cty::c_int;
-pub type ImGuiChildFlags = cty::c_int;
-pub type ImGuiColorEditFlags = cty::c_int;
-pub type ImGuiConfigFlags = cty::c_int;
-pub type ImGuiComboFlags = cty::c_int;
-pub type ImGuiDockNodeFlags = cty::c_int;
-pub type ImGuiDragDropFlags = cty::c_int;
-pub type ImGuiFocusedFlags = cty::c_int;
-pub type ImGuiHoveredFlags = cty::c_int;
-pub type ImGuiInputFlags = cty::c_int;
-pub type ImGuiInputTextFlags = cty::c_int;
-pub type ImGuiItemFlags = cty::c_int;
-pub type ImGuiKeyChord = cty::c_int;
-pub type ImGuiPopupFlags = cty::c_int;
-pub type ImGuiMultiSelectFlags = cty::c_int;
-pub type ImGuiSelectableFlags = cty::c_int;
-pub type ImGuiSliderFlags = cty::c_int;
-pub type ImGuiTabBarFlags = cty::c_int;
-pub type ImGuiTabItemFlags = cty::c_int;
-pub type ImGuiTableFlags = cty::c_int;
-pub type ImGuiTableColumnFlags = cty::c_int;
-pub type ImGuiTableRowFlags = cty::c_int;
-pub type ImGuiTreeNodeFlags = cty::c_int;
-pub type ImGuiViewportFlags = cty::c_int;
-pub type ImGuiWindowFlags = cty::c_int;
-pub type ImTextureID = *mut cty::c_void;
-pub type ImDrawIdx = cty::c_ushort;
-pub type ImWchar32 = cty::c_uint;
-pub type ImWchar16 = cty::c_ushort;
+pub type ImGuiID = core::ffi::c_uint;
+pub type ImS8 = core::ffi::c_schar;
+pub type ImU8 = core::ffi::c_uchar;
+pub type ImS16 = core::ffi::c_short;
+pub type ImU16 = core::ffi::c_ushort;
+pub type ImS32 = core::ffi::c_int;
+pub type ImU32 = core::ffi::c_uint;
+pub type ImS64 = core::ffi::c_longlong;
+pub type ImU64 = core::ffi::c_ulonglong;
+pub type ImGuiCol = core::ffi::c_int;
+pub type ImGuiCond = core::ffi::c_int;
+pub type ImGuiDataType = core::ffi::c_int;
+pub type ImGuiMouseButton = core::ffi::c_int;
+pub type ImGuiMouseCursor = core::ffi::c_int;
+pub type ImGuiStyleVar = core::ffi::c_int;
+pub type ImGuiTableBgTarget = core::ffi::c_int;
+pub type ImDrawFlags = core::ffi::c_int;
+pub type ImDrawListFlags = core::ffi::c_int;
+pub type ImFontAtlasFlags = core::ffi::c_int;
+pub type ImGuiBackendFlags = core::ffi::c_int;
+pub type ImGuiButtonFlags = core::ffi::c_int;
+pub type ImGuiChildFlags = core::ffi::c_int;
+pub type ImGuiColorEditFlags = core::ffi::c_int;
+pub type ImGuiConfigFlags = core::ffi::c_int;
+pub type ImGuiComboFlags = core::ffi::c_int;
+pub type ImGuiDockNodeFlags = core::ffi::c_int;
+pub type ImGuiDragDropFlags = core::ffi::c_int;
+pub type ImGuiFocusedFlags = core::ffi::c_int;
+pub type ImGuiHoveredFlags = core::ffi::c_int;
+pub type ImGuiInputFlags = core::ffi::c_int;
+pub type ImGuiInputTextFlags = core::ffi::c_int;
+pub type ImGuiItemFlags = core::ffi::c_int;
+pub type ImGuiKeyChord = core::ffi::c_int;
+pub type ImGuiPopupFlags = core::ffi::c_int;
+pub type ImGuiMultiSelectFlags = core::ffi::c_int;
+pub type ImGuiSelectableFlags = core::ffi::c_int;
+pub type ImGuiSliderFlags = core::ffi::c_int;
+pub type ImGuiTabBarFlags = core::ffi::c_int;
+pub type ImGuiTabItemFlags = core::ffi::c_int;
+pub type ImGuiTableFlags = core::ffi::c_int;
+pub type ImGuiTableColumnFlags = core::ffi::c_int;
+pub type ImGuiTableRowFlags = core::ffi::c_int;
+pub type ImGuiTreeNodeFlags = core::ffi::c_int;
+pub type ImGuiViewportFlags = core::ffi::c_int;
+pub type ImGuiWindowFlags = core::ffi::c_int;
+pub type ImTextureID = *mut core::ffi::c_void;
+pub type ImDrawIdx = core::ffi::c_ushort;
+pub type ImWchar32 = core::ffi::c_uint;
+pub type ImWchar16 = core::ffi::c_ushort;
 pub type ImWchar = ImWchar32;
 pub type ImGuiSelectionUserData = ImS64;
 pub type ImGuiInputTextCallback = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> cty::c_int,
+    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> core::ffi::c_int,
 >;
 pub type ImGuiSizeCallback =
     ::core::option::Option<unsafe extern "C" fn(data: *mut ImGuiSizeCallbackData)>;
 pub type ImGuiMemAllocFunc = ::core::option::Option<
-    unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+    unsafe extern "C" fn(sz: usize, user_data: *mut core::ffi::c_void) -> *mut core::ffi::c_void,
 >;
 pub type ImGuiMemFreeFunc = ::core::option::Option<
-    unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+    unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -290,7 +296,7 @@ pub const ImGuiWindowFlags_Popup: ImGuiWindowFlags_ = 67108864;
 pub const ImGuiWindowFlags_Modal: ImGuiWindowFlags_ = 134217728;
 pub const ImGuiWindowFlags_ChildMenu: ImGuiWindowFlags_ = 268435456;
 pub const ImGuiWindowFlags_DockNodeHost: ImGuiWindowFlags_ = 536870912;
-pub type ImGuiWindowFlags_ = cty::c_uint;
+pub type ImGuiWindowFlags_ = core::ffi::c_uint;
 pub const ImGuiChildFlags_None: ImGuiChildFlags_ = 0;
 pub const ImGuiChildFlags_Borders: ImGuiChildFlags_ = 1;
 pub const ImGuiChildFlags_AlwaysUseWindowPadding: ImGuiChildFlags_ = 2;
@@ -301,7 +307,7 @@ pub const ImGuiChildFlags_AutoResizeY: ImGuiChildFlags_ = 32;
 pub const ImGuiChildFlags_AlwaysAutoResize: ImGuiChildFlags_ = 64;
 pub const ImGuiChildFlags_FrameStyle: ImGuiChildFlags_ = 128;
 pub const ImGuiChildFlags_NavFlattened: ImGuiChildFlags_ = 256;
-pub type ImGuiChildFlags_ = cty::c_uint;
+pub type ImGuiChildFlags_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_None: ImGuiItemFlags_ = 0;
 pub const ImGuiItemFlags_NoTabStop: ImGuiItemFlags_ = 1;
 pub const ImGuiItemFlags_NoNav: ImGuiItemFlags_ = 2;
@@ -309,7 +315,7 @@ pub const ImGuiItemFlags_NoNavDefaultFocus: ImGuiItemFlags_ = 4;
 pub const ImGuiItemFlags_ButtonRepeat: ImGuiItemFlags_ = 8;
 pub const ImGuiItemFlags_AutoClosePopups: ImGuiItemFlags_ = 16;
 pub const ImGuiItemFlags_AllowDuplicateId: ImGuiItemFlags_ = 32;
-pub type ImGuiItemFlags_ = cty::c_uint;
+pub type ImGuiItemFlags_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_None: ImGuiInputTextFlags_ = 0;
 pub const ImGuiInputTextFlags_CharsDecimal: ImGuiInputTextFlags_ = 1;
 pub const ImGuiInputTextFlags_CharsHexadecimal: ImGuiInputTextFlags_ = 2;
@@ -334,7 +340,7 @@ pub const ImGuiInputTextFlags_CallbackAlways: ImGuiInputTextFlags_ = 524288;
 pub const ImGuiInputTextFlags_CallbackCharFilter: ImGuiInputTextFlags_ = 1048576;
 pub const ImGuiInputTextFlags_CallbackResize: ImGuiInputTextFlags_ = 2097152;
 pub const ImGuiInputTextFlags_CallbackEdit: ImGuiInputTextFlags_ = 4194304;
-pub type ImGuiInputTextFlags_ = cty::c_uint;
+pub type ImGuiInputTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_None: ImGuiTreeNodeFlags_ = 0;
 pub const ImGuiTreeNodeFlags_Selected: ImGuiTreeNodeFlags_ = 1;
 pub const ImGuiTreeNodeFlags_Framed: ImGuiTreeNodeFlags_ = 2;
@@ -353,7 +359,7 @@ pub const ImGuiTreeNodeFlags_SpanTextWidth: ImGuiTreeNodeFlags_ = 8192;
 pub const ImGuiTreeNodeFlags_SpanAllColumns: ImGuiTreeNodeFlags_ = 16384;
 pub const ImGuiTreeNodeFlags_NavLeftJumpsBackHere: ImGuiTreeNodeFlags_ = 32768;
 pub const ImGuiTreeNodeFlags_CollapsingHeader: ImGuiTreeNodeFlags_ = 26;
-pub type ImGuiTreeNodeFlags_ = cty::c_uint;
+pub type ImGuiTreeNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiPopupFlags_None: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonLeft: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonRight: ImGuiPopupFlags_ = 1;
@@ -366,7 +372,7 @@ pub const ImGuiPopupFlags_NoOpenOverItems: ImGuiPopupFlags_ = 256;
 pub const ImGuiPopupFlags_AnyPopupId: ImGuiPopupFlags_ = 1024;
 pub const ImGuiPopupFlags_AnyPopupLevel: ImGuiPopupFlags_ = 2048;
 pub const ImGuiPopupFlags_AnyPopup: ImGuiPopupFlags_ = 3072;
-pub type ImGuiPopupFlags_ = cty::c_uint;
+pub type ImGuiPopupFlags_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_None: ImGuiSelectableFlags_ = 0;
 pub const ImGuiSelectableFlags_NoAutoClosePopups: ImGuiSelectableFlags_ = 1;
 pub const ImGuiSelectableFlags_SpanAllColumns: ImGuiSelectableFlags_ = 2;
@@ -374,7 +380,7 @@ pub const ImGuiSelectableFlags_AllowDoubleClick: ImGuiSelectableFlags_ = 4;
 pub const ImGuiSelectableFlags_Disabled: ImGuiSelectableFlags_ = 8;
 pub const ImGuiSelectableFlags_AllowOverlap: ImGuiSelectableFlags_ = 16;
 pub const ImGuiSelectableFlags_Highlight: ImGuiSelectableFlags_ = 32;
-pub type ImGuiSelectableFlags_ = cty::c_uint;
+pub type ImGuiSelectableFlags_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_None: ImGuiComboFlags_ = 0;
 pub const ImGuiComboFlags_PopupAlignLeft: ImGuiComboFlags_ = 1;
 pub const ImGuiComboFlags_HeightSmall: ImGuiComboFlags_ = 2;
@@ -385,7 +391,7 @@ pub const ImGuiComboFlags_NoArrowButton: ImGuiComboFlags_ = 32;
 pub const ImGuiComboFlags_NoPreview: ImGuiComboFlags_ = 64;
 pub const ImGuiComboFlags_WidthFitPreview: ImGuiComboFlags_ = 128;
 pub const ImGuiComboFlags_HeightMask_: ImGuiComboFlags_ = 30;
-pub type ImGuiComboFlags_ = cty::c_uint;
+pub type ImGuiComboFlags_ = core::ffi::c_uint;
 pub const ImGuiTabBarFlags_None: ImGuiTabBarFlags_ = 0;
 pub const ImGuiTabBarFlags_Reorderable: ImGuiTabBarFlags_ = 1;
 pub const ImGuiTabBarFlags_AutoSelectNewTabs: ImGuiTabBarFlags_ = 2;
@@ -398,7 +404,7 @@ pub const ImGuiTabBarFlags_FittingPolicyResizeDown: ImGuiTabBarFlags_ = 128;
 pub const ImGuiTabBarFlags_FittingPolicyScroll: ImGuiTabBarFlags_ = 256;
 pub const ImGuiTabBarFlags_FittingPolicyMask_: ImGuiTabBarFlags_ = 384;
 pub const ImGuiTabBarFlags_FittingPolicyDefault_: ImGuiTabBarFlags_ = 128;
-pub type ImGuiTabBarFlags_ = cty::c_uint;
+pub type ImGuiTabBarFlags_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_None: ImGuiTabItemFlags_ = 0;
 pub const ImGuiTabItemFlags_UnsavedDocument: ImGuiTabItemFlags_ = 1;
 pub const ImGuiTabItemFlags_SetSelected: ImGuiTabItemFlags_ = 2;
@@ -409,7 +415,7 @@ pub const ImGuiTabItemFlags_NoReorder: ImGuiTabItemFlags_ = 32;
 pub const ImGuiTabItemFlags_Leading: ImGuiTabItemFlags_ = 64;
 pub const ImGuiTabItemFlags_Trailing: ImGuiTabItemFlags_ = 128;
 pub const ImGuiTabItemFlags_NoAssumedClosure: ImGuiTabItemFlags_ = 256;
-pub type ImGuiTabItemFlags_ = cty::c_uint;
+pub type ImGuiTabItemFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusedFlags_None: ImGuiFocusedFlags_ = 0;
 pub const ImGuiFocusedFlags_ChildWindows: ImGuiFocusedFlags_ = 1;
 pub const ImGuiFocusedFlags_RootWindow: ImGuiFocusedFlags_ = 2;
@@ -417,7 +423,7 @@ pub const ImGuiFocusedFlags_AnyWindow: ImGuiFocusedFlags_ = 4;
 pub const ImGuiFocusedFlags_NoPopupHierarchy: ImGuiFocusedFlags_ = 8;
 pub const ImGuiFocusedFlags_DockHierarchy: ImGuiFocusedFlags_ = 16;
 pub const ImGuiFocusedFlags_RootAndChildWindows: ImGuiFocusedFlags_ = 3;
-pub type ImGuiFocusedFlags_ = cty::c_uint;
+pub type ImGuiFocusedFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_None: ImGuiHoveredFlags_ = 0;
 pub const ImGuiHoveredFlags_ChildWindows: ImGuiHoveredFlags_ = 1;
 pub const ImGuiHoveredFlags_RootWindow: ImGuiHoveredFlags_ = 2;
@@ -439,7 +445,7 @@ pub const ImGuiHoveredFlags_DelayNone: ImGuiHoveredFlags_ = 16384;
 pub const ImGuiHoveredFlags_DelayShort: ImGuiHoveredFlags_ = 32768;
 pub const ImGuiHoveredFlags_DelayNormal: ImGuiHoveredFlags_ = 65536;
 pub const ImGuiHoveredFlags_NoSharedDelay: ImGuiHoveredFlags_ = 131072;
-pub type ImGuiHoveredFlags_ = cty::c_uint;
+pub type ImGuiHoveredFlags_ = core::ffi::c_uint;
 pub const ImGuiDockNodeFlags_None: ImGuiDockNodeFlags_ = 0;
 pub const ImGuiDockNodeFlags_KeepAliveOnly: ImGuiDockNodeFlags_ = 1;
 pub const ImGuiDockNodeFlags_NoDockingOverCentralNode: ImGuiDockNodeFlags_ = 4;
@@ -448,7 +454,7 @@ pub const ImGuiDockNodeFlags_NoDockingSplit: ImGuiDockNodeFlags_ = 16;
 pub const ImGuiDockNodeFlags_NoResize: ImGuiDockNodeFlags_ = 32;
 pub const ImGuiDockNodeFlags_AutoHideTabBar: ImGuiDockNodeFlags_ = 64;
 pub const ImGuiDockNodeFlags_NoUndocking: ImGuiDockNodeFlags_ = 128;
-pub type ImGuiDockNodeFlags_ = cty::c_uint;
+pub type ImGuiDockNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiDragDropFlags_None: ImGuiDragDropFlags_ = 0;
 pub const ImGuiDragDropFlags_SourceNoPreviewTooltip: ImGuiDragDropFlags_ = 1;
 pub const ImGuiDragDropFlags_SourceNoDisableHover: ImGuiDragDropFlags_ = 2;
@@ -462,7 +468,7 @@ pub const ImGuiDragDropFlags_AcceptBeforeDelivery: ImGuiDragDropFlags_ = 1024;
 pub const ImGuiDragDropFlags_AcceptNoDrawDefaultRect: ImGuiDragDropFlags_ = 2048;
 pub const ImGuiDragDropFlags_AcceptNoPreviewTooltip: ImGuiDragDropFlags_ = 4096;
 pub const ImGuiDragDropFlags_AcceptPeekOnly: ImGuiDragDropFlags_ = 3072;
-pub type ImGuiDragDropFlags_ = cty::c_uint;
+pub type ImGuiDragDropFlags_ = core::ffi::c_uint;
 pub const ImGuiDataType_S8: ImGuiDataType_ = 0;
 pub const ImGuiDataType_U8: ImGuiDataType_ = 1;
 pub const ImGuiDataType_S16: ImGuiDataType_ = 2;
@@ -475,18 +481,18 @@ pub const ImGuiDataType_Float: ImGuiDataType_ = 8;
 pub const ImGuiDataType_Double: ImGuiDataType_ = 9;
 pub const ImGuiDataType_Bool: ImGuiDataType_ = 10;
 pub const ImGuiDataType_COUNT: ImGuiDataType_ = 11;
-pub type ImGuiDataType_ = cty::c_uint;
+pub type ImGuiDataType_ = core::ffi::c_uint;
 pub const ImGuiDir_None: ImGuiDir = -1;
 pub const ImGuiDir_Left: ImGuiDir = 0;
 pub const ImGuiDir_Right: ImGuiDir = 1;
 pub const ImGuiDir_Up: ImGuiDir = 2;
 pub const ImGuiDir_Down: ImGuiDir = 3;
 pub const ImGuiDir_COUNT: ImGuiDir = 4;
-pub type ImGuiDir = cty::c_int;
+pub type ImGuiDir = core::ffi::c_int;
 pub const ImGuiSortDirection_None: ImGuiSortDirection = 0;
 pub const ImGuiSortDirection_Ascending: ImGuiSortDirection = 1;
 pub const ImGuiSortDirection_Descending: ImGuiSortDirection = 2;
-pub type ImGuiSortDirection = cty::c_uint;
+pub type ImGuiSortDirection = core::ffi::c_uint;
 pub const ImGuiKey_None: ImGuiKey = 0;
 pub const ImGuiKey_Tab: ImGuiKey = 512;
 pub const ImGuiKey_LeftArrow: ImGuiKey = 513;
@@ -654,7 +660,7 @@ pub const ImGuiKey_NamedKey_END: ImGuiKey = 666;
 pub const ImGuiKey_NamedKey_COUNT: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_SIZE: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_OFFSET: ImGuiKey = 512;
-pub type ImGuiKey = cty::c_uint;
+pub type ImGuiKey = core::ffi::c_uint;
 pub const ImGuiInputFlags_None: ImGuiInputFlags_ = 0;
 pub const ImGuiInputFlags_Repeat: ImGuiInputFlags_ = 1;
 pub const ImGuiInputFlags_RouteActive: ImGuiInputFlags_ = 1024;
@@ -666,7 +672,7 @@ pub const ImGuiInputFlags_RouteOverActive: ImGuiInputFlags_ = 32768;
 pub const ImGuiInputFlags_RouteUnlessBgFocused: ImGuiInputFlags_ = 65536;
 pub const ImGuiInputFlags_RouteFromRootWindow: ImGuiInputFlags_ = 131072;
 pub const ImGuiInputFlags_Tooltip: ImGuiInputFlags_ = 262144;
-pub type ImGuiInputFlags_ = cty::c_uint;
+pub type ImGuiInputFlags_ = core::ffi::c_uint;
 pub const ImGuiConfigFlags_None: ImGuiConfigFlags_ = 0;
 pub const ImGuiConfigFlags_NavEnableKeyboard: ImGuiConfigFlags_ = 1;
 pub const ImGuiConfigFlags_NavEnableGamepad: ImGuiConfigFlags_ = 2;
@@ -681,7 +687,7 @@ pub const ImGuiConfigFlags_DpiEnableScaleViewports: ImGuiConfigFlags_ = 16384;
 pub const ImGuiConfigFlags_DpiEnableScaleFonts: ImGuiConfigFlags_ = 32768;
 pub const ImGuiConfigFlags_IsSRGB: ImGuiConfigFlags_ = 1048576;
 pub const ImGuiConfigFlags_IsTouchScreen: ImGuiConfigFlags_ = 2097152;
-pub type ImGuiConfigFlags_ = cty::c_uint;
+pub type ImGuiConfigFlags_ = core::ffi::c_uint;
 pub const ImGuiBackendFlags_None: ImGuiBackendFlags_ = 0;
 pub const ImGuiBackendFlags_HasGamepad: ImGuiBackendFlags_ = 1;
 pub const ImGuiBackendFlags_HasMouseCursors: ImGuiBackendFlags_ = 2;
@@ -690,7 +696,7 @@ pub const ImGuiBackendFlags_RendererHasVtxOffset: ImGuiBackendFlags_ = 8;
 pub const ImGuiBackendFlags_PlatformHasViewports: ImGuiBackendFlags_ = 1024;
 pub const ImGuiBackendFlags_HasMouseHoveredViewport: ImGuiBackendFlags_ = 2048;
 pub const ImGuiBackendFlags_RendererHasViewports: ImGuiBackendFlags_ = 4096;
-pub type ImGuiBackendFlags_ = cty::c_uint;
+pub type ImGuiBackendFlags_ = core::ffi::c_uint;
 pub const ImGuiCol_Text: ImGuiCol_ = 0;
 pub const ImGuiCol_TextDisabled: ImGuiCol_ = 1;
 pub const ImGuiCol_WindowBg: ImGuiCol_ = 2;
@@ -750,7 +756,7 @@ pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 55;
 pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 56;
 pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 57;
 pub const ImGuiCol_COUNT: ImGuiCol_ = 58;
-pub type ImGuiCol_ = cty::c_uint;
+pub type ImGuiCol_ = core::ffi::c_uint;
 pub const ImGuiStyleVar_Alpha: ImGuiStyleVar_ = 0;
 pub const ImGuiStyleVar_DisabledAlpha: ImGuiStyleVar_ = 1;
 pub const ImGuiStyleVar_WindowPadding: ImGuiStyleVar_ = 2;
@@ -786,13 +792,13 @@ pub const ImGuiStyleVar_SeparatorTextAlign: ImGuiStyleVar_ = 31;
 pub const ImGuiStyleVar_SeparatorTextPadding: ImGuiStyleVar_ = 32;
 pub const ImGuiStyleVar_DockingSeparatorSize: ImGuiStyleVar_ = 33;
 pub const ImGuiStyleVar_COUNT: ImGuiStyleVar_ = 34;
-pub type ImGuiStyleVar_ = cty::c_uint;
+pub type ImGuiStyleVar_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_None: ImGuiButtonFlags_ = 0;
 pub const ImGuiButtonFlags_MouseButtonLeft: ImGuiButtonFlags_ = 1;
 pub const ImGuiButtonFlags_MouseButtonRight: ImGuiButtonFlags_ = 2;
 pub const ImGuiButtonFlags_MouseButtonMiddle: ImGuiButtonFlags_ = 4;
 pub const ImGuiButtonFlags_MouseButtonMask_: ImGuiButtonFlags_ = 7;
-pub type ImGuiButtonFlags_ = cty::c_uint;
+pub type ImGuiButtonFlags_ = core::ffi::c_uint;
 pub const ImGuiColorEditFlags_None: ImGuiColorEditFlags_ = 0;
 pub const ImGuiColorEditFlags_NoAlpha: ImGuiColorEditFlags_ = 2;
 pub const ImGuiColorEditFlags_NoPicker: ImGuiColorEditFlags_ = 4;
@@ -822,7 +828,7 @@ pub const ImGuiColorEditFlags_DisplayMask_: ImGuiColorEditFlags_ = 7340032;
 pub const ImGuiColorEditFlags_DataTypeMask_: ImGuiColorEditFlags_ = 25165824;
 pub const ImGuiColorEditFlags_PickerMask_: ImGuiColorEditFlags_ = 100663296;
 pub const ImGuiColorEditFlags_InputMask_: ImGuiColorEditFlags_ = 402653184;
-pub type ImGuiColorEditFlags_ = cty::c_uint;
+pub type ImGuiColorEditFlags_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_None: ImGuiSliderFlags_ = 0;
 pub const ImGuiSliderFlags_Logarithmic: ImGuiSliderFlags_ = 32;
 pub const ImGuiSliderFlags_NoRoundToFormat: ImGuiSliderFlags_ = 64;
@@ -832,12 +838,12 @@ pub const ImGuiSliderFlags_ClampOnInput: ImGuiSliderFlags_ = 512;
 pub const ImGuiSliderFlags_ClampZeroRange: ImGuiSliderFlags_ = 1024;
 pub const ImGuiSliderFlags_AlwaysClamp: ImGuiSliderFlags_ = 1536;
 pub const ImGuiSliderFlags_InvalidMask_: ImGuiSliderFlags_ = 1879048207;
-pub type ImGuiSliderFlags_ = cty::c_uint;
+pub type ImGuiSliderFlags_ = core::ffi::c_uint;
 pub const ImGuiMouseButton_Left: ImGuiMouseButton_ = 0;
 pub const ImGuiMouseButton_Right: ImGuiMouseButton_ = 1;
 pub const ImGuiMouseButton_Middle: ImGuiMouseButton_ = 2;
 pub const ImGuiMouseButton_COUNT: ImGuiMouseButton_ = 5;
-pub type ImGuiMouseButton_ = cty::c_uint;
+pub type ImGuiMouseButton_ = core::ffi::c_uint;
 pub const ImGuiMouseCursor_None: ImGuiMouseCursor_ = -1;
 pub const ImGuiMouseCursor_Arrow: ImGuiMouseCursor_ = 0;
 pub const ImGuiMouseCursor_TextInput: ImGuiMouseCursor_ = 1;
@@ -849,18 +855,18 @@ pub const ImGuiMouseCursor_ResizeNWSE: ImGuiMouseCursor_ = 6;
 pub const ImGuiMouseCursor_Hand: ImGuiMouseCursor_ = 7;
 pub const ImGuiMouseCursor_NotAllowed: ImGuiMouseCursor_ = 8;
 pub const ImGuiMouseCursor_COUNT: ImGuiMouseCursor_ = 9;
-pub type ImGuiMouseCursor_ = cty::c_int;
+pub type ImGuiMouseCursor_ = core::ffi::c_int;
 pub const ImGuiMouseSource_Mouse: ImGuiMouseSource = 0;
 pub const ImGuiMouseSource_TouchScreen: ImGuiMouseSource = 1;
 pub const ImGuiMouseSource_Pen: ImGuiMouseSource = 2;
 pub const ImGuiMouseSource_COUNT: ImGuiMouseSource = 3;
-pub type ImGuiMouseSource = cty::c_uint;
+pub type ImGuiMouseSource = core::ffi::c_uint;
 pub const ImGuiCond_None: ImGuiCond_ = 0;
 pub const ImGuiCond_Always: ImGuiCond_ = 1;
 pub const ImGuiCond_Once: ImGuiCond_ = 2;
 pub const ImGuiCond_FirstUseEver: ImGuiCond_ = 4;
 pub const ImGuiCond_Appearing: ImGuiCond_ = 8;
-pub type ImGuiCond_ = cty::c_uint;
+pub type ImGuiCond_ = core::ffi::c_uint;
 pub const ImGuiTableFlags_None: ImGuiTableFlags_ = 0;
 pub const ImGuiTableFlags_Resizable: ImGuiTableFlags_ = 1;
 pub const ImGuiTableFlags_Reorderable: ImGuiTableFlags_ = 2;
@@ -898,7 +904,7 @@ pub const ImGuiTableFlags_SortMulti: ImGuiTableFlags_ = 67108864;
 pub const ImGuiTableFlags_SortTristate: ImGuiTableFlags_ = 134217728;
 pub const ImGuiTableFlags_HighlightHoveredColumn: ImGuiTableFlags_ = 268435456;
 pub const ImGuiTableFlags_SizingMask_: ImGuiTableFlags_ = 57344;
-pub type ImGuiTableFlags_ = cty::c_uint;
+pub type ImGuiTableFlags_ = core::ffi::c_uint;
 pub const ImGuiTableColumnFlags_None: ImGuiTableColumnFlags_ = 0;
 pub const ImGuiTableColumnFlags_Disabled: ImGuiTableColumnFlags_ = 1;
 pub const ImGuiTableColumnFlags_DefaultHide: ImGuiTableColumnFlags_ = 2;
@@ -927,20 +933,20 @@ pub const ImGuiTableColumnFlags_WidthMask_: ImGuiTableColumnFlags_ = 24;
 pub const ImGuiTableColumnFlags_IndentMask_: ImGuiTableColumnFlags_ = 196608;
 pub const ImGuiTableColumnFlags_StatusMask_: ImGuiTableColumnFlags_ = 251658240;
 pub const ImGuiTableColumnFlags_NoDirectResize_: ImGuiTableColumnFlags_ = 1073741824;
-pub type ImGuiTableColumnFlags_ = cty::c_uint;
+pub type ImGuiTableColumnFlags_ = core::ffi::c_uint;
 pub const ImGuiTableRowFlags_None: ImGuiTableRowFlags_ = 0;
 pub const ImGuiTableRowFlags_Headers: ImGuiTableRowFlags_ = 1;
-pub type ImGuiTableRowFlags_ = cty::c_uint;
+pub type ImGuiTableRowFlags_ = core::ffi::c_uint;
 pub const ImGuiTableBgTarget_None: ImGuiTableBgTarget_ = 0;
 pub const ImGuiTableBgTarget_RowBg0: ImGuiTableBgTarget_ = 1;
 pub const ImGuiTableBgTarget_RowBg1: ImGuiTableBgTarget_ = 2;
 pub const ImGuiTableBgTarget_CellBg: ImGuiTableBgTarget_ = 3;
-pub type ImGuiTableBgTarget_ = cty::c_uint;
+pub type ImGuiTableBgTarget_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTableSortSpecs {
     pub Specs: *const ImGuiTableColumnSortSpecs,
-    pub SpecsCount: cty::c_int,
+    pub SpecsCount: core::ffi::c_int,
     pub SpecsDirty: bool,
 }
 impl Default for ImGuiTableSortSpecs {
@@ -1047,8 +1053,8 @@ pub struct ImGuiKeyData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImWchar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImWchar,
 }
 impl Default for ImVector_ImWchar {
@@ -1068,9 +1074,9 @@ pub struct ImGuiIO {
     pub DisplaySize: ImVec2,
     pub DeltaTime: f32,
     pub IniSavingRate: f32,
-    pub IniFilename: *const cty::c_char,
-    pub LogFilename: *const cty::c_char,
-    pub UserData: *mut cty::c_void,
+    pub IniFilename: *const core::ffi::c_char,
+    pub LogFilename: *const core::ffi::c_char,
+    pub UserData: *mut core::ffi::c_void,
     pub Fonts: *mut ImFontAtlas,
     pub FontGlobalScale: f32,
     pub FontAllowUserScaling: bool,
@@ -1110,11 +1116,11 @@ pub struct ImGuiIO {
     pub ConfigDebugBeginReturnValueLoop: bool,
     pub ConfigDebugIgnoreFocusLoss: bool,
     pub ConfigDebugIniSettings: bool,
-    pub BackendPlatformName: *const cty::c_char,
-    pub BackendRendererName: *const cty::c_char,
-    pub BackendPlatformUserData: *mut cty::c_void,
-    pub BackendRendererUserData: *mut cty::c_void,
-    pub BackendLanguageUserData: *mut cty::c_void,
+    pub BackendPlatformName: *const core::ffi::c_char,
+    pub BackendRendererName: *const core::ffi::c_char,
+    pub BackendPlatformUserData: *mut core::ffi::c_void,
+    pub BackendRendererUserData: *mut core::ffi::c_void,
+    pub BackendLanguageUserData: *mut core::ffi::c_void,
     pub WantCaptureMouse: bool,
     pub WantCaptureKeyboard: bool,
     pub WantTextInput: bool,
@@ -1123,10 +1129,10 @@ pub struct ImGuiIO {
     pub NavActive: bool,
     pub NavVisible: bool,
     pub Framerate: f32,
-    pub MetricsRenderVertices: cty::c_int,
-    pub MetricsRenderIndices: cty::c_int,
-    pub MetricsRenderWindows: cty::c_int,
-    pub MetricsActiveWindows: cty::c_int,
+    pub MetricsRenderVertices: core::ffi::c_int,
+    pub MetricsRenderIndices: core::ffi::c_int,
+    pub MetricsRenderWindows: core::ffi::c_int,
+    pub MetricsActiveWindows: core::ffi::c_int,
     pub MouseDelta: ImVec2,
     pub Ctx: *mut ImGuiContext,
     pub MousePos: ImVec2,
@@ -1181,16 +1187,16 @@ pub struct ImGuiInputTextCallbackData {
     pub Ctx: *mut ImGuiContext,
     pub EventFlag: ImGuiInputTextFlags,
     pub Flags: ImGuiInputTextFlags,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub EventChar: ImWchar,
     pub EventKey: ImGuiKey,
-    pub Buf: *mut cty::c_char,
-    pub BufTextLen: cty::c_int,
-    pub BufSize: cty::c_int,
+    pub Buf: *mut core::ffi::c_char,
+    pub BufTextLen: core::ffi::c_int,
+    pub BufSize: core::ffi::c_int,
     pub BufDirty: bool,
-    pub CursorPos: cty::c_int,
-    pub SelectionStart: cty::c_int,
-    pub SelectionEnd: cty::c_int,
+    pub CursorPos: core::ffi::c_int,
+    pub SelectionStart: core::ffi::c_int,
+    pub SelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextCallbackData {
     fn default() -> Self {
@@ -1204,7 +1210,7 @@ impl Default for ImGuiInputTextCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiSizeCallbackData {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub Pos: ImVec2,
     pub CurrentSize: ImVec2,
     pub DesiredSize: ImVec2,
@@ -1234,12 +1240,12 @@ pub struct ImGuiWindowClass {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPayload {
-    pub Data: *mut cty::c_void,
-    pub DataSize: cty::c_int,
+    pub Data: *mut core::ffi::c_void,
+    pub DataSize: core::ffi::c_int,
     pub SourceId: ImGuiID,
     pub SourceParentId: ImGuiID,
-    pub DataFrameCount: cty::c_int,
-    pub DataType: [cty::c_char; 33usize],
+    pub DataFrameCount: core::ffi::c_int,
+    pub DataType: [core::ffi::c_char; 33usize],
     pub Preview: bool,
     pub Delivery: bool,
 }
@@ -1255,13 +1261,13 @@ impl Default for ImGuiPayload {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiOnceUponAFrame {
-    pub RefFrame: cty::c_int,
+    pub RefFrame: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextRange {
-    pub b: *const cty::c_char,
-    pub e: *const cty::c_char,
+    pub b: *const core::ffi::c_char,
+    pub e: *const core::ffi::c_char,
 }
 impl Default for ImGuiTextRange {
     fn default() -> Self {
@@ -1275,8 +1281,8 @@ impl Default for ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTextRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTextRange,
 }
 impl Default for ImVector_ImGuiTextRange {
@@ -1291,9 +1297,9 @@ impl Default for ImVector_ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextFilter {
-    pub InputBuf: [cty::c_char; 256usize],
+    pub InputBuf: [core::ffi::c_char; 256usize],
     pub Filters: ImVector_ImGuiTextRange,
-    pub CountGrep: cty::c_int,
+    pub CountGrep: core::ffi::c_int,
 }
 impl Default for ImGuiTextFilter {
     fn default() -> Self {
@@ -1307,9 +1313,9 @@ impl Default for ImGuiTextFilter {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_char,
 }
 impl Default for ImVector_char {
     fn default() -> Self {
@@ -1343,9 +1349,9 @@ pub struct ImGuiStoragePair {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStoragePair__bindgen_ty_1 {
-    pub val_i: cty::c_int,
+    pub val_i: core::ffi::c_int,
     pub val_f: f32,
-    pub val_p: *mut cty::c_void,
+    pub val_p: *mut core::ffi::c_void,
 }
 impl Default for ImGuiStoragePair__bindgen_ty_1 {
     fn default() -> Self {
@@ -1382,8 +1388,8 @@ impl ::core::fmt::Debug for ImGuiStoragePair {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStoragePair {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStoragePair,
 }
 impl Default for ImVector_ImGuiStoragePair {
@@ -1413,13 +1419,13 @@ impl Default for ImGuiStorage {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiListClipper {
     pub Ctx: *mut ImGuiContext,
-    pub DisplayStart: cty::c_int,
-    pub DisplayEnd: cty::c_int,
-    pub ItemsCount: cty::c_int,
+    pub DisplayStart: core::ffi::c_int,
+    pub DisplayEnd: core::ffi::c_int,
+    pub ItemsCount: core::ffi::c_int,
     pub ItemsHeight: f32,
     pub StartPosY: f32,
     pub StartSeekOffsetY: f64,
-    pub TempData: *mut cty::c_void,
+    pub TempData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiListClipper {
     fn default() -> Self {
@@ -1452,12 +1458,12 @@ pub const ImGuiMultiSelectFlags_ScopeRect: ImGuiMultiSelectFlags_ = 4096;
 pub const ImGuiMultiSelectFlags_SelectOnClick: ImGuiMultiSelectFlags_ = 8192;
 pub const ImGuiMultiSelectFlags_SelectOnClickRelease: ImGuiMultiSelectFlags_ = 16384;
 pub const ImGuiMultiSelectFlags_NavWrapX: ImGuiMultiSelectFlags_ = 65536;
-pub type ImGuiMultiSelectFlags_ = cty::c_uint;
+pub type ImGuiMultiSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSelectionRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSelectionRequest,
 }
 impl Default for ImVector_ImGuiSelectionRequest {
@@ -1477,7 +1483,7 @@ pub struct ImGuiMultiSelectIO {
     pub NavIdItem: ImGuiSelectionUserData,
     pub NavIdSelected: bool,
     pub RangeSrcReset: bool,
-    pub ItemsCount: cty::c_int,
+    pub ItemsCount: core::ffi::c_int,
 }
 impl Default for ImGuiMultiSelectIO {
     fn default() -> Self {
@@ -1491,7 +1497,7 @@ impl Default for ImGuiMultiSelectIO {
 pub const ImGuiSelectionRequestType_None: ImGuiSelectionRequestType = 0;
 pub const ImGuiSelectionRequestType_SetAll: ImGuiSelectionRequestType = 1;
 pub const ImGuiSelectionRequestType_SetRange: ImGuiSelectionRequestType = 2;
-pub type ImGuiSelectionRequestType = cty::c_uint;
+pub type ImGuiSelectionRequestType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionRequest {
@@ -1513,13 +1519,16 @@ impl Default for ImGuiSelectionRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionBasicStorage {
-    pub Size: cty::c_int,
+    pub Size: core::ffi::c_int,
     pub PreserveOrder: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterIndexToStorageId: ::core::option::Option<
-        unsafe extern "C" fn(self_: *mut ImGuiSelectionBasicStorage, idx: cty::c_int) -> ImGuiID,
+        unsafe extern "C" fn(
+            self_: *mut ImGuiSelectionBasicStorage,
+            idx: core::ffi::c_int,
+        ) -> ImGuiID,
     >,
-    pub _SelectionOrder: cty::c_int,
+    pub _SelectionOrder: core::ffi::c_int,
     pub _Storage: ImGuiStorage,
 }
 impl Default for ImGuiSelectionBasicStorage {
@@ -1534,11 +1543,11 @@ impl Default for ImGuiSelectionBasicStorage {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionExternalStorage {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterSetItemSelected: ::core::option::Option<
         unsafe extern "C" fn(
             self_: *mut ImGuiSelectionExternalStorage,
-            idx: cty::c_int,
+            idx: core::ffi::c_int,
             selected: bool,
         ),
     >,
@@ -1560,11 +1569,11 @@ pub type ImDrawCallback = ::core::option::Option<
 pub struct ImDrawCmd {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
-    pub IdxOffset: cty::c_uint,
-    pub ElemCount: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
+    pub IdxOffset: core::ffi::c_uint,
+    pub ElemCount: core::ffi::c_uint,
     pub UserCallback: ImDrawCallback,
-    pub UserCallbackData: *mut cty::c_void,
+    pub UserCallbackData: *mut core::ffi::c_void,
 }
 impl Default for ImDrawCmd {
     fn default() -> Self {
@@ -1587,7 +1596,7 @@ pub struct ImDrawVert {
 pub struct ImDrawCmdHeader {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
 }
 impl Default for ImDrawCmdHeader {
     fn default() -> Self {
@@ -1601,8 +1610,8 @@ impl Default for ImDrawCmdHeader {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawCmd {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawCmd,
 }
 impl Default for ImVector_ImDrawCmd {
@@ -1617,8 +1626,8 @@ impl Default for ImVector_ImDrawCmd {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawIdx {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawIdx,
 }
 impl Default for ImVector_ImDrawIdx {
@@ -1648,8 +1657,8 @@ impl Default for ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawChannel {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawChannel,
 }
 impl Default for ImVector_ImDrawChannel {
@@ -1664,8 +1673,8 @@ impl Default for ImVector_ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImDrawListSplitter {
-    pub _Current: cty::c_int,
-    pub _Count: cty::c_int,
+    pub _Current: core::ffi::c_int,
+    pub _Count: core::ffi::c_int,
     pub _Channels: ImVector_ImDrawChannel,
 }
 impl Default for ImDrawListSplitter {
@@ -1691,18 +1700,18 @@ pub const ImDrawFlags_RoundCornersRight: ImDrawFlags_ = 160;
 pub const ImDrawFlags_RoundCornersAll: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersDefault_: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersMask_: ImDrawFlags_ = 496;
-pub type ImDrawFlags_ = cty::c_uint;
+pub type ImDrawFlags_ = core::ffi::c_uint;
 pub const ImDrawListFlags_None: ImDrawListFlags_ = 0;
 pub const ImDrawListFlags_AntiAliasedLines: ImDrawListFlags_ = 1;
 pub const ImDrawListFlags_AntiAliasedLinesUseTex: ImDrawListFlags_ = 2;
 pub const ImDrawListFlags_AntiAliasedFill: ImDrawListFlags_ = 4;
 pub const ImDrawListFlags_AllowVtxOffset: ImDrawListFlags_ = 8;
-pub type ImDrawListFlags_ = cty::c_uint;
+pub type ImDrawListFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawVert {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawVert,
 }
 impl Default for ImVector_ImDrawVert {
@@ -1717,8 +1726,8 @@ impl Default for ImVector_ImDrawVert {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec2 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec2,
 }
 impl Default for ImVector_ImVec2 {
@@ -1733,8 +1742,8 @@ impl Default for ImVector_ImVec2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec4 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec4,
 }
 impl Default for ImVector_ImVec4 {
@@ -1749,8 +1758,8 @@ impl Default for ImVector_ImVec4 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImTextureID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImTextureID,
 }
 impl Default for ImVector_ImTextureID {
@@ -1769,7 +1778,7 @@ pub struct ImDrawList {
     pub IdxBuffer: ImVector_ImDrawIdx,
     pub VtxBuffer: ImVector_ImDrawVert,
     pub Flags: ImDrawListFlags,
-    pub _VtxCurrentIdx: cty::c_uint,
+    pub _VtxCurrentIdx: core::ffi::c_uint,
     pub _Data: *mut ImDrawListSharedData,
     pub _VtxWritePtr: *mut ImDrawVert,
     pub _IdxWritePtr: *mut ImDrawIdx,
@@ -1779,7 +1788,7 @@ pub struct ImDrawList {
     pub _ClipRectStack: ImVector_ImVec4,
     pub _TextureIdStack: ImVector_ImTextureID,
     pub _FringeScale: f32,
-    pub _OwnerName: *const cty::c_char,
+    pub _OwnerName: *const core::ffi::c_char,
 }
 impl Default for ImDrawList {
     fn default() -> Self {
@@ -1793,8 +1802,8 @@ impl Default for ImDrawList {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawListPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImDrawList,
 }
 impl Default for ImVector_ImDrawListPtr {
@@ -1810,9 +1819,9 @@ impl Default for ImVector_ImDrawListPtr {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImDrawData {
     pub Valid: bool,
-    pub CmdListsCount: cty::c_int,
-    pub TotalIdxCount: cty::c_int,
-    pub TotalVtxCount: cty::c_int,
+    pub CmdListsCount: core::ffi::c_int,
+    pub TotalIdxCount: core::ffi::c_int,
+    pub TotalVtxCount: core::ffi::c_int,
     pub CmdLists: ImVector_ImDrawListPtr,
     pub DisplayPos: ImVec2,
     pub DisplaySize: ImVec2,
@@ -1831,13 +1840,13 @@ impl Default for ImDrawData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontConfig {
-    pub FontData: *mut cty::c_void,
-    pub FontDataSize: cty::c_int,
+    pub FontData: *mut core::ffi::c_void,
+    pub FontDataSize: core::ffi::c_int,
     pub FontDataOwnedByAtlas: bool,
-    pub FontNo: cty::c_int,
+    pub FontNo: core::ffi::c_int,
     pub SizePixels: f32,
-    pub OversampleH: cty::c_int,
-    pub OversampleV: cty::c_int,
+    pub OversampleH: core::ffi::c_int,
+    pub OversampleV: core::ffi::c_int,
     pub PixelSnapH: bool,
     pub GlyphExtraSpacing: ImVec2,
     pub GlyphOffset: ImVec2,
@@ -1845,11 +1854,11 @@ pub struct ImFontConfig {
     pub GlyphMinAdvanceX: f32,
     pub GlyphMaxAdvanceX: f32,
     pub MergeMode: bool,
-    pub FontBuilderFlags: cty::c_uint,
+    pub FontBuilderFlags: core::ffi::c_uint,
     pub RasterizerMultiply: f32,
     pub RasterizerDensity: f32,
     pub EllipsisChar: ImWchar,
-    pub Name: [cty::c_char; 40usize],
+    pub Name: [core::ffi::c_char; 40usize],
     pub DstFont: *mut ImFont,
 }
 impl Default for ImFontConfig {
@@ -1878,33 +1887,33 @@ pub struct ImFontGlyph {
 }
 impl ImFontGlyph {
     #[inline]
-    pub fn Colored(&self) -> cty::c_uint {
+    pub fn Colored(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Colored(&mut self, val: cty::c_uint) {
+    pub fn set_Colored(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Visible(&self) -> cty::c_uint {
+    pub fn Visible(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Visible(&mut self, val: cty::c_uint) {
+    pub fn set_Visible(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(1usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Codepoint(&self) -> cty::c_uint {
+    pub fn Codepoint(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
     }
     #[inline]
-    pub fn set_Codepoint(&mut self, val: cty::c_uint) {
+    pub fn set_Codepoint(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(2usize, 30u8, val as u64)
@@ -1912,9 +1921,9 @@ impl ImFontGlyph {
     }
     #[inline]
     pub fn new_bitfield_1(
-        Colored: cty::c_uint,
-        Visible: cty::c_uint,
-        Codepoint: cty::c_uint,
+        Colored: core::ffi::c_uint,
+        Visible: core::ffi::c_uint,
+        Codepoint: core::ffi::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1935,8 +1944,8 @@ impl ImFontGlyph {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImU32 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImU32,
 }
 impl Default for ImVector_ImU32 {
@@ -1965,11 +1974,11 @@ impl Default for ImFontGlyphRangesBuilder {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontAtlasCustomRect {
-    pub Width: cty::c_ushort,
-    pub Height: cty::c_ushort,
-    pub X: cty::c_ushort,
-    pub Y: cty::c_ushort,
-    pub GlyphID: cty::c_uint,
+    pub Width: core::ffi::c_ushort,
+    pub Height: core::ffi::c_ushort,
+    pub X: core::ffi::c_ushort,
+    pub Y: core::ffi::c_ushort,
+    pub GlyphID: core::ffi::c_uint,
     pub GlyphAdvanceX: f32,
     pub GlyphOffset: ImVec2,
     pub Font: *mut ImFont,
@@ -1987,12 +1996,12 @@ pub const ImFontAtlasFlags_None: ImFontAtlasFlags_ = 0;
 pub const ImFontAtlasFlags_NoPowerOfTwoHeight: ImFontAtlasFlags_ = 1;
 pub const ImFontAtlasFlags_NoMouseCursors: ImFontAtlasFlags_ = 2;
 pub const ImFontAtlasFlags_NoBakedLines: ImFontAtlasFlags_ = 4;
-pub type ImFontAtlasFlags_ = cty::c_uint;
+pub type ImFontAtlasFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImFont,
 }
 impl Default for ImVector_ImFontPtr {
@@ -2007,8 +2016,8 @@ impl Default for ImVector_ImFontPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontAtlasCustomRect {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontAtlasCustomRect,
 }
 impl Default for ImVector_ImFontAtlasCustomRect {
@@ -2023,8 +2032,8 @@ impl Default for ImVector_ImFontAtlasCustomRect {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontConfig {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontConfig,
 }
 impl Default for ImVector_ImFontConfig {
@@ -2041,16 +2050,16 @@ impl Default for ImVector_ImFontConfig {
 pub struct ImFontAtlas {
     pub Flags: ImFontAtlasFlags,
     pub TexID: ImTextureID,
-    pub TexDesiredWidth: cty::c_int,
-    pub TexGlyphPadding: cty::c_int,
+    pub TexDesiredWidth: core::ffi::c_int,
+    pub TexGlyphPadding: core::ffi::c_int,
     pub Locked: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub TexReady: bool,
     pub TexPixelsUseColors: bool,
-    pub TexPixelsAlpha8: *mut cty::c_uchar,
-    pub TexPixelsRGBA32: *mut cty::c_uint,
-    pub TexWidth: cty::c_int,
-    pub TexHeight: cty::c_int,
+    pub TexPixelsAlpha8: *mut core::ffi::c_uchar,
+    pub TexPixelsRGBA32: *mut core::ffi::c_uint,
+    pub TexWidth: core::ffi::c_int,
+    pub TexHeight: core::ffi::c_int,
     pub TexUvScale: ImVec2,
     pub TexUvWhitePixel: ImVec2,
     pub Fonts: ImVector_ImFontPtr,
@@ -2058,9 +2067,9 @@ pub struct ImFontAtlas {
     pub ConfigData: ImVector_ImFontConfig,
     pub TexUvLines: [ImVec4; 64usize],
     pub FontBuilderIO: *const ImFontBuilderIO,
-    pub FontBuilderFlags: cty::c_uint,
-    pub PackIdMouseCursors: cty::c_int,
-    pub PackIdLines: cty::c_int,
+    pub FontBuilderFlags: core::ffi::c_uint,
+    pub PackIdMouseCursors: core::ffi::c_int,
+    pub PackIdLines: core::ffi::c_int,
 }
 impl Default for ImFontAtlas {
     fn default() -> Self {
@@ -2074,8 +2083,8 @@ impl Default for ImFontAtlas {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_float {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut f32,
 }
 impl Default for ImVector_float {
@@ -2090,8 +2099,8 @@ impl Default for ImVector_float {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontGlyph {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontGlyph,
 }
 impl Default for ImVector_ImFontGlyph {
@@ -2114,17 +2123,17 @@ pub struct ImFont {
     pub FallbackGlyph: *const ImFontGlyph,
     pub ContainerAtlas: *mut ImFontAtlas,
     pub ConfigData: *const ImFontConfig,
-    pub ConfigDataCount: cty::c_short,
+    pub ConfigDataCount: core::ffi::c_short,
     pub FallbackChar: ImWchar,
     pub EllipsisChar: ImWchar,
-    pub EllipsisCharCount: cty::c_short,
+    pub EllipsisCharCount: core::ffi::c_short,
     pub EllipsisWidth: f32,
     pub EllipsisCharStep: f32,
     pub DirtyLookupTables: bool,
     pub Scale: f32,
     pub Ascent: f32,
     pub Descent: f32,
-    pub MetricsTotalSurface: cty::c_int,
+    pub MetricsTotalSurface: core::ffi::c_int,
     pub Used4kPagesMap: [ImU8; 34usize],
 }
 impl Default for ImFont {
@@ -2151,7 +2160,7 @@ pub const ImGuiViewportFlags_TopMost: ImGuiViewportFlags_ = 1024;
 pub const ImGuiViewportFlags_CanHostOtherWindows: ImGuiViewportFlags_ = 2048;
 pub const ImGuiViewportFlags_IsMinimized: ImGuiViewportFlags_ = 4096;
 pub const ImGuiViewportFlags_IsFocused: ImGuiViewportFlags_ = 8192;
-pub type ImGuiViewportFlags_ = cty::c_uint;
+pub type ImGuiViewportFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiViewport {
@@ -2164,10 +2173,10 @@ pub struct ImGuiViewport {
     pub DpiScale: f32,
     pub ParentViewportId: ImGuiID,
     pub DrawData: *mut ImDrawData,
-    pub RendererUserData: *mut cty::c_void,
-    pub PlatformUserData: *mut cty::c_void,
-    pub PlatformHandle: *mut cty::c_void,
-    pub PlatformHandleRaw: *mut cty::c_void,
+    pub RendererUserData: *mut core::ffi::c_void,
+    pub PlatformUserData: *mut core::ffi::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
+    pub PlatformHandleRaw: *mut core::ffi::c_void,
     pub PlatformWindowCreated: bool,
     pub PlatformRequestMove: bool,
     pub PlatformRequestResize: bool,
@@ -2185,8 +2194,8 @@ impl Default for ImGuiViewport {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPlatformMonitor {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPlatformMonitor,
 }
 impl Default for ImVector_ImGuiPlatformMonitor {
@@ -2201,8 +2210,8 @@ impl Default for ImVector_ImGuiPlatformMonitor {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiViewportPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiViewport,
 }
 impl Default for ImVector_ImGuiViewportPtr {
@@ -2217,16 +2226,17 @@ impl Default for ImVector_ImGuiViewportPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPlatformIO {
-    pub Platform_GetClipboardTextFn:
-        ::core::option::Option<unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const cty::c_char>,
+    pub Platform_GetClipboardTextFn: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const core::ffi::c_char,
+    >,
     pub Platform_SetClipboardTextFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const cty::c_char),
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const core::ffi::c_char),
     >,
-    pub Platform_ClipboardUserData: *mut cty::c_void,
+    pub Platform_ClipboardUserData: *mut core::ffi::c_void,
     pub Platform_OpenInShellFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const cty::c_char) -> bool,
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const core::ffi::c_char) -> bool,
     >,
-    pub Platform_OpenInShellUserData: *mut cty::c_void,
+    pub Platform_OpenInShellUserData: *mut core::ffi::c_void,
     pub Platform_SetImeDataFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
@@ -2234,7 +2244,7 @@ pub struct ImGuiPlatformIO {
             data: *mut ImGuiPlatformImeData,
         ),
     >,
-    pub Platform_ImeUserData: *mut cty::c_void,
+    pub Platform_ImeUserData: *mut core::ffi::c_void,
     pub Platform_LocaleDecimalPoint: ImWchar,
     pub Platform_CreateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Platform_DestroyWindow:
@@ -2255,16 +2265,16 @@ pub struct ImGuiPlatformIO {
     pub Platform_GetWindowMinimized:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> bool>,
     pub Platform_SetWindowTitle: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, str_: *const cty::c_char),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, str_: *const core::ffi::c_char),
     >,
     pub Platform_SetWindowAlpha:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, alpha: f32)>,
     pub Platform_UpdateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Platform_RenderWindow: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Platform_SwapBuffers: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Platform_GetWindowDpiScale:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport) -> f32>,
@@ -2276,9 +2286,9 @@ pub struct ImGuiPlatformIO {
         unsafe extern "C" fn(
             vp: *mut ImGuiViewport,
             vk_inst: ImU64,
-            vk_allocators: *const cty::c_void,
+            vk_allocators: *const core::ffi::c_void,
             out_vk_surface: *mut ImU64,
-        ) -> cty::c_int,
+        ) -> core::ffi::c_int,
     >,
     pub Renderer_CreateWindow: ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport)>,
     pub Renderer_DestroyWindow:
@@ -2286,10 +2296,10 @@ pub struct ImGuiPlatformIO {
     pub Renderer_SetWindowSize:
         ::core::option::Option<unsafe extern "C" fn(vp: *mut ImGuiViewport, size: ImVec2)>,
     pub Renderer_RenderWindow: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Renderer_SwapBuffers: ::core::option::Option<
-        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut cty::c_void),
+        unsafe extern "C" fn(vp: *mut ImGuiViewport, render_arg: *mut core::ffi::c_void),
     >,
     pub Monitors: ImVector_ImGuiPlatformMonitor,
     pub Viewports: ImVector_ImGuiViewportPtr,
@@ -2311,7 +2321,7 @@ pub struct ImGuiPlatformMonitor {
     pub WorkPos: ImVec2,
     pub WorkSize: ImVec2,
     pub DpiScale: f32,
-    pub PlatformHandle: *mut cty::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
 }
 impl Default for ImGuiPlatformMonitor {
     fn default() -> Self {
@@ -2329,23 +2339,23 @@ pub struct ImGuiPlatformImeData {
     pub InputPos: ImVec2,
     pub InputLineHeight: f32,
 }
-pub type ImGuiDataAuthority = cty::c_int;
-pub type ImGuiLayoutType = cty::c_int;
-pub type ImGuiActivateFlags = cty::c_int;
-pub type ImGuiDebugLogFlags = cty::c_int;
-pub type ImGuiFocusRequestFlags = cty::c_int;
-pub type ImGuiItemStatusFlags = cty::c_int;
-pub type ImGuiOldColumnFlags = cty::c_int;
-pub type ImGuiNavHighlightFlags = cty::c_int;
-pub type ImGuiNavMoveFlags = cty::c_int;
-pub type ImGuiNextItemDataFlags = cty::c_int;
-pub type ImGuiNextWindowDataFlags = cty::c_int;
-pub type ImGuiScrollFlags = cty::c_int;
-pub type ImGuiSeparatorFlags = cty::c_int;
-pub type ImGuiTextFlags = cty::c_int;
-pub type ImGuiTooltipFlags = cty::c_int;
-pub type ImGuiTypingSelectFlags = cty::c_int;
-pub type ImGuiWindowRefreshFlags = cty::c_int;
+pub type ImGuiDataAuthority = core::ffi::c_int;
+pub type ImGuiLayoutType = core::ffi::c_int;
+pub type ImGuiActivateFlags = core::ffi::c_int;
+pub type ImGuiDebugLogFlags = core::ffi::c_int;
+pub type ImGuiFocusRequestFlags = core::ffi::c_int;
+pub type ImGuiItemStatusFlags = core::ffi::c_int;
+pub type ImGuiOldColumnFlags = core::ffi::c_int;
+pub type ImGuiNavHighlightFlags = core::ffi::c_int;
+pub type ImGuiNavMoveFlags = core::ffi::c_int;
+pub type ImGuiNextItemDataFlags = core::ffi::c_int;
+pub type ImGuiNextWindowDataFlags = core::ffi::c_int;
+pub type ImGuiScrollFlags = core::ffi::c_int;
+pub type ImGuiSeparatorFlags = core::ffi::c_int;
+pub type ImGuiTextFlags = core::ffi::c_int;
+pub type ImGuiTooltipFlags = core::ffi::c_int;
+pub type ImGuiTypingSelectFlags = core::ffi::c_int;
+pub type ImGuiWindowRefreshFlags = core::ffi::c_int;
 pub type ImFileHandle = *mut FILE;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -2355,8 +2365,8 @@ pub struct ImVec1 {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVec2ih {
-    pub x: cty::c_short,
-    pub y: cty::c_short,
+    pub x: core::ffi::c_short,
+    pub y: core::ffi::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -2379,13 +2389,13 @@ impl Default for ImBitVector {
         }
     }
 }
-pub type ImPoolIdx = cty::c_int;
+pub type ImPoolIdx = core::ffi::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_int {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_int,
 }
 impl Default for ImVector_int {
     fn default() -> Self {
@@ -2400,7 +2410,7 @@ impl Default for ImVector_int {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextIndex {
     pub LineOffsets: ImVector_int,
-    pub EndOffset: cty::c_int,
+    pub EndOffset: core::ffi::c_int,
 }
 impl Default for ImGuiTextIndex {
     fn default() -> Self {
@@ -2468,9 +2478,9 @@ pub struct ImGuiDataTypeStorage {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDataTypeInfo {
     pub Size: usize,
-    pub Name: *const cty::c_char,
-    pub PrintFmt: *const cty::c_char,
-    pub ScanFmt: *const cty::c_char,
+    pub Name: *const core::ffi::c_char,
+    pub PrintFmt: *const core::ffi::c_char,
+    pub ScanFmt: *const core::ffi::c_char,
 }
 impl Default for ImGuiDataTypeInfo {
     fn default() -> Self {
@@ -2484,7 +2494,7 @@ impl Default for ImGuiDataTypeInfo {
 pub const ImGuiDataType_String: ImGuiDataTypePrivate_ = 12;
 pub const ImGuiDataType_Pointer: ImGuiDataTypePrivate_ = 13;
 pub const ImGuiDataType_ID: ImGuiDataTypePrivate_ = 14;
-pub type ImGuiDataTypePrivate_ = cty::c_uint;
+pub type ImGuiDataTypePrivate_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_Disabled: ImGuiItemFlagsPrivate_ = 1024;
 pub const ImGuiItemFlags_ReadOnly: ImGuiItemFlagsPrivate_ = 2048;
 pub const ImGuiItemFlags_MixedValue: ImGuiItemFlagsPrivate_ = 4096;
@@ -2494,7 +2504,7 @@ pub const ImGuiItemFlags_Inputable: ImGuiItemFlagsPrivate_ = 1048576;
 pub const ImGuiItemFlags_HasSelectionUserData: ImGuiItemFlagsPrivate_ = 2097152;
 pub const ImGuiItemFlags_IsMultiSelect: ImGuiItemFlagsPrivate_ = 4194304;
 pub const ImGuiItemFlags_Default_: ImGuiItemFlagsPrivate_ = 16;
-pub type ImGuiItemFlagsPrivate_ = cty::c_uint;
+pub type ImGuiItemFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiItemStatusFlags_None: ImGuiItemStatusFlags_ = 0;
 pub const ImGuiItemStatusFlags_HoveredRect: ImGuiItemStatusFlags_ = 1;
 pub const ImGuiItemStatusFlags_HasDisplayRect: ImGuiItemStatusFlags_ = 2;
@@ -2507,16 +2517,16 @@ pub const ImGuiItemStatusFlags_HoveredWindow: ImGuiItemStatusFlags_ = 128;
 pub const ImGuiItemStatusFlags_Visible: ImGuiItemStatusFlags_ = 256;
 pub const ImGuiItemStatusFlags_HasClipRect: ImGuiItemStatusFlags_ = 512;
 pub const ImGuiItemStatusFlags_HasShortcut: ImGuiItemStatusFlags_ = 1024;
-pub type ImGuiItemStatusFlags_ = cty::c_uint;
+pub type ImGuiItemStatusFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_DelayMask_: ImGuiHoveredFlagsPrivate_ = 245760;
 pub const ImGuiHoveredFlags_AllowedMaskForIsWindowHovered: ImGuiHoveredFlagsPrivate_ = 12479;
 pub const ImGuiHoveredFlags_AllowedMaskForIsItemHovered: ImGuiHoveredFlagsPrivate_ = 262048;
-pub type ImGuiHoveredFlagsPrivate_ = cty::c_uint;
+pub type ImGuiHoveredFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_Multiline: ImGuiInputTextFlagsPrivate_ = 67108864;
 pub const ImGuiInputTextFlags_NoMarkEdited: ImGuiInputTextFlagsPrivate_ = 134217728;
 pub const ImGuiInputTextFlags_MergedItem: ImGuiInputTextFlagsPrivate_ = 268435456;
 pub const ImGuiInputTextFlags_LocalizeDecimalPoint: ImGuiInputTextFlagsPrivate_ = 536870912;
-pub type ImGuiInputTextFlagsPrivate_ = cty::c_uint;
+pub type ImGuiInputTextFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_PressedOnClick: ImGuiButtonFlagsPrivate_ = 16;
 pub const ImGuiButtonFlags_PressedOnClickRelease: ImGuiButtonFlagsPrivate_ = 32;
 pub const ImGuiButtonFlags_PressedOnClickReleaseAnywhere: ImGuiButtonFlagsPrivate_ = 64;
@@ -2536,12 +2546,12 @@ pub const ImGuiButtonFlags_NoSetKeyOwner: ImGuiButtonFlagsPrivate_ = 1048576;
 pub const ImGuiButtonFlags_NoTestKeyOwner: ImGuiButtonFlagsPrivate_ = 2097152;
 pub const ImGuiButtonFlags_PressedOnMask_: ImGuiButtonFlagsPrivate_ = 1008;
 pub const ImGuiButtonFlags_PressedOnDefault_: ImGuiButtonFlagsPrivate_ = 32;
-pub type ImGuiButtonFlagsPrivate_ = cty::c_uint;
+pub type ImGuiButtonFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_CustomPreview: ImGuiComboFlagsPrivate_ = 1048576;
-pub type ImGuiComboFlagsPrivate_ = cty::c_uint;
+pub type ImGuiComboFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_Vertical: ImGuiSliderFlagsPrivate_ = 1048576;
 pub const ImGuiSliderFlags_ReadOnly: ImGuiSliderFlagsPrivate_ = 2097152;
-pub type ImGuiSliderFlagsPrivate_ = cty::c_uint;
+pub type ImGuiSliderFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_NoHoldingActiveID: ImGuiSelectableFlagsPrivate_ = 1048576;
 pub const ImGuiSelectableFlags_SelectOnNav: ImGuiSelectableFlagsPrivate_ = 2097152;
 pub const ImGuiSelectableFlags_SelectOnClick: ImGuiSelectableFlagsPrivate_ = 4194304;
@@ -2550,42 +2560,42 @@ pub const ImGuiSelectableFlags_SpanAvailWidth: ImGuiSelectableFlagsPrivate_ = 16
 pub const ImGuiSelectableFlags_SetNavIdOnHover: ImGuiSelectableFlagsPrivate_ = 33554432;
 pub const ImGuiSelectableFlags_NoPadWithHalfSpacing: ImGuiSelectableFlagsPrivate_ = 67108864;
 pub const ImGuiSelectableFlags_NoSetKeyOwner: ImGuiSelectableFlagsPrivate_ = 134217728;
-pub type ImGuiSelectableFlagsPrivate_ = cty::c_uint;
+pub type ImGuiSelectableFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_ClipLabelForTrailingButton: ImGuiTreeNodeFlagsPrivate_ = 268435456;
 pub const ImGuiTreeNodeFlags_UpsideDownArrow: ImGuiTreeNodeFlagsPrivate_ = 536870912;
 pub const ImGuiTreeNodeFlags_OpenOnMask_: ImGuiTreeNodeFlagsPrivate_ = 192;
-pub type ImGuiTreeNodeFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTreeNodeFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiSeparatorFlags_None: ImGuiSeparatorFlags_ = 0;
 pub const ImGuiSeparatorFlags_Horizontal: ImGuiSeparatorFlags_ = 1;
 pub const ImGuiSeparatorFlags_Vertical: ImGuiSeparatorFlags_ = 2;
 pub const ImGuiSeparatorFlags_SpanAllColumns: ImGuiSeparatorFlags_ = 4;
-pub type ImGuiSeparatorFlags_ = cty::c_uint;
+pub type ImGuiSeparatorFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusRequestFlags_None: ImGuiFocusRequestFlags_ = 0;
 pub const ImGuiFocusRequestFlags_RestoreFocusedChild: ImGuiFocusRequestFlags_ = 1;
 pub const ImGuiFocusRequestFlags_UnlessBelowModal: ImGuiFocusRequestFlags_ = 2;
-pub type ImGuiFocusRequestFlags_ = cty::c_uint;
+pub type ImGuiFocusRequestFlags_ = core::ffi::c_uint;
 pub const ImGuiTextFlags_None: ImGuiTextFlags_ = 0;
 pub const ImGuiTextFlags_NoWidthForLargeClippedText: ImGuiTextFlags_ = 1;
-pub type ImGuiTextFlags_ = cty::c_uint;
+pub type ImGuiTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTooltipFlags_None: ImGuiTooltipFlags_ = 0;
 pub const ImGuiTooltipFlags_OverridePrevious: ImGuiTooltipFlags_ = 2;
-pub type ImGuiTooltipFlags_ = cty::c_uint;
+pub type ImGuiTooltipFlags_ = core::ffi::c_uint;
 pub const ImGuiLayoutType_Horizontal: ImGuiLayoutType_ = 0;
 pub const ImGuiLayoutType_Vertical: ImGuiLayoutType_ = 1;
-pub type ImGuiLayoutType_ = cty::c_uint;
+pub type ImGuiLayoutType_ = core::ffi::c_uint;
 pub const ImGuiLogType_None: ImGuiLogType = 0;
 pub const ImGuiLogType_TTY: ImGuiLogType = 1;
 pub const ImGuiLogType_File: ImGuiLogType = 2;
 pub const ImGuiLogType_Buffer: ImGuiLogType = 3;
 pub const ImGuiLogType_Clipboard: ImGuiLogType = 4;
-pub type ImGuiLogType = cty::c_uint;
+pub type ImGuiLogType = core::ffi::c_uint;
 pub const ImGuiAxis_None: ImGuiAxis = -1;
 pub const ImGuiAxis_X: ImGuiAxis = 0;
 pub const ImGuiAxis_Y: ImGuiAxis = 1;
-pub type ImGuiAxis = cty::c_int;
+pub type ImGuiAxis = core::ffi::c_int;
 pub const ImGuiPlotType_Lines: ImGuiPlotType = 0;
 pub const ImGuiPlotType_Histogram: ImGuiPlotType = 1;
-pub type ImGuiPlotType = cty::c_uint;
+pub type ImGuiPlotType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiColorMod {
@@ -2601,7 +2611,7 @@ pub struct ImGuiStyleMod {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStyleMod__bindgen_ty_1 {
-    pub BackupInt: [cty::c_int; 2usize],
+    pub BackupInt: [core::ffi::c_int; 2usize],
     pub BackupFloat: [f32; 2usize],
 }
 impl Default for ImGuiStyleMod__bindgen_ty_1 {
@@ -2697,11 +2707,11 @@ pub struct ImGuiInputTextState {
     pub Ctx: *mut ImGuiContext,
     pub Stb: *mut ImStbTexteditState,
     pub ID: ImGuiID,
-    pub CurLenA: cty::c_int,
+    pub CurLenA: core::ffi::c_int,
     pub TextA: ImVector_char,
     pub InitialTextA: ImVector_char,
     pub CallbackTextBackup: ImVector_char,
-    pub BufCapacityA: cty::c_int,
+    pub BufCapacityA: core::ffi::c_int,
     pub Scroll: ImVec2,
     pub CursorAnim: f32,
     pub CursorFollow: bool,
@@ -2709,8 +2719,8 @@ pub struct ImGuiInputTextState {
     pub Edited: bool,
     pub Flags: ImGuiInputTextFlags,
     pub ReloadUserBuf: bool,
-    pub ReloadSelectionStart: cty::c_int,
-    pub ReloadSelectionEnd: cty::c_int,
+    pub ReloadSelectionStart: core::ffi::c_int,
+    pub ReloadSelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextState {
     fn default() -> Self {
@@ -2725,7 +2735,7 @@ pub const ImGuiWindowRefreshFlags_None: ImGuiWindowRefreshFlags_ = 0;
 pub const ImGuiWindowRefreshFlags_TryToAvoidRefresh: ImGuiWindowRefreshFlags_ = 1;
 pub const ImGuiWindowRefreshFlags_RefreshOnHover: ImGuiWindowRefreshFlags_ = 2;
 pub const ImGuiWindowRefreshFlags_RefreshOnFocus: ImGuiWindowRefreshFlags_ = 4;
-pub type ImGuiWindowRefreshFlags_ = cty::c_uint;
+pub type ImGuiWindowRefreshFlags_ = core::ffi::c_uint;
 pub const ImGuiNextWindowDataFlags_None: ImGuiNextWindowDataFlags_ = 0;
 pub const ImGuiNextWindowDataFlags_HasPos: ImGuiNextWindowDataFlags_ = 1;
 pub const ImGuiNextWindowDataFlags_HasSize: ImGuiNextWindowDataFlags_ = 2;
@@ -2740,7 +2750,7 @@ pub const ImGuiNextWindowDataFlags_HasRefreshPolicy: ImGuiNextWindowDataFlags_ =
 pub const ImGuiNextWindowDataFlags_HasViewport: ImGuiNextWindowDataFlags_ = 1024;
 pub const ImGuiNextWindowDataFlags_HasDock: ImGuiNextWindowDataFlags_ = 2048;
 pub const ImGuiNextWindowDataFlags_HasWindowClass: ImGuiNextWindowDataFlags_ = 4096;
-pub type ImGuiNextWindowDataFlags_ = cty::c_uint;
+pub type ImGuiNextWindowDataFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiNextWindowData {
@@ -2759,7 +2769,7 @@ pub struct ImGuiNextWindowData {
     pub CollapsedVal: bool,
     pub SizeConstraintRect: ImRect,
     pub SizeCallback: ImGuiSizeCallback,
-    pub SizeCallbackUserData: *mut cty::c_void,
+    pub SizeCallbackUserData: *mut core::ffi::c_void,
     pub BgAlphaVal: f32,
     pub ViewportId: ImGuiID,
     pub DockId: ImGuiID,
@@ -2782,7 +2792,7 @@ pub const ImGuiNextItemDataFlags_HasOpen: ImGuiNextItemDataFlags_ = 2;
 pub const ImGuiNextItemDataFlags_HasShortcut: ImGuiNextItemDataFlags_ = 4;
 pub const ImGuiNextItemDataFlags_HasRefVal: ImGuiNextItemDataFlags_ = 8;
 pub const ImGuiNextItemDataFlags_HasStorageID: ImGuiNextItemDataFlags_ = 16;
-pub type ImGuiNextItemDataFlags_ = cty::c_uint;
+pub type ImGuiNextItemDataFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiNextItemData {
@@ -2821,17 +2831,17 @@ pub struct ImGuiTreeNodeStackData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiErrorRecoveryState {
-    pub SizeOfWindowStack: cty::c_short,
-    pub SizeOfIDStack: cty::c_short,
-    pub SizeOfTreeStack: cty::c_short,
-    pub SizeOfColorStack: cty::c_short,
-    pub SizeOfStyleVarStack: cty::c_short,
-    pub SizeOfFontStack: cty::c_short,
-    pub SizeOfFocusScopeStack: cty::c_short,
-    pub SizeOfGroupStack: cty::c_short,
-    pub SizeOfItemFlagsStack: cty::c_short,
-    pub SizeOfBeginPopupStack: cty::c_short,
-    pub SizeOfDisabledStack: cty::c_short,
+    pub SizeOfWindowStack: core::ffi::c_short,
+    pub SizeOfIDStack: core::ffi::c_short,
+    pub SizeOfTreeStack: core::ffi::c_short,
+    pub SizeOfColorStack: core::ffi::c_short,
+    pub SizeOfStyleVarStack: core::ffi::c_short,
+    pub SizeOfFontStack: core::ffi::c_short,
+    pub SizeOfFocusScopeStack: core::ffi::c_short,
+    pub SizeOfGroupStack: core::ffi::c_short,
+    pub SizeOfItemFlagsStack: core::ffi::c_short,
+    pub SizeOfBeginPopupStack: core::ffi::c_short,
+    pub SizeOfDisabledStack: core::ffi::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -2853,15 +2863,15 @@ impl Default for ImGuiWindowStackData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiShrinkWidthItem {
-    pub Index: cty::c_int,
+    pub Index: core::ffi::c_int,
     pub Width: f32,
     pub InitialWidth: f32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPtrOrIndex {
-    pub Ptr: *mut cty::c_void,
-    pub Index: cty::c_int,
+    pub Ptr: *mut core::ffi::c_void,
+    pub Index: core::ffi::c_int,
 }
 impl Default for ImGuiPtrOrIndex {
     fn default() -> Self {
@@ -2875,15 +2885,15 @@ impl Default for ImGuiPtrOrIndex {
 pub const ImGuiPopupPositionPolicy_Default: ImGuiPopupPositionPolicy = 0;
 pub const ImGuiPopupPositionPolicy_ComboBox: ImGuiPopupPositionPolicy = 1;
 pub const ImGuiPopupPositionPolicy_Tooltip: ImGuiPopupPositionPolicy = 2;
-pub type ImGuiPopupPositionPolicy = cty::c_uint;
+pub type ImGuiPopupPositionPolicy = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiPopupData {
     pub PopupId: ImGuiID,
     pub Window: *mut ImGuiWindow,
     pub RestoreNavWindow: *mut ImGuiWindow,
-    pub ParentNavLayer: cty::c_int,
-    pub OpenFrameCount: cty::c_int,
+    pub ParentNavLayer: core::ffi::c_int,
+    pub OpenFrameCount: core::ffi::c_int,
     pub OpenParentId: ImGuiID,
     pub OpenPopupPos: ImVec2,
     pub OpenMousePos: ImVec2,
@@ -2912,13 +2922,13 @@ pub const ImGuiInputEventType_Key: ImGuiInputEventType = 5;
 pub const ImGuiInputEventType_Text: ImGuiInputEventType = 6;
 pub const ImGuiInputEventType_Focus: ImGuiInputEventType = 7;
 pub const ImGuiInputEventType_COUNT: ImGuiInputEventType = 8;
-pub type ImGuiInputEventType = cty::c_uint;
+pub type ImGuiInputEventType = core::ffi::c_uint;
 pub const ImGuiInputSource_None: ImGuiInputSource = 0;
 pub const ImGuiInputSource_Mouse: ImGuiInputSource = 1;
 pub const ImGuiInputSource_Keyboard: ImGuiInputSource = 2;
 pub const ImGuiInputSource_Gamepad: ImGuiInputSource = 3;
 pub const ImGuiInputSource_COUNT: ImGuiInputSource = 4;
-pub type ImGuiInputSource = cty::c_uint;
+pub type ImGuiInputSource = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiInputEventMousePos {
@@ -2954,7 +2964,7 @@ impl Default for ImGuiInputEventMouseWheel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiInputEventMouseButton {
-    pub Button: cty::c_int,
+    pub Button: core::ffi::c_int,
     pub Down: bool,
     pub MouseSource: ImGuiMouseSource,
 }
@@ -2991,7 +3001,7 @@ impl Default for ImGuiInputEventKey {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiInputEventText {
-    pub Char: cty::c_uint,
+    pub Char: core::ffi::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -3060,8 +3070,8 @@ pub struct ImGuiKeyRoutingData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiKeyRoutingData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiKeyRoutingData,
 }
 impl Default for ImVector_ImGuiKeyRoutingData {
@@ -3121,12 +3131,12 @@ pub const ImGuiInputFlags_SupportedByShortcut: ImGuiInputFlagsPrivate_ = 261375;
 pub const ImGuiInputFlags_SupportedBySetNextItemShortcut: ImGuiInputFlagsPrivate_ = 523519;
 pub const ImGuiInputFlags_SupportedBySetKeyOwner: ImGuiInputFlagsPrivate_ = 3145728;
 pub const ImGuiInputFlags_SupportedBySetItemKeyOwner: ImGuiInputFlagsPrivate_ = 15728640;
-pub type ImGuiInputFlagsPrivate_ = cty::c_uint;
+pub type ImGuiInputFlagsPrivate_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiListClipperRange {
-    pub Min: cty::c_int,
-    pub Max: cty::c_int,
+    pub Min: core::ffi::c_int,
+    pub Max: core::ffi::c_int,
     pub PosToIndexConvert: bool,
     pub PosToIndexOffsetMin: ImS8,
     pub PosToIndexOffsetMax: ImS8,
@@ -3134,8 +3144,8 @@ pub struct ImGuiListClipperRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiListClipperRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiListClipperRange,
 }
 impl Default for ImVector_ImGuiListClipperRange {
@@ -3152,8 +3162,8 @@ impl Default for ImVector_ImGuiListClipperRange {
 pub struct ImGuiListClipperData {
     pub ListClipper: *mut ImGuiListClipper,
     pub LossynessOffset: f32,
-    pub StepNo: cty::c_int,
-    pub ItemsFrozen: cty::c_int,
+    pub StepNo: core::ffi::c_int,
+    pub ItemsFrozen: core::ffi::c_int,
     pub Ranges: ImVector_ImGuiListClipperRange,
 }
 impl Default for ImGuiListClipperData {
@@ -3171,7 +3181,7 @@ pub const ImGuiActivateFlags_PreferTweak: ImGuiActivateFlags_ = 2;
 pub const ImGuiActivateFlags_TryToPreserveState: ImGuiActivateFlags_ = 4;
 pub const ImGuiActivateFlags_FromTabbing: ImGuiActivateFlags_ = 8;
 pub const ImGuiActivateFlags_FromShortcut: ImGuiActivateFlags_ = 16;
-pub type ImGuiActivateFlags_ = cty::c_uint;
+pub type ImGuiActivateFlags_ = core::ffi::c_uint;
 pub const ImGuiScrollFlags_None: ImGuiScrollFlags_ = 0;
 pub const ImGuiScrollFlags_KeepVisibleEdgeX: ImGuiScrollFlags_ = 1;
 pub const ImGuiScrollFlags_KeepVisibleEdgeY: ImGuiScrollFlags_ = 2;
@@ -3182,12 +3192,12 @@ pub const ImGuiScrollFlags_AlwaysCenterY: ImGuiScrollFlags_ = 32;
 pub const ImGuiScrollFlags_NoScrollParent: ImGuiScrollFlags_ = 64;
 pub const ImGuiScrollFlags_MaskX_: ImGuiScrollFlags_ = 21;
 pub const ImGuiScrollFlags_MaskY_: ImGuiScrollFlags_ = 42;
-pub type ImGuiScrollFlags_ = cty::c_uint;
+pub type ImGuiScrollFlags_ = core::ffi::c_uint;
 pub const ImGuiNavHighlightFlags_None: ImGuiNavHighlightFlags_ = 0;
 pub const ImGuiNavHighlightFlags_Compact: ImGuiNavHighlightFlags_ = 2;
 pub const ImGuiNavHighlightFlags_AlwaysDraw: ImGuiNavHighlightFlags_ = 4;
 pub const ImGuiNavHighlightFlags_NoRounding: ImGuiNavHighlightFlags_ = 8;
-pub type ImGuiNavHighlightFlags_ = cty::c_uint;
+pub type ImGuiNavHighlightFlags_ = core::ffi::c_uint;
 pub const ImGuiNavMoveFlags_None: ImGuiNavMoveFlags_ = 0;
 pub const ImGuiNavMoveFlags_LoopX: ImGuiNavMoveFlags_ = 1;
 pub const ImGuiNavMoveFlags_LoopY: ImGuiNavMoveFlags_ = 2;
@@ -3206,11 +3216,11 @@ pub const ImGuiNavMoveFlags_Activate: ImGuiNavMoveFlags_ = 4096;
 pub const ImGuiNavMoveFlags_NoSelect: ImGuiNavMoveFlags_ = 8192;
 pub const ImGuiNavMoveFlags_NoSetNavHighlight: ImGuiNavMoveFlags_ = 16384;
 pub const ImGuiNavMoveFlags_NoClearActiveId: ImGuiNavMoveFlags_ = 32768;
-pub type ImGuiNavMoveFlags_ = cty::c_uint;
+pub type ImGuiNavMoveFlags_ = core::ffi::c_uint;
 pub const ImGuiNavLayer_Main: ImGuiNavLayer = 0;
 pub const ImGuiNavLayer_Menu: ImGuiNavLayer = 1;
 pub const ImGuiNavLayer_COUNT: ImGuiNavLayer = 2;
-pub type ImGuiNavLayer = cty::c_uint;
+pub type ImGuiNavLayer = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiNavItemData {
@@ -3242,13 +3252,13 @@ pub struct ImGuiFocusScopeData {
 pub const ImGuiTypingSelectFlags_None: ImGuiTypingSelectFlags_ = 0;
 pub const ImGuiTypingSelectFlags_AllowBackspace: ImGuiTypingSelectFlags_ = 1;
 pub const ImGuiTypingSelectFlags_AllowSingleCharMode: ImGuiTypingSelectFlags_ = 2;
-pub type ImGuiTypingSelectFlags_ = cty::c_uint;
+pub type ImGuiTypingSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTypingSelectRequest {
     pub Flags: ImGuiTypingSelectFlags,
-    pub SearchBufferLen: cty::c_int,
-    pub SearchBuffer: *const cty::c_char,
+    pub SearchBufferLen: core::ffi::c_int,
+    pub SearchBuffer: *const core::ffi::c_char,
     pub SelectRequest: bool,
     pub SingleCharMode: bool,
     pub SingleCharSize: ImS8,
@@ -3266,9 +3276,9 @@ impl Default for ImGuiTypingSelectRequest {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTypingSelectState {
     pub Request: ImGuiTypingSelectRequest,
-    pub SearchBuffer: [cty::c_char; 64usize],
+    pub SearchBuffer: [core::ffi::c_char; 64usize],
     pub FocusScope: ImGuiID,
-    pub LastRequestFrame: cty::c_int,
+    pub LastRequestFrame: core::ffi::c_int,
     pub LastRequestTime: f32,
     pub SingleCharModeLock: bool,
 }
@@ -3287,7 +3297,7 @@ pub const ImGuiOldColumnFlags_NoResize: ImGuiOldColumnFlags_ = 2;
 pub const ImGuiOldColumnFlags_NoPreserveWidths: ImGuiOldColumnFlags_ = 4;
 pub const ImGuiOldColumnFlags_NoForceWithinWindow: ImGuiOldColumnFlags_ = 8;
 pub const ImGuiOldColumnFlags_GrowParentContentsSize: ImGuiOldColumnFlags_ = 16;
-pub type ImGuiOldColumnFlags_ = cty::c_uint;
+pub type ImGuiOldColumnFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct ImGuiOldColumnData {
@@ -3299,8 +3309,8 @@ pub struct ImGuiOldColumnData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiOldColumnData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiOldColumnData,
 }
 impl Default for ImVector_ImGuiOldColumnData {
@@ -3319,8 +3329,8 @@ pub struct ImGuiOldColumns {
     pub Flags: ImGuiOldColumnFlags,
     pub IsFirstFrame: bool,
     pub IsBeingResized: bool,
-    pub Current: cty::c_int,
-    pub Count: cty::c_int,
+    pub Current: core::ffi::c_int,
+    pub Count: core::ffi::c_int,
     pub OffMinX: f32,
     pub OffMaxX: f32,
     pub LineMinY: f32,
@@ -3427,8 +3437,8 @@ impl Default for ImGuiMultiSelectTempData {
 pub struct ImGuiMultiSelectState {
     pub Window: *mut ImGuiWindow,
     pub ID: ImGuiID,
-    pub LastFrameActive: cty::c_int,
-    pub LastSelectionSize: cty::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastSelectionSize: core::ffi::c_int,
     pub RangeSelected: ImS8,
     pub NavIdSelected: ImS8,
     pub RangeSrcItem: ImGuiSelectionUserData,
@@ -3461,21 +3471,21 @@ pub const ImGuiDockNodeFlags_SharedFlagsInheritMask_: ImGuiDockNodeFlagsPrivate_
 pub const ImGuiDockNodeFlags_NoResizeFlagsMask_: ImGuiDockNodeFlagsPrivate_ = 196640;
 pub const ImGuiDockNodeFlags_LocalFlagsTransferMask_: ImGuiDockNodeFlagsPrivate_ = 260208;
 pub const ImGuiDockNodeFlags_SavedFlagsMask_: ImGuiDockNodeFlagsPrivate_ = 261152;
-pub type ImGuiDockNodeFlagsPrivate_ = cty::c_int;
+pub type ImGuiDockNodeFlagsPrivate_ = core::ffi::c_int;
 pub const ImGuiDataAuthority_Auto: ImGuiDataAuthority_ = 0;
 pub const ImGuiDataAuthority_DockNode: ImGuiDataAuthority_ = 1;
 pub const ImGuiDataAuthority_Window: ImGuiDataAuthority_ = 2;
-pub type ImGuiDataAuthority_ = cty::c_uint;
+pub type ImGuiDataAuthority_ = core::ffi::c_uint;
 pub const ImGuiDockNodeState_Unknown: ImGuiDockNodeState = 0;
 pub const ImGuiDockNodeState_HostWindowHiddenBecauseSingleWindow: ImGuiDockNodeState = 1;
 pub const ImGuiDockNodeState_HostWindowHiddenBecauseWindowsAreResizing: ImGuiDockNodeState = 2;
 pub const ImGuiDockNodeState_HostWindowVisible: ImGuiDockNodeState = 3;
-pub type ImGuiDockNodeState = cty::c_uint;
+pub type ImGuiDockNodeState = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiWindowPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiWindow,
 }
 impl Default for ImVector_ImGuiWindowPtr {
@@ -3510,10 +3520,10 @@ pub struct ImGuiDockNode {
     pub VisibleWindow: *mut ImGuiWindow,
     pub CentralNode: *mut ImGuiDockNode,
     pub OnlyNodeWithWindows: *mut ImGuiDockNode,
-    pub CountNodeWithWindows: cty::c_int,
-    pub LastFrameAlive: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub LastFrameFocused: cty::c_int,
+    pub CountNodeWithWindows: core::ffi::c_int,
+    pub LastFrameAlive: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFrameFocused: core::ffi::c_int,
     pub LastFocusedNodeId: ImGuiID,
     pub SelectedTabId: ImGuiID,
     pub WantCloseTabId: ImGuiID,
@@ -3774,7 +3784,7 @@ pub const ImGuiWindowDockStyleCol_TabDimmed: ImGuiWindowDockStyleCol = 5;
 pub const ImGuiWindowDockStyleCol_TabDimmedSelected: ImGuiWindowDockStyleCol = 6;
 pub const ImGuiWindowDockStyleCol_TabDimmedSelectedOverline: ImGuiWindowDockStyleCol = 7;
 pub const ImGuiWindowDockStyleCol_COUNT: ImGuiWindowDockStyleCol = 8;
-pub type ImGuiWindowDockStyleCol = cty::c_uint;
+pub type ImGuiWindowDockStyleCol = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiWindowDockStyle {
@@ -3783,8 +3793,8 @@ pub struct ImGuiWindowDockStyle {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiDockRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiDockRequest,
 }
 impl Default for ImVector_ImGuiDockRequest {
@@ -3799,8 +3809,8 @@ impl Default for ImVector_ImGuiDockRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiDockNodeSettings {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiDockNodeSettings,
 }
 impl Default for ImVector_ImGuiDockNodeSettings {
@@ -3834,17 +3844,17 @@ impl Default for ImGuiDockContext {
 pub struct ImGuiViewportP {
     pub _ImGuiViewport: ImGuiViewport,
     pub Window: *mut ImGuiWindow,
-    pub Idx: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub LastFocusedStampCount: cty::c_int,
+    pub Idx: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFocusedStampCount: core::ffi::c_int,
     pub LastNameHash: ImGuiID,
     pub LastPos: ImVec2,
     pub LastSize: ImVec2,
     pub Alpha: f32,
     pub LastAlpha: f32,
     pub LastFocusedHadNavWindow: bool,
-    pub PlatformMonitor: cty::c_short,
-    pub BgFgDrawListsLastFrame: [cty::c_int; 2usize],
+    pub PlatformMonitor: core::ffi::c_short,
+    pub BgFgDrawListsLastFrame: [core::ffi::c_int; 2usize],
     pub BgFgDrawLists: [*mut ImDrawList; 2usize],
     pub DrawDataP: ImDrawData,
     pub DrawDataBuilder: ImDrawDataBuilder,
@@ -3875,7 +3885,7 @@ pub struct ImGuiWindowSettings {
     pub ViewportId: ImGuiID,
     pub DockId: ImGuiID,
     pub ClassId: ImGuiID,
-    pub DockOrder: cty::c_short,
+    pub DockOrder: core::ffi::c_short,
     pub Collapsed: bool,
     pub IsChild: bool,
     pub WantApply: bool,
@@ -3884,7 +3894,7 @@ pub struct ImGuiWindowSettings {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSettingsHandler {
-    pub TypeName: *const cty::c_char,
+    pub TypeName: *const core::ffi::c_char,
     pub TypeHash: ImGuiID,
     pub ClearAllFn: ::core::option::Option<
         unsafe extern "C" fn(ctx: *mut ImGuiContext, handler: *mut ImGuiSettingsHandler),
@@ -3896,15 +3906,15 @@ pub struct ImGuiSettingsHandler {
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
             handler: *mut ImGuiSettingsHandler,
-            name: *const cty::c_char,
-        ) -> *mut cty::c_void,
+            name: *const core::ffi::c_char,
+        ) -> *mut core::ffi::c_void,
     >,
     pub ReadLineFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
             handler: *mut ImGuiSettingsHandler,
-            entry: *mut cty::c_void,
-            line: *const cty::c_char,
+            entry: *mut core::ffi::c_void,
+            line: *const core::ffi::c_char,
         ),
     >,
     pub ApplyAllFn: ::core::option::Option<
@@ -3917,7 +3927,7 @@ pub struct ImGuiSettingsHandler {
             out_buf: *mut ImGuiTextBuffer,
         ),
     >,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiSettingsHandler {
     fn default() -> Self {
@@ -3942,12 +3952,12 @@ pub const ImGuiLocKey_DockingHideTabBar: ImGuiLocKey = 10;
 pub const ImGuiLocKey_DockingHoldShiftToDock: ImGuiLocKey = 11;
 pub const ImGuiLocKey_DockingDragToUndockOrMoveNode: ImGuiLocKey = 12;
 pub const ImGuiLocKey_COUNT: ImGuiLocKey = 13;
-pub type ImGuiLocKey = cty::c_uint;
+pub type ImGuiLocKey = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiLocEntry {
     pub Key: ImGuiLocKey,
-    pub Text: *const cty::c_char,
+    pub Text: *const core::ffi::c_char,
 }
 impl Default for ImGuiLocEntry {
     fn default() -> Self {
@@ -3961,8 +3971,8 @@ impl Default for ImGuiLocEntry {
 pub type ImGuiErrorCallback = ::core::option::Option<
     unsafe extern "C" fn(
         ctx: *mut ImGuiContext,
-        user_data: *mut cty::c_void,
-        msg: *const cty::c_char,
+        user_data: *mut core::ffi::c_void,
+        msg: *const core::ffi::c_char,
     ),
 >;
 pub const ImGuiDebugLogFlags_None: ImGuiDebugLogFlags_ = 0;
@@ -3980,19 +3990,19 @@ pub const ImGuiDebugLogFlags_EventViewport: ImGuiDebugLogFlags_ = 1024;
 pub const ImGuiDebugLogFlags_EventMask_: ImGuiDebugLogFlags_ = 2047;
 pub const ImGuiDebugLogFlags_OutputToTTY: ImGuiDebugLogFlags_ = 1048576;
 pub const ImGuiDebugLogFlags_OutputToTestEngine: ImGuiDebugLogFlags_ = 2097152;
-pub type ImGuiDebugLogFlags_ = cty::c_uint;
+pub type ImGuiDebugLogFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDebugAllocEntry {
-    pub FrameCount: cty::c_int,
+    pub FrameCount: core::ffi::c_int,
     pub AllocCount: ImS16,
     pub FreeCount: ImS16,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiDebugAllocInfo {
-    pub TotalAllocCount: cty::c_int,
-    pub TotalFreeCount: cty::c_int,
+    pub TotalAllocCount: core::ffi::c_int,
+    pub TotalFreeCount: core::ffi::c_int,
     pub LastEntriesIdx: ImS16,
     pub LastEntriesBuf: [ImGuiDebugAllocEntry; 6usize],
 }
@@ -4009,9 +4019,9 @@ pub struct ImGuiMetricsConfig {
     pub ShowTextEncodingViewer: bool,
     pub ShowAtlasTintedWithTextColor: bool,
     pub ShowDockingNodes: bool,
-    pub ShowWindowsRectsType: cty::c_int,
-    pub ShowTablesRectsType: cty::c_int,
-    pub HighlightMonitorIdx: cty::c_int,
+    pub ShowWindowsRectsType: core::ffi::c_int,
+    pub ShowTablesRectsType: core::ffi::c_int,
+    pub HighlightMonitorIdx: core::ffi::c_int,
     pub HighlightViewportID: ImGuiID,
 }
 #[repr(C)]
@@ -4022,7 +4032,7 @@ pub struct ImGuiStackLevelInfo {
     pub QuerySuccess: bool,
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub Desc: [cty::c_char; 57usize],
+    pub Desc: [core::ffi::c_char; 57usize],
 }
 impl Default for ImGuiStackLevelInfo {
     fn default() -> Self {
@@ -4058,8 +4068,8 @@ impl ImGuiStackLevelInfo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStackLevelInfo {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStackLevelInfo,
 }
 impl Default for ImVector_ImGuiStackLevelInfo {
@@ -4074,8 +4084,8 @@ impl Default for ImVector_ImGuiStackLevelInfo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiIDStackTool {
-    pub LastActiveFrame: cty::c_int,
-    pub StackLevel: cty::c_int,
+    pub LastActiveFrame: core::ffi::c_int,
+    pub StackLevel: core::ffi::c_int,
     pub QueryId: ImGuiID,
     pub Results: ImVector_ImGuiStackLevelInfo,
     pub CopyToClipboardOnCtrlC: bool,
@@ -4101,7 +4111,7 @@ pub const ImGuiContextHookType_RenderPre: ImGuiContextHookType = 4;
 pub const ImGuiContextHookType_RenderPost: ImGuiContextHookType = 5;
 pub const ImGuiContextHookType_Shutdown: ImGuiContextHookType = 6;
 pub const ImGuiContextHookType_PendingRemoval_: ImGuiContextHookType = 7;
-pub type ImGuiContextHookType = cty::c_uint;
+pub type ImGuiContextHookType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiContextHook {
@@ -4109,7 +4119,7 @@ pub struct ImGuiContextHook {
     pub Type: ImGuiContextHookType,
     pub Owner: ImGuiID,
     pub Callback: ImGuiContextHookCallback,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiContextHook {
     fn default() -> Self {
@@ -4123,8 +4133,8 @@ impl Default for ImGuiContextHook {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiInputEvent {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiInputEvent,
 }
 impl Default for ImVector_ImGuiInputEvent {
@@ -4139,8 +4149,8 @@ impl Default for ImVector_ImGuiInputEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiWindowStackData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiWindowStackData,
 }
 impl Default for ImVector_ImGuiWindowStackData {
@@ -4155,8 +4165,8 @@ impl Default for ImVector_ImGuiWindowStackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiColorMod {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiColorMod,
 }
 impl Default for ImVector_ImGuiColorMod {
@@ -4171,8 +4181,8 @@ impl Default for ImVector_ImGuiColorMod {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStyleMod {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStyleMod,
 }
 impl Default for ImVector_ImGuiStyleMod {
@@ -4187,8 +4197,8 @@ impl Default for ImVector_ImGuiStyleMod {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiFocusScopeData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiFocusScopeData,
 }
 impl Default for ImVector_ImGuiFocusScopeData {
@@ -4203,8 +4213,8 @@ impl Default for ImVector_ImGuiFocusScopeData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiItemFlags {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiItemFlags,
 }
 impl Default for ImVector_ImGuiItemFlags {
@@ -4219,8 +4229,8 @@ impl Default for ImVector_ImGuiItemFlags {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiGroupData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiGroupData,
 }
 impl Default for ImVector_ImGuiGroupData {
@@ -4235,8 +4245,8 @@ impl Default for ImVector_ImGuiGroupData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPopupData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPopupData,
 }
 impl Default for ImVector_ImGuiPopupData {
@@ -4251,8 +4261,8 @@ impl Default for ImVector_ImGuiPopupData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTreeNodeStackData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTreeNodeStackData,
 }
 impl Default for ImVector_ImGuiTreeNodeStackData {
@@ -4267,8 +4277,8 @@ impl Default for ImVector_ImGuiTreeNodeStackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiViewportPPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImGuiViewportP,
 }
 impl Default for ImVector_ImGuiViewportPPtr {
@@ -4283,9 +4293,9 @@ impl Default for ImVector_ImGuiViewportPPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_unsigned_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_uchar,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_uchar,
 }
 impl Default for ImVector_unsigned_char {
     fn default() -> Self {
@@ -4299,8 +4309,8 @@ impl Default for ImVector_unsigned_char {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiListClipperData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiListClipperData,
 }
 impl Default for ImVector_ImGuiListClipperData {
@@ -4315,8 +4325,8 @@ impl Default for ImVector_ImGuiListClipperData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableTempData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableTempData,
 }
 impl Default for ImVector_ImGuiTableTempData {
@@ -4331,8 +4341,8 @@ impl Default for ImVector_ImGuiTableTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTable {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTable,
 }
 impl Default for ImVector_ImGuiTable {
@@ -4364,8 +4374,8 @@ impl Default for ImPool_ImGuiTable {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTabBar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTabBar,
 }
 impl Default for ImVector_ImGuiTabBar {
@@ -4397,8 +4407,8 @@ impl Default for ImPool_ImGuiTabBar {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiPtrOrIndex {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiPtrOrIndex,
 }
 impl Default for ImVector_ImGuiPtrOrIndex {
@@ -4413,8 +4423,8 @@ impl Default for ImVector_ImGuiPtrOrIndex {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiShrinkWidthItem {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiShrinkWidthItem,
 }
 impl Default for ImVector_ImGuiShrinkWidthItem {
@@ -4429,8 +4439,8 @@ impl Default for ImVector_ImGuiShrinkWidthItem {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiMultiSelectTempData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiMultiSelectTempData,
 }
 impl Default for ImVector_ImGuiMultiSelectTempData {
@@ -4445,8 +4455,8 @@ impl Default for ImVector_ImGuiMultiSelectTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiMultiSelectState {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiMultiSelectState,
 }
 impl Default for ImVector_ImGuiMultiSelectState {
@@ -4478,8 +4488,8 @@ impl Default for ImPool_ImGuiMultiSelectState {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiID,
 }
 impl Default for ImVector_ImGuiID {
@@ -4494,8 +4504,8 @@ impl Default for ImVector_ImGuiID {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSettingsHandler {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSettingsHandler,
 }
 impl Default for ImVector_ImGuiSettingsHandler {
@@ -4538,8 +4548,8 @@ impl Default for ImChunkStream_ImGuiTableSettings {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiContextHook {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiContextHook,
 }
 impl Default for ImVector_ImGuiContextHook {
@@ -4568,17 +4578,17 @@ pub struct ImGuiContext {
     pub CurrentDpiScale: f32,
     pub DrawListSharedData: ImDrawListSharedData,
     pub Time: f64,
-    pub FrameCount: cty::c_int,
-    pub FrameCountEnded: cty::c_int,
-    pub FrameCountPlatformEnded: cty::c_int,
-    pub FrameCountRendered: cty::c_int,
+    pub FrameCount: core::ffi::c_int,
+    pub FrameCountEnded: core::ffi::c_int,
+    pub FrameCountPlatformEnded: core::ffi::c_int,
+    pub FrameCountRendered: core::ffi::c_int,
     pub WithinFrameScope: bool,
     pub WithinFrameScopeWithImplicitWindow: bool,
     pub WithinEndChild: bool,
     pub GcCompactAll: bool,
     pub TestEngineHookItems: bool,
-    pub TestEngine: *mut cty::c_void,
-    pub ContextName: [cty::c_char; 16usize],
+    pub TestEngine: *mut core::ffi::c_void,
+    pub ContextName: [core::ffi::c_char; 16usize],
     pub InputEventsQueue: ImVector_ImGuiInputEvent,
     pub InputEventsTrail: ImVector_ImGuiInputEvent,
     pub InputEventsNextMouseSource: ImGuiMouseSource,
@@ -4588,7 +4598,7 @@ pub struct ImGuiContext {
     pub WindowsTempSortBuffer: ImVector_ImGuiWindowPtr,
     pub CurrentWindowStack: ImVector_ImGuiWindowStackData,
     pub WindowsById: ImGuiStorage,
-    pub WindowsActiveCount: cty::c_int,
+    pub WindowsActiveCount: core::ffi::c_int,
     pub WindowsHoverPadding: ImVec2,
     pub DebugBreakInWindow: ImGuiID,
     pub CurrentWindow: *mut ImGuiWindow,
@@ -4598,8 +4608,8 @@ pub struct ImGuiContext {
     pub MovingWindow: *mut ImGuiWindow,
     pub WheelingWindow: *mut ImGuiWindow,
     pub WheelingWindowRefMousePos: ImVec2,
-    pub WheelingWindowStartFrame: cty::c_int,
-    pub WheelingWindowScrolledFrame: cty::c_int,
+    pub WheelingWindowStartFrame: core::ffi::c_int,
+    pub WheelingWindowScrolledFrame: core::ffi::c_int,
     pub WheelingWindowReleaseTimer: f32,
     pub WheelingWindowWheelRemainder: ImVec2,
     pub WheelingAxisAvg: ImVec2,
@@ -4607,7 +4617,7 @@ pub struct ImGuiContext {
     pub DebugHookIdInfo: ImGuiID,
     pub HoveredId: ImGuiID,
     pub HoveredIdPreviousFrame: ImGuiID,
-    pub HoveredIdPreviousFrameItemCount: cty::c_int,
+    pub HoveredIdPreviousFrameItemCount: core::ffi::c_int,
     pub HoveredIdTimer: f32,
     pub HoveredIdNotActiveTimer: f32,
     pub HoveredIdAllowOverlap: bool,
@@ -4667,9 +4677,9 @@ pub struct ImGuiContext {
     pub PlatformLastFocusedViewportId: ImGuiID,
     pub FallbackMonitor: ImGuiPlatformMonitor,
     pub PlatformMonitorsFullWorkRect: ImRect,
-    pub ViewportCreatedCount: cty::c_int,
-    pub PlatformWindowsCreatedCount: cty::c_int,
-    pub ViewportFocusedStampCount: cty::c_int,
+    pub ViewportCreatedCount: core::ffi::c_int,
+    pub PlatformWindowsCreatedCount: core::ffi::c_int,
+    pub ViewportFocusedStampCount: core::ffi::c_int,
     pub NavWindow: *mut ImGuiWindow,
     pub NavId: ImGuiID,
     pub NavFocusScopeId: ImGuiID,
@@ -4704,9 +4714,9 @@ pub struct ImGuiContext {
     pub NavMoveClipDir: ImGuiDir,
     pub NavScoringRect: ImRect,
     pub NavScoringNoClipRect: ImRect,
-    pub NavScoringDebugCount: cty::c_int,
-    pub NavTabbingDir: cty::c_int,
-    pub NavTabbingCounter: cty::c_int,
+    pub NavScoringDebugCount: core::ffi::c_int,
+    pub NavTabbingDir: core::ffi::c_int,
+    pub NavTabbingCounter: core::ffi::c_int,
     pub NavMoveResultLocal: ImGuiNavItemData,
     pub NavMoveResultLocalVisible: ImGuiNavItemData,
     pub NavMoveResultOther: ImGuiNavItemData,
@@ -4733,8 +4743,8 @@ pub struct ImGuiContext {
     pub DragDropWithinSource: bool,
     pub DragDropWithinTarget: bool,
     pub DragDropSourceFlags: ImGuiDragDropFlags,
-    pub DragDropSourceFrameCount: cty::c_int,
-    pub DragDropMouseButton: cty::c_int,
+    pub DragDropSourceFrameCount: core::ffi::c_int,
+    pub DragDropMouseButton: core::ffi::c_int,
     pub DragDropPayload: ImGuiPayload,
     pub DragDropTargetRect: ImRect,
     pub DragDropTargetClipRect: ImRect,
@@ -4743,15 +4753,15 @@ pub struct ImGuiContext {
     pub DragDropAcceptIdCurrRectSurface: f32,
     pub DragDropAcceptIdCurr: ImGuiID,
     pub DragDropAcceptIdPrev: ImGuiID,
-    pub DragDropAcceptFrameCount: cty::c_int,
+    pub DragDropAcceptFrameCount: core::ffi::c_int,
     pub DragDropHoldJustPressedId: ImGuiID,
     pub DragDropPayloadBufHeap: ImVector_unsigned_char,
-    pub DragDropPayloadBufLocal: [cty::c_uchar; 16usize],
-    pub ClipperTempDataStacked: cty::c_int,
+    pub DragDropPayloadBufLocal: [core::ffi::c_uchar; 16usize],
+    pub ClipperTempDataStacked: core::ffi::c_int,
     pub ClipperTempData: ImVector_ImGuiListClipperData,
     pub CurrentTable: *mut ImGuiTable,
     pub DebugBreakInTable: ImGuiID,
-    pub TablesTempDataStacked: cty::c_int,
+    pub TablesTempDataStacked: core::ffi::c_int,
     pub TablesTempData: ImVector_ImGuiTableTempData,
     pub Tables: ImPool_ImGuiTable,
     pub TablesLastTimeActive: ImVector_float,
@@ -4762,7 +4772,7 @@ pub struct ImGuiContext {
     pub ShrinkWidthBuffer: ImVector_ImGuiShrinkWidthItem,
     pub BoxSelectState: ImGuiBoxSelectState,
     pub CurrentMultiSelect: *mut ImGuiMultiSelectTempData,
-    pub MultiSelectTempDataStacked: cty::c_int,
+    pub MultiSelectTempDataStacked: core::ffi::c_int,
     pub MultiSelectTempData: ImVector_ImGuiMultiSelectTempData,
     pub MultiSelectStorage: ImPool_ImGuiMultiSelectState,
     pub HoverItemDelayId: ImGuiID,
@@ -4779,8 +4789,8 @@ pub struct ImGuiContext {
     pub InputTextPasswordFont: ImFont,
     pub TempInputId: ImGuiID,
     pub DataTypeZeroValue: ImGuiDataTypeStorage,
-    pub BeginMenuDepth: cty::c_int,
-    pub BeginComboDepth: cty::c_int,
+    pub BeginMenuDepth: core::ffi::c_int,
+    pub BeginComboDepth: core::ffi::c_int,
     pub ColorEditOptions: ImGuiColorEditFlags,
     pub ColorEditCurrentID: ImGuiID,
     pub ColorEditSavedID: ImGuiID,
@@ -4791,7 +4801,7 @@ pub struct ImGuiContext {
     pub ComboPreviewData: ImGuiComboPreviewData,
     pub WindowResizeBorderExpectedRect: ImRect,
     pub WindowResizeRelativeMode: bool,
-    pub ScrollbarSeekMode: cty::c_short,
+    pub ScrollbarSeekMode: core::ffi::c_short,
     pub ScrollbarClickDeltaToGrabCenter: f32,
     pub SliderGrabClickOffset: f32,
     pub SliderCurrentAccum: f32,
@@ -4800,9 +4810,9 @@ pub struct ImGuiContext {
     pub DragCurrentAccum: f32,
     pub DragSpeedDefaultRatio: f32,
     pub DisabledAlphaBackup: f32,
-    pub DisabledStackSize: cty::c_short,
-    pub LockMarkEdited: cty::c_short,
-    pub TooltipOverrideCount: cty::c_short,
+    pub DisabledStackSize: core::ffi::c_short,
+    pub LockMarkEdited: core::ffi::c_short,
+    pub TooltipOverrideCount: core::ffi::c_short,
     pub TooltipPreviousWindow: *mut ImGuiWindow,
     pub ClipboardHandlerData: ImVector_char,
     pub MenusIdSubmittedThisFrame: ImVector_ImGuiID,
@@ -4826,30 +4836,30 @@ pub struct ImGuiContext {
     pub SettingsTables: ImChunkStream_ImGuiTableSettings,
     pub Hooks: ImVector_ImGuiContextHook,
     pub HookIdNext: ImGuiID,
-    pub LocalizationTable: [*const cty::c_char; 13usize],
+    pub LocalizationTable: [*const core::ffi::c_char; 13usize],
     pub LogEnabled: bool,
     pub LogType: ImGuiLogType,
     pub LogFile: ImFileHandle,
     pub LogBuffer: ImGuiTextBuffer,
-    pub LogNextPrefix: *const cty::c_char,
-    pub LogNextSuffix: *const cty::c_char,
+    pub LogNextPrefix: *const core::ffi::c_char,
+    pub LogNextSuffix: *const core::ffi::c_char,
     pub LogLinePosY: f32,
     pub LogLineFirstItem: bool,
-    pub LogDepthRef: cty::c_int,
-    pub LogDepthToExpand: cty::c_int,
-    pub LogDepthToExpandDefault: cty::c_int,
+    pub LogDepthRef: core::ffi::c_int,
+    pub LogDepthToExpand: core::ffi::c_int,
+    pub LogDepthToExpandDefault: core::ffi::c_int,
     pub ErrorCallback: ImGuiErrorCallback,
-    pub ErrorCallbackUserData: *mut cty::c_void,
+    pub ErrorCallbackUserData: *mut core::ffi::c_void,
     pub ErrorTooltipLockedPos: ImVec2,
     pub ErrorFirst: bool,
-    pub ErrorCountCurrentFrame: cty::c_int,
+    pub ErrorCountCurrentFrame: core::ffi::c_int,
     pub StackSizesInNewFrame: ImGuiErrorRecoveryState,
     pub StackSizesInBeginForCurrentWindow: *mut ImGuiErrorRecoveryState,
-    pub DebugDrawIdConflictsCount: cty::c_int,
+    pub DebugDrawIdConflictsCount: core::ffi::c_int,
     pub DebugLogFlags: ImGuiDebugLogFlags,
     pub DebugLogBuf: ImGuiTextBuffer,
     pub DebugLogIndex: ImGuiTextIndex,
-    pub DebugLogSkippedErrors: cty::c_int,
+    pub DebugLogSkippedErrors: core::ffi::c_int,
     pub DebugLogAutoDisableFlags: ImGuiDebugLogFlags,
     pub DebugLogAutoDisableFrames: ImU8,
     pub DebugLocateFrames: ImU8,
@@ -4866,14 +4876,14 @@ pub struct ImGuiContext {
     pub DebugAllocInfo: ImGuiDebugAllocInfo,
     pub DebugHoveredDockNode: *mut ImGuiDockNode,
     pub FramerateSecPerFrame: [f32; 60usize],
-    pub FramerateSecPerFrameIdx: cty::c_int,
-    pub FramerateSecPerFrameCount: cty::c_int,
+    pub FramerateSecPerFrameIdx: core::ffi::c_int,
+    pub FramerateSecPerFrameCount: core::ffi::c_int,
     pub FramerateSecPerFrameAccum: f32,
-    pub WantCaptureMouseNextFrame: cty::c_int,
-    pub WantCaptureKeyboardNextFrame: cty::c_int,
-    pub WantTextInputNextFrame: cty::c_int,
+    pub WantCaptureMouseNextFrame: core::ffi::c_int,
+    pub WantCaptureKeyboardNextFrame: core::ffi::c_int,
+    pub WantTextInputNextFrame: core::ffi::c_int,
     pub TempBuffer: ImVector_char,
-    pub TempKeychordName: [cty::c_char; 64usize],
+    pub TempKeychordName: [core::ffi::c_char; 64usize],
 }
 impl Default for ImGuiContext {
     fn default() -> Self {
@@ -4886,18 +4896,20 @@ impl Default for ImGuiContext {
 }
 impl ImGuiContext {
     #[inline]
-    pub fn ActiveIdMouseButton(&self) -> cty::c_int {
+    pub fn ActiveIdMouseButton(&self) -> core::ffi::c_int {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
     }
     #[inline]
-    pub fn set_ActiveIdMouseButton(&mut self, val: cty::c_int) {
+    pub fn set_ActiveIdMouseButton(&mut self, val: core::ffi::c_int) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 8u8, val as u64)
         }
     }
     #[inline]
-    pub fn new_bitfield_1(ActiveIdMouseButton: cty::c_int) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+    pub fn new_bitfield_1(
+        ActiveIdMouseButton: core::ffi::c_int,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 8u8, {
             let ActiveIdMouseButton: u32 = unsafe { ::core::mem::transmute(ActiveIdMouseButton) };
@@ -4925,20 +4937,20 @@ pub struct ImGuiWindowTempData {
     pub GroupOffset: ImVec1,
     pub CursorStartPosLossyness: ImVec2,
     pub NavLayerCurrent: ImGuiNavLayer,
-    pub NavLayersActiveMask: cty::c_short,
-    pub NavLayersActiveMaskNext: cty::c_short,
+    pub NavLayersActiveMask: core::ffi::c_short,
+    pub NavLayersActiveMaskNext: core::ffi::c_short,
     pub NavIsScrollPushableX: bool,
     pub NavHideHighlightOneFrame: bool,
     pub NavWindowHasScrollY: bool,
     pub MenuBarAppending: bool,
     pub MenuBarOffset: ImVec2,
     pub MenuColumns: ImGuiMenuColumns,
-    pub TreeDepth: cty::c_int,
+    pub TreeDepth: core::ffi::c_int,
     pub TreeHasStackDataDepthMask: ImU32,
     pub ChildWindows: ImVector_ImGuiWindowPtr,
     pub StateStorage: *mut ImGuiStorage,
     pub CurrentColumns: *mut ImGuiOldColumns,
-    pub CurrentTableIdx: cty::c_int,
+    pub CurrentTableIdx: core::ffi::c_int,
     pub LayoutType: ImGuiLayoutType,
     pub ParentLayoutType: ImGuiLayoutType,
     pub ModalDimBgColor: ImU32,
@@ -4959,8 +4971,8 @@ impl Default for ImGuiWindowTempData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiOldColumns {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiOldColumns,
 }
 impl Default for ImVector_ImGuiOldColumns {
@@ -4976,7 +4988,7 @@ impl Default for ImVector_ImGuiOldColumns {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiWindow {
     pub Ctx: *mut ImGuiContext,
-    pub Name: *mut cty::c_char,
+    pub Name: *mut core::ffi::c_char,
     pub ID: ImGuiID,
     pub Flags: ImGuiWindowFlags,
     pub FlagsPreviousFrame: ImGuiWindowFlags,
@@ -4985,7 +4997,7 @@ pub struct ImGuiWindow {
     pub Viewport: *mut ImGuiViewportP,
     pub ViewportId: ImGuiID,
     pub ViewportPos: ImVec2,
-    pub ViewportAllowPlatformMonitorExtend: cty::c_int,
+    pub ViewportAllowPlatformMonitorExtend: core::ffi::c_int,
     pub Pos: ImVec2,
     pub Size: ImVec2,
     pub SizeFull: ImVec2,
@@ -5003,7 +5015,7 @@ pub struct ImGuiWindow {
     pub DecoOuterSizeY2: f32,
     pub DecoInnerSizeX1: f32,
     pub DecoInnerSizeY1: f32,
-    pub NameBufLen: cty::c_int,
+    pub NameBufLen: core::ffi::c_int,
     pub MoveId: ImGuiID,
     pub TabId: ImGuiID,
     pub ChildId: ImGuiID,
@@ -5029,13 +5041,13 @@ pub struct ImGuiWindow {
     pub IsFallbackWindow: bool,
     pub IsExplicitChild: bool,
     pub HasCloseButton: bool,
-    pub ResizeBorderHovered: cty::c_schar,
-    pub ResizeBorderHeld: cty::c_schar,
-    pub BeginCount: cty::c_short,
-    pub BeginCountPreviousFrame: cty::c_short,
-    pub BeginOrderWithinParent: cty::c_short,
-    pub BeginOrderWithinContext: cty::c_short,
-    pub FocusOrder: cty::c_short,
+    pub ResizeBorderHovered: core::ffi::c_schar,
+    pub ResizeBorderHeld: core::ffi::c_schar,
+    pub BeginCount: core::ffi::c_short,
+    pub BeginCountPreviousFrame: core::ffi::c_short,
+    pub BeginOrderWithinParent: core::ffi::c_short,
+    pub BeginOrderWithinContext: core::ffi::c_short,
+    pub FocusOrder: core::ffi::c_short,
     pub AutoFitFramesX: ImS8,
     pub AutoFitFramesY: ImS8,
     pub AutoFitOnlyGrows: bool,
@@ -5059,15 +5071,15 @@ pub struct ImGuiWindow {
     pub ContentRegionRect: ImRect,
     pub HitTestHoleSize: ImVec2ih,
     pub HitTestHoleOffset: ImVec2ih,
-    pub LastFrameActive: cty::c_int,
-    pub LastFrameJustFocused: cty::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub LastFrameJustFocused: core::ffi::c_int,
     pub LastTimeActive: f32,
     pub ItemWidthDefault: f32,
     pub StateStorage: ImGuiStorage,
     pub ColumnsStorage: ImVector_ImGuiOldColumns,
     pub FontWindowScale: f32,
     pub FontDpiScale: f32,
-    pub SettingsOffset: cty::c_int,
+    pub SettingsOffset: core::ffi::c_int,
     pub DrawList: *mut ImDrawList,
     pub DrawListInst: ImDrawList,
     pub ParentWindow: *mut ImGuiWindow,
@@ -5083,12 +5095,12 @@ pub struct ImGuiWindow {
     pub NavRectRel: [ImRect; 2usize],
     pub NavPreferredScoringPosRel: [ImVec2; 2usize],
     pub NavRootFocusScopeId: ImGuiID,
-    pub MemoryDrawListIdxCapacity: cty::c_int,
-    pub MemoryDrawListVtxCapacity: cty::c_int,
+    pub MemoryDrawListIdxCapacity: core::ffi::c_int,
+    pub MemoryDrawListVtxCapacity: core::ffi::c_int,
     pub MemoryCompacted: bool,
     pub _bitfield_align_2: [u8; 0],
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub DockOrder: cty::c_short,
+    pub DockOrder: core::ffi::c_short,
     pub DockStyle: ImGuiWindowDockStyle,
     pub DockNode: *mut ImGuiDockNode,
     pub DockNodeAsHost: *mut ImGuiDockNode,
@@ -5254,20 +5266,20 @@ impl ImGuiWindow {
 pub const ImGuiTabBarFlags_DockNode: ImGuiTabBarFlagsPrivate_ = 1048576;
 pub const ImGuiTabBarFlags_IsFocused: ImGuiTabBarFlagsPrivate_ = 2097152;
 pub const ImGuiTabBarFlags_SaveSettings: ImGuiTabBarFlagsPrivate_ = 4194304;
-pub type ImGuiTabBarFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTabBarFlagsPrivate_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_SectionMask_: ImGuiTabItemFlagsPrivate_ = 192;
 pub const ImGuiTabItemFlags_NoCloseButton: ImGuiTabItemFlagsPrivate_ = 1048576;
 pub const ImGuiTabItemFlags_Button: ImGuiTabItemFlagsPrivate_ = 2097152;
 pub const ImGuiTabItemFlags_Unsorted: ImGuiTabItemFlagsPrivate_ = 4194304;
-pub type ImGuiTabItemFlagsPrivate_ = cty::c_uint;
+pub type ImGuiTabItemFlagsPrivate_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTabItem {
     pub ID: ImGuiID,
     pub Flags: ImGuiTabItemFlags,
     pub Window: *mut ImGuiWindow,
-    pub LastFrameVisible: cty::c_int,
-    pub LastFrameSelected: cty::c_int,
+    pub LastFrameVisible: core::ffi::c_int,
+    pub LastFrameSelected: core::ffi::c_int,
     pub Offset: f32,
     pub Width: f32,
     pub ContentWidth: f32,
@@ -5289,8 +5301,8 @@ impl Default for ImGuiTabItem {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTabItem {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTabItem,
 }
 impl Default for ImVector_ImGuiTabItem {
@@ -5312,8 +5324,8 @@ pub struct ImGuiTabBar {
     pub SelectedTabId: ImGuiID,
     pub NextSelectedTabId: ImGuiID,
     pub VisibleTabId: ImGuiID,
-    pub CurrFrameVisible: cty::c_int,
-    pub PrevFrameVisible: cty::c_int,
+    pub CurrFrameVisible: core::ffi::c_int,
+    pub PrevFrameVisible: core::ffi::c_int,
     pub BarRect: ImRect,
     pub CurrTabsContentsHeight: f32,
     pub PrevTabsContentsHeight: f32,
@@ -5475,8 +5487,8 @@ pub struct ImGuiTableInstanceData {
     pub LastOuterHeight: f32,
     pub LastTopHeadersRowHeight: f32,
     pub LastFrozenHeight: f32,
-    pub HoveredRowLast: cty::c_int,
-    pub HoveredRowNext: cty::c_int,
+    pub HoveredRowLast: core::ffi::c_int,
+    pub HoveredRowNext: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -5526,8 +5538,8 @@ impl Default for ImSpan_ImGuiTableCellData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableInstanceData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableInstanceData,
 }
 impl Default for ImVector_ImGuiTableInstanceData {
@@ -5542,8 +5554,8 @@ impl Default for ImVector_ImGuiTableInstanceData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableColumnSortSpecs {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableColumnSortSpecs,
 }
 impl Default for ImVector_ImGuiTableColumnSortSpecs {
@@ -5560,7 +5572,7 @@ impl Default for ImVector_ImGuiTableColumnSortSpecs {
 pub struct ImGuiTable {
     pub ID: ImGuiID,
     pub Flags: ImGuiTableFlags,
-    pub RawData: *mut cty::c_void,
+    pub RawData: *mut core::ffi::c_void,
     pub TempData: *mut ImGuiTableTempData,
     pub Columns: ImSpan_ImGuiTableColumn,
     pub DisplayOrderToIndex: ImSpan_ImGuiTableColumnIdx,
@@ -5569,11 +5581,11 @@ pub struct ImGuiTable {
     pub EnabledMaskByIndex: ImBitArrayPtr,
     pub VisibleMaskByIndex: ImBitArrayPtr,
     pub SettingsLoadedFlags: ImGuiTableFlags,
-    pub SettingsOffset: cty::c_int,
-    pub LastFrameActive: cty::c_int,
-    pub ColumnsCount: cty::c_int,
-    pub CurrentRow: cty::c_int,
-    pub CurrentColumn: cty::c_int,
+    pub SettingsOffset: core::ffi::c_int,
+    pub LastFrameActive: core::ffi::c_int,
+    pub ColumnsCount: core::ffi::c_int,
+    pub CurrentRow: core::ffi::c_int,
+    pub CurrentColumn: core::ffi::c_int,
     pub InstanceCurrent: ImS16,
     pub InstanceInteracted: ImS16,
     pub RowPosY1: f32,
@@ -5584,7 +5596,7 @@ pub struct ImGuiTable {
     pub RowIndentOffsetX: f32,
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub RowBgColorCounter: cty::c_int,
+    pub RowBgColorCounter: core::ffi::c_int,
     pub RowBgColor: [ImU32; 2usize],
     pub BorderColorStrong: ImU32,
     pub BorderColorLight: ImU32,
@@ -5723,8 +5735,8 @@ impl ImGuiTable {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTableHeaderData {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTableHeaderData,
 }
 impl Default for ImVector_ImGuiTableHeaderData {
@@ -5739,7 +5751,7 @@ impl Default for ImVector_ImGuiTableHeaderData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiTableTempData {
-    pub TableIndex: cty::c_int,
+    pub TableIndex: core::ffi::c_int,
     pub LastTimeActive: f32,
     pub AngledHeadersExtraWidth: f32,
     pub AngledHeadersRequests: ImVector_ImGuiTableHeaderData,
@@ -5752,7 +5764,7 @@ pub struct ImGuiTableTempData {
     pub HostBackupCursorMaxPos: ImVec2,
     pub HostBackupColumnsOffset: ImVec1,
     pub HostBackupItemWidth: f32,
-    pub HostBackupItemWidthStackSize: cty::c_int,
+    pub HostBackupItemWidthStackSize: core::ffi::c_int,
 }
 impl Default for ImGuiTableTempData {
     fn default() -> Self {
@@ -5857,7 +5869,7 @@ pub const ImGuiFreeTypeBuilderFlags_Oblique: ImGuiFreeTypeBuilderFlags = 64;
 pub const ImGuiFreeTypeBuilderFlags_Monochrome: ImGuiFreeTypeBuilderFlags = 128;
 pub const ImGuiFreeTypeBuilderFlags_LoadColor: ImGuiFreeTypeBuilderFlags = 256;
 pub const ImGuiFreeTypeBuilderFlags_Bitmap: ImGuiFreeTypeBuilderFlags = 512;
-pub type ImGuiFreeTypeBuilderFlags = cty::c_uint;
+pub type ImGuiFreeTypeBuilderFlags = core::ffi::c_uint;
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImVec2_ImVec2_Nil() -> *mut ImVec2;
@@ -5952,11 +5964,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShowStyleSelector(label: *const cty::c_char) -> bool;
+    pub fn igShowStyleSelector(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShowFontSelector(label: *const cty::c_char);
+    pub fn igShowFontSelector(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5964,7 +5976,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetVersion() -> *const cty::c_char;
+    pub fn igGetVersion() -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5980,7 +5992,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBegin(name: *const cty::c_char, p_open: *mut bool, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBegin(
+        name: *const core::ffi::c_char,
+        p_open: *mut bool,
+        flags: ImGuiWindowFlags,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5989,7 +6005,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginChild_Str(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         child_flags: ImGuiChildFlags,
         window_flags: ImGuiWindowFlags,
@@ -6066,7 +6082,7 @@ extern "C" {
         size_min: ImVec2,
         size_max: ImVec2,
         custom_callback: ImGuiSizeCallback,
-        custom_callback_data: *mut cty::c_void,
+        custom_callback_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -6115,19 +6131,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowPos_Str(name: *const cty::c_char, pos: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowPos_Str(name: *const core::ffi::c_char, pos: ImVec2, cond: ImGuiCond);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowSize_Str(name: *const cty::c_char, size: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowSize_Str(name: *const core::ffi::c_char, size: ImVec2, cond: ImGuiCond);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowCollapsed_Str(name: *const cty::c_char, collapsed: bool, cond: ImGuiCond);
+    pub fn igSetWindowCollapsed_Str(
+        name: *const core::ffi::c_char,
+        collapsed: bool,
+        cond: ImGuiCond,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowFocus_Str(name: *const cty::c_char);
+    pub fn igSetWindowFocus_Str(name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6187,7 +6207,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPopStyleColor(count: cty::c_int);
+    pub fn igPopStyleColor(count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6207,7 +6227,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPopStyleVar(count: cty::c_int);
+    pub fn igPopStyleVar(count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6367,19 +6387,22 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Str(str_id: *const cty::c_char);
+    pub fn igPushID_Str(str_id: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_StrStr(str_id_begin: *const cty::c_char, str_id_end: *const cty::c_char);
+    pub fn igPushID_StrStr(
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Ptr(ptr_id: *const cty::c_void);
+    pub fn igPushID_Ptr(ptr_id: *const core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Int(int_id: cty::c_int);
+    pub fn igPushID_Int(int_id: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6387,110 +6410,110 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Str(str_id: *const cty::c_char) -> ImGuiID;
+    pub fn igGetID_Str(str_id: *const core::ffi::c_char) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igGetID_StrStr(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Ptr(ptr_id: *const cty::c_void) -> ImGuiID;
+    pub fn igGetID_Ptr(ptr_id: *const core::ffi::c_void) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Int(int_id: cty::c_int) -> ImGuiID;
+    pub fn igGetID_Int(int_id: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextUnformatted(text: *const cty::c_char, text_end: *const cty::c_char);
+    pub fn igTextUnformatted(text: *const core::ffi::c_char, text_end: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igText(fmt: *const cty::c_char, ...);
+    pub fn igText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextColored(col: ImVec4, fmt: *const cty::c_char, ...);
+    pub fn igTextColored(col: ImVec4, fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextDisabled(fmt: *const cty::c_char, ...);
+    pub fn igTextDisabled(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextWrapped(fmt: *const cty::c_char, ...);
+    pub fn igTextWrapped(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLabelText(label: *const cty::c_char, fmt: *const cty::c_char, ...);
+    pub fn igLabelText(label: *const core::ffi::c_char, fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBulletText(fmt: *const cty::c_char, ...);
+    pub fn igBulletText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSeparatorText(label: *const cty::c_char);
+    pub fn igSeparatorText(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igButton(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igButton(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSmallButton(label: *const cty::c_char) -> bool;
+    pub fn igSmallButton(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInvisibleButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         flags: ImGuiButtonFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igArrowButton(str_id: *const cty::c_char, dir: ImGuiDir) -> bool;
+    pub fn igArrowButton(str_id: *const core::ffi::c_char, dir: ImGuiDir) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igCheckbox(label: *const cty::c_char, v: *mut bool) -> bool;
+    pub fn igCheckbox(label: *const core::ffi::c_char, v: *mut bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_IntPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_int,
-        flags_value: cty::c_int,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_int,
+        flags_value: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_UintPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_uint,
-        flags_value: cty::c_uint,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_uint,
+        flags_value: core::ffi::c_uint,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igRadioButton_Bool(label: *const cty::c_char, active: bool) -> bool;
+    pub fn igRadioButton_Bool(label: *const core::ffi::c_char, active: bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igRadioButton_IntPtr(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_button: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_button: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const cty::c_char);
+    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6498,11 +6521,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextLink(label: *const cty::c_char) -> bool;
+    pub fn igTextLink(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextLinkOpenURL(label: *const cty::c_char, url: *const cty::c_char);
+    pub fn igTextLinkOpenURL(label: *const core::ffi::c_char, url: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -6518,7 +6541,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImageButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         user_texture_id: ImTextureID,
         image_size: ImVec2,
         uv0: ImVec2,
@@ -6530,8 +6553,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginCombo(
-        label: *const cty::c_char,
-        preview_value: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        preview_value: *const core::ffi::c_char,
         flags: ImGuiComboFlags,
     ) -> bool;
 }
@@ -6542,497 +6565,497 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_Str(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items_separated_by_zeros: *const cty::c_char,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items_separated_by_zeros: *const core::ffi::c_char,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloatRange2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_current_min: *mut f32,
         v_current_max: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragIntRange2(
-        label: *const cty::c_char,
-        v_current_min: *mut cty::c_int,
-        v_current_max: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v_current_min: *mut core::ffi::c_int,
+        v_current_max: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderAngle(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_rad: *mut f32,
         v_degrees_min: f32,
         v_degrees_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderInt(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputText(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextMultiline(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         size: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextWithHint(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         step: f32,
         step_fast: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        step: cty::c_int,
-        step_fast: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        step: core::ffi::c_int,
+        step_fast: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputDouble(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f64,
         step: f64,
         step_fast: f64,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorEdit3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -7040,7 +7063,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorEdit4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -7048,7 +7071,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorPicker3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -7056,7 +7079,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorPicker4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
         ref_col: *const f32,
@@ -7065,7 +7088,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorButton(
-        desc_id: *const cty::c_char,
+        desc_id: *const core::ffi::c_char,
         col: ImVec4,
         flags: ImGuiColorEditFlags,
         size: ImVec2,
@@ -7077,45 +7100,53 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_Str(label: *const cty::c_char) -> bool;
+    pub fn igTreeNode_Str(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_StrStr(str_id: *const cty::c_char, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_StrStr(
+        str_id: *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_Ptr(ptr_id: *const cty::c_void, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_Ptr(
+        ptr_id: *const core::ffi::c_void,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNodeEx_Str(label: *const cty::c_char, flags: ImGuiTreeNodeFlags) -> bool;
+    pub fn igTreeNodeEx_Str(label: *const core::ffi::c_char, flags: ImGuiTreeNodeFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTreeNodeEx_StrStr(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTreeNodeEx_Ptr(
-        ptr_id: *const cty::c_void,
+        ptr_id: *const core::ffi::c_void,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreePush_Str(str_id: *const cty::c_char);
+    pub fn igTreePush_Str(str_id: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreePush_Ptr(ptr_id: *const cty::c_void);
+    pub fn igTreePush_Ptr(ptr_id: *const core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7128,14 +7159,14 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCollapsingHeader_TreeNodeFlags(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCollapsingHeader_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_visible: *mut bool,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
@@ -7151,7 +7182,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSelectable_Bool(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         selected: bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -7160,7 +7191,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSelectable_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_selected: *mut bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -7170,8 +7201,8 @@ extern "C" {
 extern "C" {
     pub fn igBeginMultiSelect(
         flags: ImGuiMultiSelectFlags,
-        selection_size: cty::c_int,
-        items_count: cty::c_int,
+        selection_size: core::ffi::c_int,
+        items_count: core::ffi::c_int,
     ) -> *mut ImGuiMultiSelectIO;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -7188,7 +7219,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginListBox(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igBeginListBox(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7197,54 +7228,54 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igListBox_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igListBox_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotLines_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotLines_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -7253,28 +7284,28 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotHistogram_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotHistogram_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -7282,19 +7313,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Bool(prefix: *const cty::c_char, b: bool);
+    pub fn igValue_Bool(prefix: *const core::ffi::c_char, b: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Int(prefix: *const cty::c_char, v: cty::c_int);
+    pub fn igValue_Int(prefix: *const core::ffi::c_char, v: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Uint(prefix: *const cty::c_char, v: cty::c_uint);
+    pub fn igValue_Uint(prefix: *const core::ffi::c_char, v: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Float(prefix: *const cty::c_char, v: f32, float_format: *const cty::c_char);
+    pub fn igValue_Float(
+        prefix: *const core::ffi::c_char,
+        v: f32,
+        float_format: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7314,7 +7349,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginMenu(label: *const cty::c_char, enabled: bool) -> bool;
+    pub fn igBeginMenu(label: *const core::ffi::c_char, enabled: bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7323,8 +7358,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItem_Bool(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
@@ -7332,8 +7367,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItem_BoolPtr(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         p_selected: *mut bool,
         enabled: bool,
     ) -> bool;
@@ -7348,7 +7383,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetTooltip(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7356,16 +7391,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetItemTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetItemTooltip(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginPopup(str_id: *const cty::c_char, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBeginPopup(str_id: *const core::ffi::c_char, flags: ImGuiWindowFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupModal(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiWindowFlags,
     ) -> bool;
@@ -7376,7 +7411,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igOpenPopup_Str(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopup_Str(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7384,7 +7419,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igOpenPopupOnItemClick(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopupOnItemClick(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7393,33 +7428,33 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextItem(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextWindow(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextVoid(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igIsPopupOpen_Str(str_id: *const cty::c_char, flags: ImGuiPopupFlags) -> bool;
+    pub fn igIsPopupOpen_Str(str_id: *const core::ffi::c_char, flags: ImGuiPopupFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTable(
-        str_id: *const cty::c_char,
-        columns: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        columns: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -7439,12 +7474,12 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnIndex(column_n: cty::c_int) -> bool;
+    pub fn igTableSetColumnIndex(column_n: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableSetupColumn(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTableColumnFlags,
         init_width_or_weight: f32,
         user_id: ImGuiID,
@@ -7452,11 +7487,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetupScrollFreeze(cols: cty::c_int, rows: cty::c_int);
+    pub fn igTableSetupScrollFreeze(cols: core::ffi::c_int, rows: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableHeader(label: *const cty::c_char);
+    pub fn igTableHeader(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7472,39 +7507,39 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnCount() -> cty::c_int;
+    pub fn igTableGetColumnCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnIndex() -> cty::c_int;
+    pub fn igTableGetColumnIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetRowIndex() -> cty::c_int;
+    pub fn igTableGetRowIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnName_Int(column_n: cty::c_int) -> *const cty::c_char;
+    pub fn igTableGetColumnName_Int(column_n: core::ffi::c_int) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnFlags(column_n: cty::c_int) -> ImGuiTableColumnFlags;
+    pub fn igTableGetColumnFlags(column_n: core::ffi::c_int) -> ImGuiTableColumnFlags;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnEnabled(column_n: cty::c_int, v: bool);
+    pub fn igTableSetColumnEnabled(column_n: core::ffi::c_int, v: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetHoveredColumn() -> cty::c_int;
+    pub fn igTableGetHoveredColumn() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: cty::c_int);
+    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igColumns(count: cty::c_int, id: *const cty::c_char, borders: bool);
+    pub fn igColumns(count: core::ffi::c_int, id: *const core::ffi::c_char, borders: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7512,31 +7547,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnIndex() -> cty::c_int;
+    pub fn igGetColumnIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnWidth(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnWidth(column_index: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetColumnWidth(column_index: cty::c_int, width: f32);
+    pub fn igSetColumnWidth(column_index: core::ffi::c_int, width: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnOffset(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnOffset(column_index: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetColumnOffset(column_index: cty::c_int, offset_x: f32);
+    pub fn igSetColumnOffset(column_index: core::ffi::c_int, offset_x: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnsCount() -> cty::c_int;
+    pub fn igGetColumnsCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginTabBar(str_id: *const cty::c_char, flags: ImGuiTabBarFlags) -> bool;
+    pub fn igBeginTabBar(str_id: *const core::ffi::c_char, flags: ImGuiTabBarFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7545,7 +7580,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTabItem(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
     ) -> bool;
@@ -7556,11 +7591,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTabItemButton(label: *const cty::c_char, flags: ImGuiTabItemFlags) -> bool;
+    pub fn igTabItemButton(label: *const core::ffi::c_char, flags: ImGuiTabItemFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const cty::c_char);
+    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7598,15 +7633,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToTTY(auto_open_depth: cty::c_int);
+    pub fn igLogToTTY(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToFile(auto_open_depth: cty::c_int, filename: *const cty::c_char);
+    pub fn igLogToFile(auto_open_depth: core::ffi::c_int, filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToClipboard(auto_open_depth: cty::c_int);
+    pub fn igLogToClipboard(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7623,8 +7658,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSetDragDropPayload(
-        type_: *const cty::c_char,
-        data: *const cty::c_void,
+        type_: *const core::ffi::c_char,
+        data: *const core::ffi::c_void,
         sz: usize,
         cond: ImGuiCond,
     ) -> bool;
@@ -7640,7 +7675,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igAcceptDragDropPayload(
-        type_: *const cty::c_char,
+        type_: *const core::ffi::c_char,
         flags: ImGuiDragDropFlags,
     ) -> *const ImGuiPayload;
 }
@@ -7678,7 +7713,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetKeyboardFocusHere(offset: cty::c_int);
+    pub fn igSetKeyboardFocusHere(offset: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7778,7 +7813,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetFrameCount() -> cty::c_int;
+    pub fn igGetFrameCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7786,7 +7821,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const cty::c_char;
+    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7800,8 +7835,8 @@ extern "C" {
 extern "C" {
     pub fn igCalcTextSize(
         pOut: *mut ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_double_hash: bool,
         wrap_width: f32,
     );
@@ -7854,11 +7889,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> cty::c_int;
+    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyName(key: ImGuiKey) -> *const cty::c_char;
+    pub fn igGetKeyName(key: ImGuiKey) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7894,7 +7929,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> cty::c_int;
+    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7942,31 +7977,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetClipboardText() -> *const cty::c_char;
+    pub fn igGetClipboardText() -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetClipboardText(text: *const cty::c_char);
+    pub fn igSetClipboardText(text: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLoadIniSettingsFromDisk(ini_filename: *const cty::c_char);
+    pub fn igLoadIniSettingsFromDisk(ini_filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLoadIniSettingsFromMemory(ini_data: *const cty::c_char, ini_size: usize);
+    pub fn igLoadIniSettingsFromMemory(ini_data: *const core::ffi::c_char, ini_size: usize);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSaveIniSettingsToDisk(ini_filename: *const cty::c_char);
+    pub fn igSaveIniSettingsToDisk(ini_filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const cty::c_char;
+    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugTextEncoding(text: *const cty::c_char);
+    pub fn igDebugTextEncoding(text: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -7979,7 +8014,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugCheckVersionAndDataLayout(
-        version_str: *const cty::c_char,
+        version_str: *const core::ffi::c_char,
         sz_io: usize,
         sz_style: usize,
         sz_vec2: usize,
@@ -7990,14 +8025,14 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugLog(fmt: *const cty::c_char, ...);
+    pub fn igDebugLog(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSetAllocatorFunctions(
         alloc_func: ImGuiMemAllocFunc,
         free_func: ImGuiMemFreeFunc,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8005,16 +8040,16 @@ extern "C" {
     pub fn igGetAllocatorFunctions(
         p_alloc_func: *mut ImGuiMemAllocFunc,
         p_free_func: *mut ImGuiMemFreeFunc,
-        p_user_data: *mut *mut cty::c_void,
+        p_user_data: *mut *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igMemAlloc(size: usize) -> *mut cty::c_void;
+    pub fn igMemAlloc(size: usize) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igMemFree(ptr: *mut cty::c_void);
+    pub fn igMemFree(ptr: *mut core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8023,8 +8058,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igRenderPlatformWindowsDefault(
-        platform_render_arg: *mut cty::c_void,
-        renderer_render_arg: *mut cty::c_void,
+        platform_render_arg: *mut core::ffi::c_void,
+        renderer_render_arg: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8037,7 +8072,9 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igFindViewportByPlatformHandle(platform_handle: *mut cty::c_void) -> *mut ImGuiViewport;
+    pub fn igFindViewportByPlatformHandle(
+        platform_handle: *mut core::ffi::c_void,
+    ) -> *mut ImGuiViewport;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8081,7 +8118,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: cty::c_int, down: bool);
+    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: core::ffi::c_int, down: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8101,7 +8138,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: cty::c_uint);
+    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8109,16 +8146,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const cty::c_char);
+    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiIO_SetKeyEventNativeData(
         self_: *mut ImGuiIO,
         key: ImGuiKey,
-        native_keycode: cty::c_int,
-        native_scancode: cty::c_int,
-        native_legacy_index: cty::c_int,
+        native_keycode: core::ffi::c_int,
+        native_scancode: core::ffi::c_int,
+        native_legacy_index: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8157,17 +8194,17 @@ extern "C" {
 extern "C" {
     pub fn ImGuiInputTextCallbackData_DeleteChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        bytes_count: cty::c_int,
+        pos: core::ffi::c_int,
+        bytes_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiInputTextCallbackData_InsertChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        pos: core::ffi::c_int,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8204,7 +8241,10 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiPayload_IsDataType(self_: *mut ImGuiPayload, type_: *const cty::c_char) -> bool;
+    pub fn ImGuiPayload_IsDataType(
+        self_: *mut ImGuiPayload,
+        type_: *const core::ffi::c_char,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8225,7 +8265,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextFilter_ImGuiTextFilter(
-        default_filter: *const cty::c_char,
+        default_filter: *const core::ffi::c_char,
     ) -> *mut ImGuiTextFilter;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8236,7 +8276,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_Draw(
         self_: *mut ImGuiTextFilter,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         width: f32,
     ) -> bool;
 }
@@ -8244,8 +8284,8 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_PassFilter(
         self_: *mut ImGuiTextFilter,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8271,8 +8311,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextRange_ImGuiTextRange_Str(
-        _b: *const cty::c_char,
-        _e: *const cty::c_char,
+        _b: *const core::ffi::c_char,
+        _e: *const core::ffi::c_char,
     ) -> *mut ImGuiTextRange;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8283,7 +8323,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextRange_split(
         self_: *mut ImGuiTextRange,
-        separator: cty::c_char,
+        separator: core::ffi::c_char,
         out: *mut ImVector_ImGuiTextRange,
     );
 }
@@ -8297,15 +8337,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> cty::c_int;
+    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8317,25 +8357,25 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: cty::c_int);
+    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextBuffer_append(
         self_: *mut ImGuiTextBuffer,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Int(
         _key: ImGuiID,
-        _val: cty::c_int,
+        _val: core::ffi::c_int,
     ) -> *mut ImGuiStoragePair;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8353,7 +8393,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Ptr(
         _key: ImGuiID,
-        _val: *mut cty::c_void,
+        _val: *mut core::ffi::c_void,
     ) -> *mut ImGuiStoragePair;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8365,12 +8405,12 @@ extern "C" {
     pub fn ImGuiStorage_GetInt(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: cty::c_int);
+    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8390,19 +8430,26 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_GetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID) -> *mut cty::c_void;
+    pub fn ImGuiStorage_GetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+    ) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID, val: *mut cty::c_void);
+    pub fn ImGuiStorage_SetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+        val: *mut core::ffi::c_void,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiStorage_GetIntRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> *mut cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> *mut core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8425,8 +8472,8 @@ extern "C" {
     pub fn ImGuiStorage_GetVoidPtrRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: *mut cty::c_void,
-    ) -> *mut *mut cty::c_void;
+        default_val: *mut core::ffi::c_void,
+    ) -> *mut *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8434,7 +8481,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: cty::c_int);
+    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8448,7 +8495,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_Begin(
         self_: *mut ImGuiListClipper,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         items_height: f32,
     );
 }
@@ -8464,20 +8511,23 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemByIndex(
         self_: *mut ImGuiListClipper,
-        item_index: cty::c_int,
+        item_index: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemsByIndex(
         self_: *mut ImGuiListClipper,
-        item_begin: cty::c_int,
-        item_end: cty::c_int,
+        item_begin: core::ffi::c_int,
+        item_end: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiListClipper_SeekCursorForItem(self_: *mut ImGuiListClipper, item_index: cty::c_int);
+    pub fn ImGuiListClipper_SeekCursorForItem(
+        self_: *mut ImGuiListClipper,
+        item_index: core::ffi::c_int,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -8498,10 +8548,10 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImColor_ImColor_Int(
-        r: cty::c_int,
-        g: cty::c_int,
-        b: cty::c_int,
-        a: cty::c_int,
+        r: core::ffi::c_int,
+        g: core::ffi::c_int,
+        b: core::ffi::c_int,
+        a: core::ffi::c_int,
     ) -> *mut ImColor;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8561,7 +8611,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetNextSelectedItem(
         self_: *mut ImGuiSelectionBasicStorage,
-        opaque_it: *mut *mut cty::c_void,
+        opaque_it: *mut *mut core::ffi::c_void,
         out_id: *mut ImGuiID,
     ) -> bool;
 }
@@ -8569,7 +8619,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetStorageIdFromIndex(
         self_: *mut ImGuiSelectionBasicStorage,
-        idx: cty::c_int,
+        idx: core::ffi::c_int,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8621,7 +8671,7 @@ extern "C" {
     pub fn ImDrawListSplitter_Split(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        count: cty::c_int,
+        count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8633,7 +8683,7 @@ extern "C" {
     pub fn ImDrawListSplitter_SetCurrentChannel(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        channel_idx: cty::c_int,
+        channel_idx: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8773,7 +8823,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8784,7 +8834,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8794,7 +8844,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8805,7 +8855,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8816,7 +8866,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -8828,7 +8878,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8837,8 +8887,8 @@ extern "C" {
         self_: *mut ImDrawList,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8849,8 +8899,8 @@ extern "C" {
         font_size: f32,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip_rect: *const ImVec4,
     );
@@ -8865,7 +8915,7 @@ extern "C" {
         p4: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8877,7 +8927,7 @@ extern "C" {
         p3: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8885,7 +8935,7 @@ extern "C" {
     pub fn ImDrawList_AddPolyline(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
         flags: ImDrawFlags,
         thickness: f32,
@@ -8896,7 +8946,7 @@ extern "C" {
     pub fn ImDrawList_AddConvexPolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -8905,7 +8955,7 @@ extern "C" {
     pub fn ImDrawList_AddConcavePolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -8988,7 +9038,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -8997,8 +9047,8 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_of_12: cty::c_int,
-        a_max_of_12: cty::c_int,
+        a_min_of_12: core::ffi::c_int,
+        a_max_of_12: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9010,7 +9060,7 @@ extern "C" {
         rot: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9020,7 +9070,7 @@ extern "C" {
         p2: ImVec2,
         p3: ImVec2,
         p4: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9029,7 +9079,7 @@ extern "C" {
         self_: *mut ImDrawList,
         p2: ImVec2,
         p3: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9047,7 +9097,7 @@ extern "C" {
     pub fn ImDrawList_AddCallback(
         self_: *mut ImDrawList,
         callback: ImDrawCallback,
-        callback_data: *mut cty::c_void,
+        callback_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9060,7 +9110,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: cty::c_int);
+    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9068,22 +9118,22 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: cty::c_int);
+    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImDrawList_PrimReserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImDrawList_PrimUnreserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9165,7 +9215,7 @@ extern "C" {
     pub fn ImDrawList__CalcCircleAutoSegmentCount(
         self_: *mut ImDrawList,
         radius: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9173,9 +9223,9 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_sample: cty::c_int,
-        a_max_sample: cty::c_int,
-        a_step: cty::c_int,
+        a_min_sample: core::ffi::c_int,
+        a_max_sample: core::ffi::c_int,
+        a_step: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9186,7 +9236,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9249,8 +9299,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontGlyphRangesBuilder_AddText(
         self_: *mut ImFontGlyphRangesBuilder,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9305,7 +9355,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromFileTTF(
         self_: *mut ImFontAtlas,
-        filename: *const cty::c_char,
+        filename: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -9315,8 +9365,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryTTF(
         self_: *mut ImFontAtlas,
-        font_data: *mut cty::c_void,
-        font_data_size: cty::c_int,
+        font_data: *mut core::ffi::c_void,
+        font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -9326,8 +9376,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedTTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data: *const cty::c_void,
-        compressed_font_data_size: cty::c_int,
+        compressed_font_data: *const core::ffi::c_void,
+        compressed_font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -9337,7 +9387,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data_base85: *const cty::c_char,
+        compressed_font_data_base85: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -9367,20 +9417,20 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsAlpha8(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsRGBA32(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9433,9 +9483,9 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectRegular(
         self_: *mut ImFontAtlas,
-        width: cty::c_int,
-        height: cty::c_int,
-    ) -> cty::c_int;
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9443,17 +9493,17 @@ extern "C" {
         self_: *mut ImFontAtlas,
         font: *mut ImFont,
         id: ImWchar,
-        width: cty::c_int,
-        height: cty::c_int,
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
         advance_x: f32,
         offset: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImFontAtlas_GetCustomRectByIndex(
         self_: *mut ImFontAtlas,
-        index: cty::c_int,
+        index: core::ffi::c_int,
     ) -> *mut ImFontAtlasCustomRect;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9502,7 +9552,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const cty::c_char;
+    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9512,9 +9562,9 @@ extern "C" {
         size: f32,
         max_width: f32,
         wrap_width: f32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
-        remaining: *mut *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        remaining: *mut *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9522,10 +9572,10 @@ extern "C" {
     pub fn ImFont_CalcWordWrapPositionA(
         self_: *mut ImFont,
         scale: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9547,8 +9597,8 @@ extern "C" {
         pos: ImVec2,
         col: ImU32,
         clip_rect: ImVec4,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip: bool,
     );
@@ -9563,7 +9613,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: cty::c_int);
+    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9594,8 +9644,8 @@ extern "C" {
 extern "C" {
     pub fn ImFont_IsGlyphRangeUnused(
         self_: *mut ImFont,
-        c_begin: cty::c_uint,
-        c_last: cty::c_uint,
+        c_begin: core::ffi::c_uint,
+        c_last: core::ffi::c_uint,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -9640,20 +9690,24 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImHashData(data: *const cty::c_void, data_size: usize, seed: ImGuiID) -> ImGuiID;
+    pub fn igImHashData(data: *const core::ffi::c_void, data_size: usize, seed: ImGuiID)
+        -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImHashStr(data: *const cty::c_char, data_size: usize, seed: ImGuiID) -> ImGuiID;
+    pub fn igImHashStr(data: *const core::ffi::c_char, data_size: usize, seed: ImGuiID) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImQsort(
-        base: *mut cty::c_void,
+        base: *mut core::ffi::c_void,
         count: usize,
         size_of_element: usize,
         compare_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *const cty::c_void, arg2: *const cty::c_void) -> cty::c_int,
+            unsafe extern "C" fn(
+                arg1: *const core::ffi::c_void,
+                arg2: *const core::ffi::c_void,
+            ) -> core::ffi::c_int,
         >,
     );
 }
@@ -9663,7 +9717,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImIsPowerOfTwo_Int(v: cty::c_int) -> bool;
+    pub fn igImIsPowerOfTwo_Int(v: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9671,221 +9725,230 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImUpperPowerOfTwo(v: cty::c_int) -> cty::c_int;
+    pub fn igImUpperPowerOfTwo(v: core::ffi::c_int) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStricmp(str1: *const cty::c_char, str2: *const cty::c_char) -> cty::c_int;
+    pub fn igImStricmp(
+        str1: *const core::ffi::c_char,
+        str2: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStrnicmp(
-        str1: *const cty::c_char,
-        str2: *const cty::c_char,
+        str1: *const core::ffi::c_char,
+        str2: *const core::ffi::c_char,
         count: usize,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrncpy(dst: *mut cty::c_char, src: *const cty::c_char, count: usize);
+    pub fn igImStrncpy(dst: *mut core::ffi::c_char, src: *const core::ffi::c_char, count: usize);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrdup(str_: *const cty::c_char) -> *mut cty::c_char;
+    pub fn igImStrdup(str_: *const core::ffi::c_char) -> *mut core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStrdupcpy(
-        dst: *mut cty::c_char,
+        dst: *mut core::ffi::c_char,
         p_dst_size: *mut usize,
-        str_: *const cty::c_char,
-    ) -> *mut cty::c_char;
+        str_: *const core::ffi::c_char,
+    ) -> *mut core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStrchrRange(
-        str_begin: *const cty::c_char,
-        str_end: *const cty::c_char,
-        c: cty::c_char,
-    ) -> *const cty::c_char;
+        str_begin: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
+        c: core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStreolRange(
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStristr(
-        haystack: *const cty::c_char,
-        haystack_end: *const cty::c_char,
-        needle: *const cty::c_char,
-        needle_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        haystack: *const core::ffi::c_char,
+        haystack_end: *const core::ffi::c_char,
+        needle: *const core::ffi::c_char,
+        needle_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrTrimBlanks(str_: *mut cty::c_char);
+    pub fn igImStrTrimBlanks(str_: *mut core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrSkipBlank(str_: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImStrSkipBlank(str_: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImStrlenW(str_: *const ImWchar) -> cty::c_int;
+    pub fn igImStrlenW(str_: *const ImWchar) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImStrbol(
-        buf_mid_line: *const cty::c_char,
-        buf_begin: *const cty::c_char,
-    ) -> *const cty::c_char;
+        buf_mid_line: *const core::ffi::c_char,
+        buf_begin: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImToUpper(c: cty::c_char) -> cty::c_char;
+    pub fn igImToUpper(c: core::ffi::c_char) -> core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImCharIsBlankA(c: cty::c_char) -> bool;
+    pub fn igImCharIsBlankA(c: core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImCharIsBlankW(c: cty::c_uint) -> bool;
+    pub fn igImCharIsBlankW(c: core::ffi::c_uint) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImCharIsXdigitA(c: cty::c_char) -> bool;
+    pub fn igImCharIsXdigitA(c: core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFormatString(
-        buf: *mut cty::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFormatStringToTempBuffer(
-        out_buf: *mut *const cty::c_char,
-        out_buf_end: *mut *const cty::c_char,
-        fmt: *const cty::c_char,
+        out_buf: *mut *const core::ffi::c_char,
+        out_buf_end: *mut *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImParseFormatFindStart(format: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImParseFormatFindStart(format: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImParseFormatFindEnd(format: *const cty::c_char) -> *const cty::c_char;
+    pub fn igImParseFormatFindEnd(format: *const core::ffi::c_char) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImParseFormatTrimDecorations(
-        format: *const cty::c_char,
-        buf: *mut cty::c_char,
+        format: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImParseFormatSanitizeForPrinting(
-        fmt_in: *const cty::c_char,
-        fmt_out: *mut cty::c_char,
+        fmt_in: *const core::ffi::c_char,
+        fmt_out: *mut core::ffi::c_char,
         fmt_out_size: usize,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImParseFormatSanitizeForScanning(
-        fmt_in: *const cty::c_char,
-        fmt_out: *mut cty::c_char,
+        fmt_in: *const core::ffi::c_char,
+        fmt_out: *mut core::ffi::c_char,
         fmt_out_size: usize,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImParseFormatPrecision(
-        format: *const cty::c_char,
-        default_value: cty::c_int,
-    ) -> cty::c_int;
+        format: *const core::ffi::c_char,
+        default_value: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImTextCharToUtf8(out_buf: *mut cty::c_char, c: cty::c_uint) -> *const cty::c_char;
+    pub fn igImTextCharToUtf8(
+        out_buf: *mut core::ffi::c_char,
+        c: core::ffi::c_uint,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextStrToUtf8(
-        out_buf: *mut cty::c_char,
-        out_buf_size: cty::c_int,
+        out_buf: *mut core::ffi::c_char,
+        out_buf_size: core::ffi::c_int,
         in_text: *const ImWchar,
         in_text_end: *const ImWchar,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCharFromUtf8(
-        out_char: *mut cty::c_uint,
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        out_char: *mut core::ffi::c_uint,
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextStrFromUtf8(
         out_buf: *mut ImWchar,
-        out_buf_size: cty::c_int,
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-        in_remaining: *mut *const cty::c_char,
-    ) -> cty::c_int;
+        out_buf_size: core::ffi::c_int,
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+        in_remaining: *mut *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCountCharsFromUtf8(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCountUtf8BytesFromChar(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCountUtf8BytesFromStr(
         in_text: *const ImWchar,
         in_text_end: *const ImWchar,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextFindPreviousUtf8Codepoint(
-        in_text_start: *const cty::c_char,
-        in_text_curr: *const cty::c_char,
-    ) -> *const cty::c_char;
+        in_text_start: *const core::ffi::c_char,
+        in_text_curr: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImTextCountLines(
-        in_text: *const cty::c_char,
-        in_text_end: *const cty::c_char,
-    ) -> cty::c_int;
+        in_text: *const core::ffi::c_char,
+        in_text_end: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImFileOpen(filename: *const cty::c_char, mode: *const cty::c_char) -> ImFileHandle;
+    pub fn igImFileOpen(
+        filename: *const core::ffi::c_char,
+        mode: *const core::ffi::c_char,
+    ) -> ImFileHandle;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9898,7 +9961,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFileRead(
-        data: *mut cty::c_void,
+        data: *mut core::ffi::c_void,
         size: ImU64,
         count: ImU64,
         file: ImFileHandle,
@@ -9907,7 +9970,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFileWrite(
-        data: *const cty::c_void,
+        data: *const core::ffi::c_void,
         size: ImU64,
         count: ImU64,
         file: ImFileHandle,
@@ -9916,11 +9979,11 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFileLoadToMemory(
-        filename: *const cty::c_char,
-        mode: *const cty::c_char,
+        filename: *const core::ffi::c_char,
+        mode: *const core::ffi::c_char,
         out_file_size: *mut usize,
-        padding_bytes: cty::c_int,
-    ) -> *mut cty::c_void;
+        padding_bytes: core::ffi::c_int,
+    ) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -9940,7 +10003,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImAbs_Int(x: cty::c_int) -> cty::c_int;
+    pub fn igImAbs_Int(x: core::ffi::c_int) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10024,7 +10087,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImModPositive(a: cty::c_int, b: cty::c_int) -> cty::c_int;
+    pub fn igImModPositive(a: core::ffi::c_int, b: core::ffi::c_int) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10052,7 +10115,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImExponentialMovingAverage(avg: f32, sample: f32, n: cty::c_int) -> f32;
+    pub fn igImExponentialMovingAverage(avg: f32, sample: f32, n: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10074,7 +10137,7 @@ extern "C" {
         p3: ImVec2,
         p4: ImVec2,
         p: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10147,7 +10210,8 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImVec2ih_ImVec2ih_short(_x: cty::c_short, _y: cty::c_short) -> *mut ImVec2ih;
+    pub fn ImVec2ih_ImVec2ih_short(_x: core::ffi::c_short, _y: core::ffi::c_short)
+        -> *mut ImVec2ih;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10275,31 +10339,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArrayGetStorageSizeInBytes(bitcount: cty::c_int) -> usize;
+    pub fn igImBitArrayGetStorageSizeInBytes(bitcount: core::ffi::c_int) -> usize;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArrayClearAllBits(arr: *mut ImU32, bitcount: cty::c_int);
+    pub fn igImBitArrayClearAllBits(arr: *mut ImU32, bitcount: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArrayTestBit(arr: *const ImU32, n: cty::c_int) -> bool;
+    pub fn igImBitArrayTestBit(arr: *const ImU32, n: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArrayClearBit(arr: *mut ImU32, n: cty::c_int);
+    pub fn igImBitArrayClearBit(arr: *mut ImU32, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArraySetBit(arr: *mut ImU32, n: cty::c_int);
+    pub fn igImBitArraySetBit(arr: *mut ImU32, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igImBitArraySetBitRange(arr: *mut ImU32, n: cty::c_int, n2: cty::c_int);
+    pub fn igImBitArraySetBitRange(arr: *mut ImU32, n: core::ffi::c_int, n2: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImBitVector_Create(self_: *mut ImBitVector, sz: cty::c_int);
+    pub fn ImBitVector_Create(self_: *mut ImBitVector, sz: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10307,15 +10371,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImBitVector_TestBit(self_: *mut ImBitVector, n: cty::c_int) -> bool;
+    pub fn ImBitVector_TestBit(self_: *mut ImBitVector, n: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImBitVector_SetBit(self_: *mut ImBitVector, n: cty::c_int);
+    pub fn ImBitVector_SetBit(self_: *mut ImBitVector, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImBitVector_ClearBit(self_: *mut ImBitVector, n: cty::c_int);
+    pub fn ImBitVector_ClearBit(self_: *mut ImBitVector, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10323,31 +10387,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextIndex_size(self_: *mut ImGuiTextIndex) -> cty::c_int;
+    pub fn ImGuiTextIndex_size(self_: *mut ImGuiTextIndex) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextIndex_get_line_begin(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        n: cty::c_int,
-    ) -> *const cty::c_char;
+        base: *const core::ffi::c_char,
+        n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextIndex_get_line_end(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        n: cty::c_int,
-    ) -> *const cty::c_char;
+        base: *const core::ffi::c_char,
+        n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextIndex_append(
         self_: *mut ImGuiTextIndex,
-        base: *const cty::c_char,
-        old_size: cty::c_int,
-        new_size: cty::c_int,
+        base: *const core::ffi::c_char,
+        old_size: core::ffi::c_int,
+        new_size: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10385,13 +10449,15 @@ extern "C" {
 extern "C" {
     pub fn ImGuiDataVarInfo_GetVarPtr(
         self_: *mut ImGuiDataVarInfo,
-        parent: *mut cty::c_void,
-    ) -> *mut cty::c_void;
+        parent: *mut core::ffi::c_void,
+    ) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStyleMod_ImGuiStyleMod_Int(idx: ImGuiStyleVar, v: cty::c_int)
-        -> *mut ImGuiStyleMod;
+    pub fn ImGuiStyleMod_ImGuiStyleMod_Int(
+        idx: ImGuiStyleVar,
+        v: core::ffi::c_int,
+    ) -> *mut ImGuiStyleMod;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10476,11 +10542,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_OnKeyPressed(self_: *mut ImGuiInputTextState, key: cty::c_int);
+    pub fn ImGuiInputTextState_OnKeyPressed(self_: *mut ImGuiInputTextState, key: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_OnCharPressed(self_: *mut ImGuiInputTextState, c: cty::c_uint);
+    pub fn ImGuiInputTextState_OnCharPressed(self_: *mut ImGuiInputTextState, c: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10500,15 +10566,18 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_GetCursorPos(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetCursorPos(self_: *mut ImGuiInputTextState) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_GetSelectionStart(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetSelectionStart(
+        self_: *mut ImGuiInputTextState,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiInputTextState_GetSelectionEnd(self_: *mut ImGuiInputTextState) -> cty::c_int;
+    pub fn ImGuiInputTextState_GetSelectionEnd(self_: *mut ImGuiInputTextState)
+        -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10568,7 +10637,8 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Ptr(ptr: *mut cty::c_void) -> *mut ImGuiPtrOrIndex;
+    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Ptr(ptr: *mut core::ffi::c_void)
+        -> *mut ImGuiPtrOrIndex;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10576,7 +10646,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Int(index: cty::c_int) -> *mut ImGuiPtrOrIndex;
+    pub fn ImGuiPtrOrIndex_ImGuiPtrOrIndex_Int(index: core::ffi::c_int) -> *mut ImGuiPtrOrIndex;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10625,8 +10695,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiListClipperRange_FromIndices(
-        min: cty::c_int,
-        max: cty::c_int,
+        min: core::ffi::c_int,
+        max: core::ffi::c_int,
     ) -> ImGuiListClipperRange;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10634,8 +10704,8 @@ extern "C" {
     pub fn ImGuiListClipperRange_FromPositions(
         y1: f32,
         y2: f32,
-        off_min: cty::c_int,
-        off_max: cty::c_int,
+        off_min: core::ffi::c_int,
+        off_max: core::ffi::c_int,
     ) -> ImGuiListClipperRange;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10844,7 +10914,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiWindowSettings_GetName(self_: *mut ImGuiWindowSettings) -> *mut cty::c_char;
+    pub fn ImGuiWindowSettings_GetName(self_: *mut ImGuiWindowSettings) -> *mut core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -10898,7 +10968,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiWindow_ImGuiWindow(
         context: *mut ImGuiContext,
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
     ) -> *mut ImGuiWindow;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -10909,17 +10979,18 @@ extern "C" {
 extern "C" {
     pub fn ImGuiWindow_GetID_Str(
         self_: *mut ImGuiWindow,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiWindow_GetID_Ptr(self_: *mut ImGuiWindow, ptr: *const cty::c_void) -> ImGuiID;
+    pub fn ImGuiWindow_GetID_Ptr(self_: *mut ImGuiWindow, ptr: *const core::ffi::c_void)
+        -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiWindow_GetID_Int(self_: *mut ImGuiWindow, n: cty::c_int) -> ImGuiID;
+    pub fn ImGuiWindow_GetID_Int(self_: *mut ImGuiWindow, n: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11029,7 +11100,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igFindWindowByName(name: *const cty::c_char) -> *mut ImGuiWindow;
+    pub fn igFindWindowByName(name: *const core::ffi::c_char) -> *mut ImGuiWindow;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11152,7 +11223,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igFindWindowDisplayIndex(window: *mut ImGuiWindow) -> cty::c_int;
+    pub fn igFindWindowDisplayIndex(window: *mut ImGuiWindow) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11297,15 +11368,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igRemoveSettingsHandler(type_name: *const cty::c_char);
+    pub fn igRemoveSettingsHandler(type_name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igFindSettingsHandler(type_name: *const cty::c_char) -> *mut ImGuiSettingsHandler;
+    pub fn igFindSettingsHandler(type_name: *const core::ffi::c_char) -> *mut ImGuiSettingsHandler;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igCreateNewWindowSettings(name: *const cty::c_char) -> *mut ImGuiWindowSettings;
+    pub fn igCreateNewWindowSettings(name: *const core::ffi::c_char) -> *mut ImGuiWindowSettings;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11317,15 +11388,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igClearWindowSettings(name: *const cty::c_char);
+    pub fn igClearWindowSettings(name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLocalizeRegisterEntries(entries: *const ImGuiLocEntry, count: cty::c_int);
+    pub fn igLocalizeRegisterEntries(entries: *const ImGuiLocEntry, count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLocalizeGetMsg(key: ImGuiLocKey) -> *const cty::c_char;
+    pub fn igLocalizeGetMsg(key: ImGuiLocKey) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11423,14 +11494,14 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igGetIDWithSeed_Str(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
         seed: ImGuiID,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetIDWithSeed_Int(n: cty::c_int, seed: ImGuiID) -> ImGuiID;
+    pub fn igGetIDWithSeed_Int(n: core::ffi::c_int, seed: ImGuiID) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11480,11 +11551,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushMultiItemsWidths(components: cty::c_int, width_full: f32);
+    pub fn igPushMultiItemsWidths(components: core::ffi::c_int, width_full: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShrinkWidths(items: *mut ImGuiShrinkWidthItem, count: cty::c_int, width_excess: f32);
+    pub fn igShrinkWidths(
+        items: *mut ImGuiShrinkWidthItem,
+        count: core::ffi::c_int,
+        width_excess: f32,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11500,28 +11575,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogBegin(type_: ImGuiLogType, auto_open_depth: cty::c_int);
+    pub fn igLogBegin(type_: ImGuiLogType, auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToBuffer(auto_open_depth: cty::c_int);
+    pub fn igLogToBuffer(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igLogRenderedText(
         ref_pos: *const ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogSetNextTextDecoration(prefix: *const cty::c_char, suffix: *const cty::c_char);
+    pub fn igLogSetNextTextDecoration(
+        prefix: *const core::ffi::c_char,
+        suffix: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginChildEx(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         id: ImGuiID,
         size_arg: ImVec2,
         child_flags: ImGuiChildFlags,
@@ -11538,7 +11616,10 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igClosePopupToLevel(remaining: cty::c_int, restore_focus_to_window_under_popup: bool);
+    pub fn igClosePopupToLevel(
+        remaining: core::ffi::c_int,
+        restore_focus_to_window_under_popup: bool,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11601,7 +11682,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginViewportSideBar(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         viewport: *mut ImGuiViewport,
         dir: ImGuiDir,
         size: f32,
@@ -11611,17 +11692,17 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginMenuEx(
-        label: *const cty::c_char,
-        icon: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        icon: *const core::ffi::c_char,
         enabled: bool,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItemEx(
-        label: *const cty::c_char,
-        icon: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        icon: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
@@ -11782,7 +11863,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyChordName(key_chord: ImGuiKeyChord) -> *const cty::c_char;
+    pub fn igGetKeyChordName(key_chord: ImGuiKeyChord) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -11813,7 +11894,7 @@ extern "C" {
         t1: f32,
         repeat_delay: f32,
         repeat_rate: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12037,7 +12118,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDockNodeGetDepth(node: *const ImGuiDockNode) -> cty::c_int;
+    pub fn igDockNodeGetDepth(node: *const ImGuiDockNode) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12069,7 +12150,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDockBuilderDockWindow(window_name: *const cty::c_char, node_id: ImGuiID);
+    pub fn igDockBuilderDockWindow(window_name: *const core::ffi::c_char, node_id: ImGuiID);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12132,8 +12213,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDockBuilderCopyWindowSettings(
-        src_name: *const cty::c_char,
-        dst_name: *const cty::c_char,
+        src_name: *const core::ffi::c_char,
+        dst_name: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -12181,36 +12262,45 @@ extern "C" {
 extern "C" {
     pub fn igTypingSelectFindMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        nav_item_idx: cty::c_int,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+        nav_item_idx: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTypingSelectFindNextSingleCharMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        nav_item_idx: cty::c_int,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+        nav_item_idx: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTypingSelectFindBestLeadingMatch(
         req: *mut ImGuiTypingSelectRequest,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         get_item_name_func: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut cty::c_void, arg2: cty::c_int) -> *const cty::c_char,
+            unsafe extern "C" fn(
+                arg1: *mut core::ffi::c_void,
+                arg2: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-    ) -> cty::c_int;
+        user_data: *mut core::ffi::c_void,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12246,7 +12336,7 @@ extern "C" {
     pub fn igMultiSelectAddSetRange(
         ms: *mut ImGuiMultiSelectTempData,
         selected: bool,
-        range_dir: cty::c_int,
+        range_dir: core::ffi::c_int,
         first_item: ImGuiSelectionUserData,
         last_item: ImGuiSelectionUserData,
     );
@@ -12266,8 +12356,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginColumns(
-        str_id: *const cty::c_char,
-        count: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        count: core::ffi::c_int,
         flags: ImGuiOldColumnFlags,
     );
 }
@@ -12277,7 +12367,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushColumnClipRect(column_index: cty::c_int);
+    pub fn igPushColumnClipRect(column_index: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12289,7 +12379,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnsID(str_id: *const cty::c_char, count: cty::c_int) -> ImGuiID;
+    pub fn igGetColumnsID(str_id: *const core::ffi::c_char, count: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12305,23 +12395,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableOpenContextMenu(column_n: cty::c_int);
+    pub fn igTableOpenContextMenu(column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnWidth(column_n: cty::c_int, width: f32);
+    pub fn igTableSetColumnWidth(column_n: core::ffi::c_int, width: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableSetColumnSortDirection(
-        column_n: cty::c_int,
+        column_n: core::ffi::c_int,
         sort_direction: ImGuiSortDirection,
         append_to_sort_specs: bool,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetHoveredRow() -> cty::c_int;
+    pub fn igTableGetHoveredRow() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12346,7 +12436,7 @@ extern "C" {
         angle: f32,
         max_label_width: f32,
         data: *const ImGuiTableHeaderData,
-        data_count: cty::c_int,
+        data_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -12360,9 +12450,9 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTableEx(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         id: ImGuiID,
-        columns_count: cty::c_int,
+        columns_count: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -12370,7 +12460,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableBeginInitMemory(table: *mut ImGuiTable, columns_count: cty::c_int);
+    pub fn igTableBeginInitMemory(table: *mut ImGuiTable, columns_count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12415,12 +12505,12 @@ extern "C" {
 extern "C" {
     pub fn igTableGetInstanceData(
         table: *mut ImGuiTable,
-        instance_no: cty::c_int,
+        instance_no: core::ffi::c_int,
     ) -> *mut ImGuiTableInstanceData;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetInstanceID(table: *mut ImGuiTable, instance_no: cty::c_int) -> ImGuiID;
+    pub fn igTableGetInstanceID(table: *mut ImGuiTable, instance_no: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12452,7 +12542,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableBeginCell(table: *mut ImGuiTable, column_n: cty::c_int);
+    pub fn igTableBeginCell(table: *mut ImGuiTable, column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12460,30 +12550,34 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetCellBgRect(pOut: *mut ImRect, table: *const ImGuiTable, column_n: cty::c_int);
+    pub fn igTableGetCellBgRect(
+        pOut: *mut ImRect,
+        table: *const ImGuiTable,
+        column_n: core::ffi::c_int,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableGetColumnName_TablePtr(
         table: *const ImGuiTable,
-        column_n: cty::c_int,
-    ) -> *const cty::c_char;
+        column_n: core::ffi::c_int,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableGetColumnResizeID(
         table: *mut ImGuiTable,
-        column_n: cty::c_int,
-        instance_no: cty::c_int,
+        column_n: core::ffi::c_int,
+        instance_no: core::ffi::c_int,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableCalcMaxColumnWidth(table: *const ImGuiTable, column_n: cty::c_int) -> f32;
+    pub fn igTableCalcMaxColumnWidth(table: *const ImGuiTable, column_n: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnWidthAutoSingle(table: *mut ImGuiTable, column_n: cty::c_int);
+    pub fn igTableSetColumnWidthAutoSingle(table: *mut ImGuiTable, column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12527,8 +12621,10 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSettingsCreate(id: ImGuiID, columns_count: cty::c_int)
-        -> *mut ImGuiTableSettings;
+    pub fn igTableSettingsCreate(
+        id: ImGuiID,
+        columns_count: core::ffi::c_int,
+    ) -> *mut ImGuiTableSettings;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12550,7 +12646,7 @@ extern "C" {
 extern "C" {
     pub fn igTabBarFindTabByOrder(
         tab_bar: *mut ImGuiTabBar,
-        order: cty::c_int,
+        order: core::ffi::c_int,
     ) -> *mut ImGuiTabItem;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -12565,14 +12661,17 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTabBarGetTabOrder(tab_bar: *mut ImGuiTabBar, tab: *mut ImGuiTabItem) -> cty::c_int;
+    pub fn igTabBarGetTabOrder(
+        tab_bar: *mut ImGuiTabBar,
+        tab: *mut ImGuiTabItem,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTabBarGetTabName(
         tab_bar: *mut ImGuiTabBar,
         tab: *mut ImGuiTabItem,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12596,14 +12695,14 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTabBarQueueFocus_Str(tab_bar: *mut ImGuiTabBar, tab_name: *const cty::c_char);
+    pub fn igTabBarQueueFocus_Str(tab_bar: *mut ImGuiTabBar, tab_name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTabBarQueueReorder(
         tab_bar: *mut ImGuiTabBar,
         tab: *mut ImGuiTabItem,
-        offset: cty::c_int,
+        offset: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -12622,7 +12721,7 @@ extern "C" {
 extern "C" {
     pub fn igTabItemEx(
         tab_bar: *mut ImGuiTabBar,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
         docked_window: *mut ImGuiWindow,
@@ -12632,7 +12731,7 @@ extern "C" {
 extern "C" {
     pub fn igTabItemCalcSize_Str(
         pOut: *mut ImVec2,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         has_close_button_or_unsaved_marker: bool,
     );
 }
@@ -12656,7 +12755,7 @@ extern "C" {
         bb: ImRect,
         flags: ImGuiTabItemFlags,
         frame_padding: ImVec2,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         tab_id: ImGuiID,
         close_button_id: ImGuiID,
         is_contents_visible: bool,
@@ -12668,8 +12767,8 @@ extern "C" {
 extern "C" {
     pub fn igRenderText(
         pos: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_hash: bool,
     );
 }
@@ -12677,8 +12776,8 @@ extern "C" {
 extern "C" {
     pub fn igRenderTextWrapped(
         pos: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
     );
 }
@@ -12687,8 +12786,8 @@ extern "C" {
     pub fn igRenderTextClipped(
         pos_min: ImVec2,
         pos_max: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
         align: ImVec2,
         clip_rect: *const ImRect,
@@ -12700,8 +12799,8 @@ extern "C" {
         draw_list: *mut ImDrawList,
         pos_min: ImVec2,
         pos_max: ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
         align: ImVec2,
         clip_rect: *const ImRect,
@@ -12715,8 +12814,8 @@ extern "C" {
         pos_max: ImVec2,
         clip_max_x: f32,
         ellipsis_max_x: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         text_size_if_known: *const ImVec2,
     );
 }
@@ -12754,9 +12853,9 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igFindRenderedTextEnd(
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
-    ) -> *const cty::c_char;
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12832,17 +12931,24 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextEx(text: *const cty::c_char, text_end: *const cty::c_char, flags: ImGuiTextFlags);
+    pub fn igTextEx(
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        flags: ImGuiTextFlags,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igButtonEx(label: *const cty::c_char, size_arg: ImVec2, flags: ImGuiButtonFlags)
-        -> bool;
+    pub fn igButtonEx(
+        label: *const core::ffi::c_char,
+        size_arg: ImVec2,
+        flags: ImGuiButtonFlags,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igArrowButtonEx(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         dir: ImGuiDir,
         size_arg: ImVec2,
         flags: ImGuiButtonFlags,
@@ -12869,15 +12975,15 @@ extern "C" {
 extern "C" {
     pub fn igSeparatorTextEx(
         id: ImGuiID,
-        label: *const cty::c_char,
-        label_end: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        label_end: *const core::ffi::c_char,
         extra_width: f32,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_S64Ptr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: *mut ImS64,
         flags_value: ImS64,
     ) -> bool;
@@ -12885,7 +12991,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_U64Ptr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: *mut ImU64,
         flags_value: ImU64,
     ) -> bool;
@@ -12924,7 +13030,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetWindowResizeCornerID(window: *mut ImGuiWindow, n: cty::c_int) -> ImGuiID;
+    pub fn igGetWindowResizeCornerID(window: *mut ImGuiWindow, n: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -12945,11 +13051,11 @@ extern "C" {
     pub fn igDragBehavior(
         id: ImGuiID,
         data_type: ImGuiDataType,
-        p_v: *mut cty::c_void,
+        p_v: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
@@ -12959,10 +13065,10 @@ extern "C" {
         bb: ImRect,
         id: ImGuiID,
         data_type: ImGuiDataType,
-        p_v: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_v: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
         out_grab_bb: *mut ImRect,
     ) -> bool;
@@ -12987,8 +13093,8 @@ extern "C" {
     pub fn igTreeNodeBehavior(
         id: ImGuiID,
         flags: ImGuiTreeNodeFlags,
-        label: *const cty::c_char,
-        label_end: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        label_end: *const core::ffi::c_char,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13014,65 +13120,65 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeFormatString(
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         data_type: ImGuiDataType,
-        p_data: *const cty::c_void,
-        format: *const cty::c_char,
-    ) -> cty::c_int;
+        p_data: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeApplyOp(
         data_type: ImGuiDataType,
-        op: cty::c_int,
-        output: *mut cty::c_void,
-        arg_1: *const cty::c_void,
-        arg_2: *const cty::c_void,
+        op: core::ffi::c_int,
+        output: *mut core::ffi::c_void,
+        arg_1: *const core::ffi::c_void,
+        arg_2: *const core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeApplyFromText(
-        buf: *const cty::c_char,
+        buf: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        format: *const cty::c_char,
-        p_data_when_empty: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        format: *const core::ffi::c_char,
+        p_data_when_empty: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeCompare(
         data_type: ImGuiDataType,
-        arg_1: *const cty::c_void,
-        arg_2: *const cty::c_void,
-    ) -> cty::c_int;
+        arg_1: *const core::ffi::c_void,
+        arg_2: *const core::ffi::c_void,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDataTypeClamp(
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDataTypeIsZero(data_type: ImGuiDataType, p_data: *const cty::c_void) -> bool;
+    pub fn igDataTypeIsZero(data_type: ImGuiDataType, p_data: *const core::ffi::c_void) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextEx(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         size_arg: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13084,9 +13190,9 @@ extern "C" {
     pub fn igTempInputText(
         bb: ImRect,
         id: ImGuiID,
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
-        buf_size: cty::c_int,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
+        buf_size: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
@@ -13095,12 +13201,12 @@ extern "C" {
     pub fn igTempInputScalar(
         bb: ImRect,
         id: ImGuiID,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        format: *const cty::c_char,
-        p_clamp_min: *const cty::c_void,
-        p_clamp_max: *const cty::c_void,
+        p_data: *mut core::ffi::c_void,
+        format: *const core::ffi::c_char,
+        p_clamp_min: *const core::ffi::c_void,
+        p_clamp_max: *const core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13113,11 +13219,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetNextItemRefVal(data_type: ImGuiDataType, p_data: *mut cty::c_void);
+    pub fn igSetNextItemRefVal(data_type: ImGuiDataType, p_data: *mut core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igColorTooltip(text: *const cty::c_char, col: *const f32, flags: ImGuiColorEditFlags);
+    pub fn igColorTooltip(
+        text: *const core::ffi::c_char,
+        col: *const f32,
+        flags: ImGuiColorEditFlags,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13131,25 +13241,25 @@ extern "C" {
 extern "C" {
     pub fn igPlotEx(
         plot_type: ImGuiPlotType,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         size_arg: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igShadeVertsLinearColorGradientKeepAlpha(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         gradient_p0: ImVec2,
         gradient_p1: ImVec2,
         col0: ImU32,
@@ -13160,8 +13270,8 @@ extern "C" {
 extern "C" {
     pub fn igShadeVertsLinearUV(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         a: ImVec2,
         b: ImVec2,
         uv_a: ImVec2,
@@ -13173,8 +13283,8 @@ extern "C" {
 extern "C" {
     pub fn igShadeVertsTransformPos(
         draw_list: *mut ImDrawList,
-        vert_start_idx: cty::c_int,
-        vert_end_idx: cty::c_int,
+        vert_start_idx: core::ffi::c_int,
+        vert_end_idx: core::ffi::c_int,
         pivot_in: ImVec2,
         cos_a: f32,
         sin_a: f32,
@@ -13195,7 +13305,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igErrorLog(msg: *const cty::c_char) -> bool;
+    pub fn igErrorLog(msg: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13229,8 +13339,8 @@ extern "C" {
 extern "C" {
     pub fn igDebugAllocHook(
         info: *mut ImGuiDebugAllocInfo,
-        frame_count: cty::c_int,
-        ptr: *mut cty::c_void,
+        frame_count: core::ffi::c_int,
+        ptr: *mut core::ffi::c_void,
         size: usize,
     );
 }
@@ -13249,8 +13359,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugTextUnformattedWithLocateItem(
-        line_begin: *const cty::c_char,
-        line_end: *const cty::c_char,
+        line_begin: *const core::ffi::c_char,
+        line_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13272,15 +13382,15 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugBreakButton(
-        label: *const cty::c_char,
-        description_of_location: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        description_of_location: *const core::ffi::c_char,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugBreakButtonTooltip(
         keyboard_only: bool,
-        description_of_location: *const cty::c_char,
+        description_of_location: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13292,8 +13402,8 @@ extern "C" {
     pub fn igDebugHookIdInfo(
         id: ImGuiID,
         data_type: ImGuiDataType,
-        data_id: *const cty::c_void,
-        data_id_end: *const cty::c_void,
+        data_id: *const core::ffi::c_void,
+        data_id_end: *const core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13302,7 +13412,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeDockNode(node: *mut ImGuiDockNode, label: *const cty::c_char);
+    pub fn igDebugNodeDockNode(node: *mut ImGuiDockNode, label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13310,7 +13420,7 @@ extern "C" {
         window: *mut ImGuiWindow,
         viewport: *mut ImGuiViewportP,
         draw_list: *const ImDrawList,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13333,11 +13443,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeStorage(storage: *mut ImGuiStorage, label: *const cty::c_char);
+    pub fn igDebugNodeStorage(storage: *mut ImGuiStorage, label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeTabBar(tab_bar: *mut ImGuiTabBar, label: *const cty::c_char);
+    pub fn igDebugNodeTabBar(tab_bar: *mut ImGuiTabBar, label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13361,7 +13471,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeWindow(window: *mut ImGuiWindow, label: *const cty::c_char);
+    pub fn igDebugNodeWindow(window: *mut ImGuiWindow, label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -13369,13 +13479,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugNodeWindowsList(windows: *mut ImVector_ImGuiWindowPtr, label: *const cty::c_char);
+    pub fn igDebugNodeWindowsList(
+        windows: *mut ImVector_ImGuiWindowPtr,
+        label: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugNodeWindowsListByBeginStackParent(
         windows: *mut *mut ImGuiWindow,
-        windows_size: cty::c_int,
+        windows_size: core::ffi::c_int,
         parent_in_begin_stack: *mut ImGuiWindow,
     );
 }
@@ -13387,8 +13500,8 @@ extern "C" {
 extern "C" {
     pub fn igDebugNodePlatformMonitor(
         monitor: *mut ImGuiPlatformMonitor,
-        label: *const cty::c_char,
-        idx: cty::c_int,
+        label: *const core::ffi::c_char,
+        idx: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13425,7 +13538,7 @@ extern "C" {
 extern "C" {
     pub fn igImFontAtlasBuildPackCustomRects(
         atlas: *mut ImFontAtlas,
-        stbrp_context_opaque: *mut cty::c_void,
+        stbrp_context_opaque: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13436,45 +13549,45 @@ extern "C" {
 extern "C" {
     pub fn igImFontAtlasBuildRender8bppRectFromString(
         atlas: *mut ImFontAtlas,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        in_str: *const cty::c_char,
-        in_marker_char: cty::c_char,
-        in_marker_pixel_value: cty::c_uchar,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        in_str: *const core::ffi::c_char,
+        in_marker_char: core::ffi::c_char,
+        in_marker_pixel_value: core::ffi::c_uchar,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFontAtlasBuildRender32bppRectFromString(
         atlas: *mut ImFontAtlas,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        in_str: *const cty::c_char,
-        in_marker_char: cty::c_char,
-        in_marker_pixel_value: cty::c_uint,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        in_str: *const core::ffi::c_char,
+        in_marker_char: core::ffi::c_char,
+        in_marker_pixel_value: core::ffi::c_uint,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFontAtlasBuildMultiplyCalcLookupTable(
-        out_table: *mut cty::c_uchar,
+        out_table: *mut core::ffi::c_uchar,
         in_multiply_factor: f32,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImFontAtlasBuildMultiplyRectAlpha8(
-        table: *const cty::c_uchar,
-        pixels: *mut cty::c_uchar,
-        x: cty::c_int,
-        y: cty::c_int,
-        w: cty::c_int,
-        h: cty::c_int,
-        stride: cty::c_int,
+        table: *const core::ffi::c_uchar,
+        pixels: *mut core::ffi::c_uchar,
+        x: core::ffi::c_int,
+        y: core::ffi::c_int,
+        w: core::ffi::c_int,
+        h: core::ffi::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -13485,19 +13598,26 @@ extern "C" {
 extern "C" {
     pub fn ImGuiFreeType_SetAllocatorFunctions(
         alloc_func: ::core::option::Option<
-            unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+            unsafe extern "C" fn(
+                sz: usize,
+                user_data: *mut core::ffi::c_void,
+            ) -> *mut core::ffi::c_void,
         >,
         free_func: ::core::option::Option<
-            unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+            unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
         >,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogText(fmt: *const cty::c_char, ...);
+    pub fn igLogText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_appendf(buffer: *mut ImGuiTextBuffer, fmt: *const cty::c_char, ...);
+    pub fn ImGuiTextBuffer_appendf(
+        buffer: *mut ImGuiTextBuffer,
+        fmt: *const core::ffi::c_char,
+        ...
+    );
 }

--- a/imgui-sys/src/wasm_freetype_bindings.rs
+++ b/imgui-sys/src/wasm_freetype_bindings.rs
@@ -97,64 +97,64 @@ pub struct ImFontBuilderIO {
 pub struct ImGuiContext {
     _unused: [u8; 0],
 }
-pub type ImGuiID = cty::c_uint;
-pub type ImS8 = cty::c_schar;
-pub type ImU8 = cty::c_uchar;
-pub type ImS16 = cty::c_short;
-pub type ImU16 = cty::c_ushort;
-pub type ImU32 = cty::c_uint;
-pub type ImS64 = cty::c_longlong;
-pub type ImGuiCol = cty::c_int;
-pub type ImGuiCond = cty::c_int;
-pub type ImGuiDataType = cty::c_int;
-pub type ImGuiMouseButton = cty::c_int;
-pub type ImGuiMouseCursor = cty::c_int;
-pub type ImGuiStyleVar = cty::c_int;
-pub type ImGuiTableBgTarget = cty::c_int;
-pub type ImDrawFlags = cty::c_int;
-pub type ImDrawListFlags = cty::c_int;
-pub type ImFontAtlasFlags = cty::c_int;
-pub type ImGuiBackendFlags = cty::c_int;
-pub type ImGuiButtonFlags = cty::c_int;
-pub type ImGuiChildFlags = cty::c_int;
-pub type ImGuiColorEditFlags = cty::c_int;
-pub type ImGuiConfigFlags = cty::c_int;
-pub type ImGuiComboFlags = cty::c_int;
-pub type ImGuiDragDropFlags = cty::c_int;
-pub type ImGuiFocusedFlags = cty::c_int;
-pub type ImGuiHoveredFlags = cty::c_int;
-pub type ImGuiInputFlags = cty::c_int;
-pub type ImGuiInputTextFlags = cty::c_int;
-pub type ImGuiItemFlags = cty::c_int;
-pub type ImGuiKeyChord = cty::c_int;
-pub type ImGuiPopupFlags = cty::c_int;
-pub type ImGuiMultiSelectFlags = cty::c_int;
-pub type ImGuiSelectableFlags = cty::c_int;
-pub type ImGuiSliderFlags = cty::c_int;
-pub type ImGuiTabBarFlags = cty::c_int;
-pub type ImGuiTabItemFlags = cty::c_int;
-pub type ImGuiTableFlags = cty::c_int;
-pub type ImGuiTableColumnFlags = cty::c_int;
-pub type ImGuiTableRowFlags = cty::c_int;
-pub type ImGuiTreeNodeFlags = cty::c_int;
-pub type ImGuiViewportFlags = cty::c_int;
-pub type ImGuiWindowFlags = cty::c_int;
-pub type ImTextureID = *mut cty::c_void;
-pub type ImDrawIdx = cty::c_ushort;
-pub type ImWchar32 = cty::c_uint;
-pub type ImWchar16 = cty::c_ushort;
+pub type ImGuiID = core::ffi::c_uint;
+pub type ImS8 = core::ffi::c_schar;
+pub type ImU8 = core::ffi::c_uchar;
+pub type ImS16 = core::ffi::c_short;
+pub type ImU16 = core::ffi::c_ushort;
+pub type ImU32 = core::ffi::c_uint;
+pub type ImS64 = core::ffi::c_longlong;
+pub type ImGuiCol = core::ffi::c_int;
+pub type ImGuiCond = core::ffi::c_int;
+pub type ImGuiDataType = core::ffi::c_int;
+pub type ImGuiMouseButton = core::ffi::c_int;
+pub type ImGuiMouseCursor = core::ffi::c_int;
+pub type ImGuiStyleVar = core::ffi::c_int;
+pub type ImGuiTableBgTarget = core::ffi::c_int;
+pub type ImDrawFlags = core::ffi::c_int;
+pub type ImDrawListFlags = core::ffi::c_int;
+pub type ImFontAtlasFlags = core::ffi::c_int;
+pub type ImGuiBackendFlags = core::ffi::c_int;
+pub type ImGuiButtonFlags = core::ffi::c_int;
+pub type ImGuiChildFlags = core::ffi::c_int;
+pub type ImGuiColorEditFlags = core::ffi::c_int;
+pub type ImGuiConfigFlags = core::ffi::c_int;
+pub type ImGuiComboFlags = core::ffi::c_int;
+pub type ImGuiDragDropFlags = core::ffi::c_int;
+pub type ImGuiFocusedFlags = core::ffi::c_int;
+pub type ImGuiHoveredFlags = core::ffi::c_int;
+pub type ImGuiInputFlags = core::ffi::c_int;
+pub type ImGuiInputTextFlags = core::ffi::c_int;
+pub type ImGuiItemFlags = core::ffi::c_int;
+pub type ImGuiKeyChord = core::ffi::c_int;
+pub type ImGuiPopupFlags = core::ffi::c_int;
+pub type ImGuiMultiSelectFlags = core::ffi::c_int;
+pub type ImGuiSelectableFlags = core::ffi::c_int;
+pub type ImGuiSliderFlags = core::ffi::c_int;
+pub type ImGuiTabBarFlags = core::ffi::c_int;
+pub type ImGuiTabItemFlags = core::ffi::c_int;
+pub type ImGuiTableFlags = core::ffi::c_int;
+pub type ImGuiTableColumnFlags = core::ffi::c_int;
+pub type ImGuiTableRowFlags = core::ffi::c_int;
+pub type ImGuiTreeNodeFlags = core::ffi::c_int;
+pub type ImGuiViewportFlags = core::ffi::c_int;
+pub type ImGuiWindowFlags = core::ffi::c_int;
+pub type ImTextureID = *mut core::ffi::c_void;
+pub type ImDrawIdx = core::ffi::c_ushort;
+pub type ImWchar32 = core::ffi::c_uint;
+pub type ImWchar16 = core::ffi::c_ushort;
 pub type ImWchar = ImWchar32;
 pub type ImGuiSelectionUserData = ImS64;
 pub type ImGuiInputTextCallback = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> cty::c_int,
+    unsafe extern "C" fn(data: *mut ImGuiInputTextCallbackData) -> core::ffi::c_int,
 >;
 pub type ImGuiSizeCallback =
     ::core::option::Option<unsafe extern "C" fn(data: *mut ImGuiSizeCallbackData)>;
 pub type ImGuiMemAllocFunc = ::core::option::Option<
-    unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+    unsafe extern "C" fn(sz: usize, user_data: *mut core::ffi::c_void) -> *mut core::ffi::c_void,
 >;
 pub type ImGuiMemFreeFunc = ::core::option::Option<
-    unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+    unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -198,7 +198,7 @@ pub const ImGuiWindowFlags_Tooltip: ImGuiWindowFlags_ = 33554432;
 pub const ImGuiWindowFlags_Popup: ImGuiWindowFlags_ = 67108864;
 pub const ImGuiWindowFlags_Modal: ImGuiWindowFlags_ = 134217728;
 pub const ImGuiWindowFlags_ChildMenu: ImGuiWindowFlags_ = 268435456;
-pub type ImGuiWindowFlags_ = cty::c_uint;
+pub type ImGuiWindowFlags_ = core::ffi::c_uint;
 pub const ImGuiChildFlags_None: ImGuiChildFlags_ = 0;
 pub const ImGuiChildFlags_Borders: ImGuiChildFlags_ = 1;
 pub const ImGuiChildFlags_AlwaysUseWindowPadding: ImGuiChildFlags_ = 2;
@@ -209,7 +209,7 @@ pub const ImGuiChildFlags_AutoResizeY: ImGuiChildFlags_ = 32;
 pub const ImGuiChildFlags_AlwaysAutoResize: ImGuiChildFlags_ = 64;
 pub const ImGuiChildFlags_FrameStyle: ImGuiChildFlags_ = 128;
 pub const ImGuiChildFlags_NavFlattened: ImGuiChildFlags_ = 256;
-pub type ImGuiChildFlags_ = cty::c_uint;
+pub type ImGuiChildFlags_ = core::ffi::c_uint;
 pub const ImGuiItemFlags_None: ImGuiItemFlags_ = 0;
 pub const ImGuiItemFlags_NoTabStop: ImGuiItemFlags_ = 1;
 pub const ImGuiItemFlags_NoNav: ImGuiItemFlags_ = 2;
@@ -217,7 +217,7 @@ pub const ImGuiItemFlags_NoNavDefaultFocus: ImGuiItemFlags_ = 4;
 pub const ImGuiItemFlags_ButtonRepeat: ImGuiItemFlags_ = 8;
 pub const ImGuiItemFlags_AutoClosePopups: ImGuiItemFlags_ = 16;
 pub const ImGuiItemFlags_AllowDuplicateId: ImGuiItemFlags_ = 32;
-pub type ImGuiItemFlags_ = cty::c_uint;
+pub type ImGuiItemFlags_ = core::ffi::c_uint;
 pub const ImGuiInputTextFlags_None: ImGuiInputTextFlags_ = 0;
 pub const ImGuiInputTextFlags_CharsDecimal: ImGuiInputTextFlags_ = 1;
 pub const ImGuiInputTextFlags_CharsHexadecimal: ImGuiInputTextFlags_ = 2;
@@ -242,7 +242,7 @@ pub const ImGuiInputTextFlags_CallbackAlways: ImGuiInputTextFlags_ = 524288;
 pub const ImGuiInputTextFlags_CallbackCharFilter: ImGuiInputTextFlags_ = 1048576;
 pub const ImGuiInputTextFlags_CallbackResize: ImGuiInputTextFlags_ = 2097152;
 pub const ImGuiInputTextFlags_CallbackEdit: ImGuiInputTextFlags_ = 4194304;
-pub type ImGuiInputTextFlags_ = cty::c_uint;
+pub type ImGuiInputTextFlags_ = core::ffi::c_uint;
 pub const ImGuiTreeNodeFlags_None: ImGuiTreeNodeFlags_ = 0;
 pub const ImGuiTreeNodeFlags_Selected: ImGuiTreeNodeFlags_ = 1;
 pub const ImGuiTreeNodeFlags_Framed: ImGuiTreeNodeFlags_ = 2;
@@ -261,7 +261,7 @@ pub const ImGuiTreeNodeFlags_SpanTextWidth: ImGuiTreeNodeFlags_ = 8192;
 pub const ImGuiTreeNodeFlags_SpanAllColumns: ImGuiTreeNodeFlags_ = 16384;
 pub const ImGuiTreeNodeFlags_NavLeftJumpsBackHere: ImGuiTreeNodeFlags_ = 32768;
 pub const ImGuiTreeNodeFlags_CollapsingHeader: ImGuiTreeNodeFlags_ = 26;
-pub type ImGuiTreeNodeFlags_ = cty::c_uint;
+pub type ImGuiTreeNodeFlags_ = core::ffi::c_uint;
 pub const ImGuiPopupFlags_None: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonLeft: ImGuiPopupFlags_ = 0;
 pub const ImGuiPopupFlags_MouseButtonRight: ImGuiPopupFlags_ = 1;
@@ -274,7 +274,7 @@ pub const ImGuiPopupFlags_NoOpenOverItems: ImGuiPopupFlags_ = 256;
 pub const ImGuiPopupFlags_AnyPopupId: ImGuiPopupFlags_ = 1024;
 pub const ImGuiPopupFlags_AnyPopupLevel: ImGuiPopupFlags_ = 2048;
 pub const ImGuiPopupFlags_AnyPopup: ImGuiPopupFlags_ = 3072;
-pub type ImGuiPopupFlags_ = cty::c_uint;
+pub type ImGuiPopupFlags_ = core::ffi::c_uint;
 pub const ImGuiSelectableFlags_None: ImGuiSelectableFlags_ = 0;
 pub const ImGuiSelectableFlags_NoAutoClosePopups: ImGuiSelectableFlags_ = 1;
 pub const ImGuiSelectableFlags_SpanAllColumns: ImGuiSelectableFlags_ = 2;
@@ -282,7 +282,7 @@ pub const ImGuiSelectableFlags_AllowDoubleClick: ImGuiSelectableFlags_ = 4;
 pub const ImGuiSelectableFlags_Disabled: ImGuiSelectableFlags_ = 8;
 pub const ImGuiSelectableFlags_AllowOverlap: ImGuiSelectableFlags_ = 16;
 pub const ImGuiSelectableFlags_Highlight: ImGuiSelectableFlags_ = 32;
-pub type ImGuiSelectableFlags_ = cty::c_uint;
+pub type ImGuiSelectableFlags_ = core::ffi::c_uint;
 pub const ImGuiComboFlags_None: ImGuiComboFlags_ = 0;
 pub const ImGuiComboFlags_PopupAlignLeft: ImGuiComboFlags_ = 1;
 pub const ImGuiComboFlags_HeightSmall: ImGuiComboFlags_ = 2;
@@ -293,7 +293,7 @@ pub const ImGuiComboFlags_NoArrowButton: ImGuiComboFlags_ = 32;
 pub const ImGuiComboFlags_NoPreview: ImGuiComboFlags_ = 64;
 pub const ImGuiComboFlags_WidthFitPreview: ImGuiComboFlags_ = 128;
 pub const ImGuiComboFlags_HeightMask_: ImGuiComboFlags_ = 30;
-pub type ImGuiComboFlags_ = cty::c_uint;
+pub type ImGuiComboFlags_ = core::ffi::c_uint;
 pub const ImGuiTabBarFlags_None: ImGuiTabBarFlags_ = 0;
 pub const ImGuiTabBarFlags_Reorderable: ImGuiTabBarFlags_ = 1;
 pub const ImGuiTabBarFlags_AutoSelectNewTabs: ImGuiTabBarFlags_ = 2;
@@ -306,7 +306,7 @@ pub const ImGuiTabBarFlags_FittingPolicyResizeDown: ImGuiTabBarFlags_ = 128;
 pub const ImGuiTabBarFlags_FittingPolicyScroll: ImGuiTabBarFlags_ = 256;
 pub const ImGuiTabBarFlags_FittingPolicyMask_: ImGuiTabBarFlags_ = 384;
 pub const ImGuiTabBarFlags_FittingPolicyDefault_: ImGuiTabBarFlags_ = 128;
-pub type ImGuiTabBarFlags_ = cty::c_uint;
+pub type ImGuiTabBarFlags_ = core::ffi::c_uint;
 pub const ImGuiTabItemFlags_None: ImGuiTabItemFlags_ = 0;
 pub const ImGuiTabItemFlags_UnsavedDocument: ImGuiTabItemFlags_ = 1;
 pub const ImGuiTabItemFlags_SetSelected: ImGuiTabItemFlags_ = 2;
@@ -317,14 +317,14 @@ pub const ImGuiTabItemFlags_NoReorder: ImGuiTabItemFlags_ = 32;
 pub const ImGuiTabItemFlags_Leading: ImGuiTabItemFlags_ = 64;
 pub const ImGuiTabItemFlags_Trailing: ImGuiTabItemFlags_ = 128;
 pub const ImGuiTabItemFlags_NoAssumedClosure: ImGuiTabItemFlags_ = 256;
-pub type ImGuiTabItemFlags_ = cty::c_uint;
+pub type ImGuiTabItemFlags_ = core::ffi::c_uint;
 pub const ImGuiFocusedFlags_None: ImGuiFocusedFlags_ = 0;
 pub const ImGuiFocusedFlags_ChildWindows: ImGuiFocusedFlags_ = 1;
 pub const ImGuiFocusedFlags_RootWindow: ImGuiFocusedFlags_ = 2;
 pub const ImGuiFocusedFlags_AnyWindow: ImGuiFocusedFlags_ = 4;
 pub const ImGuiFocusedFlags_NoPopupHierarchy: ImGuiFocusedFlags_ = 8;
 pub const ImGuiFocusedFlags_RootAndChildWindows: ImGuiFocusedFlags_ = 3;
-pub type ImGuiFocusedFlags_ = cty::c_uint;
+pub type ImGuiFocusedFlags_ = core::ffi::c_uint;
 pub const ImGuiHoveredFlags_None: ImGuiHoveredFlags_ = 0;
 pub const ImGuiHoveredFlags_ChildWindows: ImGuiHoveredFlags_ = 1;
 pub const ImGuiHoveredFlags_RootWindow: ImGuiHoveredFlags_ = 2;
@@ -345,7 +345,7 @@ pub const ImGuiHoveredFlags_DelayNone: ImGuiHoveredFlags_ = 16384;
 pub const ImGuiHoveredFlags_DelayShort: ImGuiHoveredFlags_ = 32768;
 pub const ImGuiHoveredFlags_DelayNormal: ImGuiHoveredFlags_ = 65536;
 pub const ImGuiHoveredFlags_NoSharedDelay: ImGuiHoveredFlags_ = 131072;
-pub type ImGuiHoveredFlags_ = cty::c_uint;
+pub type ImGuiHoveredFlags_ = core::ffi::c_uint;
 pub const ImGuiDragDropFlags_None: ImGuiDragDropFlags_ = 0;
 pub const ImGuiDragDropFlags_SourceNoPreviewTooltip: ImGuiDragDropFlags_ = 1;
 pub const ImGuiDragDropFlags_SourceNoDisableHover: ImGuiDragDropFlags_ = 2;
@@ -359,7 +359,7 @@ pub const ImGuiDragDropFlags_AcceptBeforeDelivery: ImGuiDragDropFlags_ = 1024;
 pub const ImGuiDragDropFlags_AcceptNoDrawDefaultRect: ImGuiDragDropFlags_ = 2048;
 pub const ImGuiDragDropFlags_AcceptNoPreviewTooltip: ImGuiDragDropFlags_ = 4096;
 pub const ImGuiDragDropFlags_AcceptPeekOnly: ImGuiDragDropFlags_ = 3072;
-pub type ImGuiDragDropFlags_ = cty::c_uint;
+pub type ImGuiDragDropFlags_ = core::ffi::c_uint;
 pub const ImGuiDataType_S8: ImGuiDataType_ = 0;
 pub const ImGuiDataType_U8: ImGuiDataType_ = 1;
 pub const ImGuiDataType_S16: ImGuiDataType_ = 2;
@@ -372,18 +372,18 @@ pub const ImGuiDataType_Float: ImGuiDataType_ = 8;
 pub const ImGuiDataType_Double: ImGuiDataType_ = 9;
 pub const ImGuiDataType_Bool: ImGuiDataType_ = 10;
 pub const ImGuiDataType_COUNT: ImGuiDataType_ = 11;
-pub type ImGuiDataType_ = cty::c_uint;
+pub type ImGuiDataType_ = core::ffi::c_uint;
 pub const ImGuiDir_None: ImGuiDir = -1;
 pub const ImGuiDir_Left: ImGuiDir = 0;
 pub const ImGuiDir_Right: ImGuiDir = 1;
 pub const ImGuiDir_Up: ImGuiDir = 2;
 pub const ImGuiDir_Down: ImGuiDir = 3;
 pub const ImGuiDir_COUNT: ImGuiDir = 4;
-pub type ImGuiDir = cty::c_int;
+pub type ImGuiDir = core::ffi::c_int;
 pub const ImGuiSortDirection_None: ImGuiSortDirection = 0;
 pub const ImGuiSortDirection_Ascending: ImGuiSortDirection = 1;
 pub const ImGuiSortDirection_Descending: ImGuiSortDirection = 2;
-pub type ImGuiSortDirection = cty::c_uint;
+pub type ImGuiSortDirection = core::ffi::c_uint;
 pub const ImGuiKey_None: ImGuiKey = 0;
 pub const ImGuiKey_Tab: ImGuiKey = 512;
 pub const ImGuiKey_LeftArrow: ImGuiKey = 513;
@@ -551,7 +551,7 @@ pub const ImGuiKey_NamedKey_END: ImGuiKey = 666;
 pub const ImGuiKey_NamedKey_COUNT: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_SIZE: ImGuiKey = 154;
 pub const ImGuiKey_KeysData_OFFSET: ImGuiKey = 512;
-pub type ImGuiKey = cty::c_uint;
+pub type ImGuiKey = core::ffi::c_uint;
 pub const ImGuiInputFlags_None: ImGuiInputFlags_ = 0;
 pub const ImGuiInputFlags_Repeat: ImGuiInputFlags_ = 1;
 pub const ImGuiInputFlags_RouteActive: ImGuiInputFlags_ = 1024;
@@ -563,7 +563,7 @@ pub const ImGuiInputFlags_RouteOverActive: ImGuiInputFlags_ = 32768;
 pub const ImGuiInputFlags_RouteUnlessBgFocused: ImGuiInputFlags_ = 65536;
 pub const ImGuiInputFlags_RouteFromRootWindow: ImGuiInputFlags_ = 131072;
 pub const ImGuiInputFlags_Tooltip: ImGuiInputFlags_ = 262144;
-pub type ImGuiInputFlags_ = cty::c_uint;
+pub type ImGuiInputFlags_ = core::ffi::c_uint;
 pub const ImGuiConfigFlags_None: ImGuiConfigFlags_ = 0;
 pub const ImGuiConfigFlags_NavEnableKeyboard: ImGuiConfigFlags_ = 1;
 pub const ImGuiConfigFlags_NavEnableGamepad: ImGuiConfigFlags_ = 2;
@@ -574,13 +574,13 @@ pub const ImGuiConfigFlags_NoMouseCursorChange: ImGuiConfigFlags_ = 32;
 pub const ImGuiConfigFlags_NoKeyboard: ImGuiConfigFlags_ = 64;
 pub const ImGuiConfigFlags_IsSRGB: ImGuiConfigFlags_ = 1048576;
 pub const ImGuiConfigFlags_IsTouchScreen: ImGuiConfigFlags_ = 2097152;
-pub type ImGuiConfigFlags_ = cty::c_uint;
+pub type ImGuiConfigFlags_ = core::ffi::c_uint;
 pub const ImGuiBackendFlags_None: ImGuiBackendFlags_ = 0;
 pub const ImGuiBackendFlags_HasGamepad: ImGuiBackendFlags_ = 1;
 pub const ImGuiBackendFlags_HasMouseCursors: ImGuiBackendFlags_ = 2;
 pub const ImGuiBackendFlags_HasSetMousePos: ImGuiBackendFlags_ = 4;
 pub const ImGuiBackendFlags_RendererHasVtxOffset: ImGuiBackendFlags_ = 8;
-pub type ImGuiBackendFlags_ = cty::c_uint;
+pub type ImGuiBackendFlags_ = core::ffi::c_uint;
 pub const ImGuiCol_Text: ImGuiCol_ = 0;
 pub const ImGuiCol_TextDisabled: ImGuiCol_ = 1;
 pub const ImGuiCol_WindowBg: ImGuiCol_ = 2;
@@ -638,7 +638,7 @@ pub const ImGuiCol_NavWindowingHighlight: ImGuiCol_ = 53;
 pub const ImGuiCol_NavWindowingDimBg: ImGuiCol_ = 54;
 pub const ImGuiCol_ModalWindowDimBg: ImGuiCol_ = 55;
 pub const ImGuiCol_COUNT: ImGuiCol_ = 56;
-pub type ImGuiCol_ = cty::c_uint;
+pub type ImGuiCol_ = core::ffi::c_uint;
 pub const ImGuiStyleVar_Alpha: ImGuiStyleVar_ = 0;
 pub const ImGuiStyleVar_DisabledAlpha: ImGuiStyleVar_ = 1;
 pub const ImGuiStyleVar_WindowPadding: ImGuiStyleVar_ = 2;
@@ -673,13 +673,13 @@ pub const ImGuiStyleVar_SeparatorTextBorderSize: ImGuiStyleVar_ = 30;
 pub const ImGuiStyleVar_SeparatorTextAlign: ImGuiStyleVar_ = 31;
 pub const ImGuiStyleVar_SeparatorTextPadding: ImGuiStyleVar_ = 32;
 pub const ImGuiStyleVar_COUNT: ImGuiStyleVar_ = 33;
-pub type ImGuiStyleVar_ = cty::c_uint;
+pub type ImGuiStyleVar_ = core::ffi::c_uint;
 pub const ImGuiButtonFlags_None: ImGuiButtonFlags_ = 0;
 pub const ImGuiButtonFlags_MouseButtonLeft: ImGuiButtonFlags_ = 1;
 pub const ImGuiButtonFlags_MouseButtonRight: ImGuiButtonFlags_ = 2;
 pub const ImGuiButtonFlags_MouseButtonMiddle: ImGuiButtonFlags_ = 4;
 pub const ImGuiButtonFlags_MouseButtonMask_: ImGuiButtonFlags_ = 7;
-pub type ImGuiButtonFlags_ = cty::c_uint;
+pub type ImGuiButtonFlags_ = core::ffi::c_uint;
 pub const ImGuiColorEditFlags_None: ImGuiColorEditFlags_ = 0;
 pub const ImGuiColorEditFlags_NoAlpha: ImGuiColorEditFlags_ = 2;
 pub const ImGuiColorEditFlags_NoPicker: ImGuiColorEditFlags_ = 4;
@@ -709,7 +709,7 @@ pub const ImGuiColorEditFlags_DisplayMask_: ImGuiColorEditFlags_ = 7340032;
 pub const ImGuiColorEditFlags_DataTypeMask_: ImGuiColorEditFlags_ = 25165824;
 pub const ImGuiColorEditFlags_PickerMask_: ImGuiColorEditFlags_ = 100663296;
 pub const ImGuiColorEditFlags_InputMask_: ImGuiColorEditFlags_ = 402653184;
-pub type ImGuiColorEditFlags_ = cty::c_uint;
+pub type ImGuiColorEditFlags_ = core::ffi::c_uint;
 pub const ImGuiSliderFlags_None: ImGuiSliderFlags_ = 0;
 pub const ImGuiSliderFlags_Logarithmic: ImGuiSliderFlags_ = 32;
 pub const ImGuiSliderFlags_NoRoundToFormat: ImGuiSliderFlags_ = 64;
@@ -719,12 +719,12 @@ pub const ImGuiSliderFlags_ClampOnInput: ImGuiSliderFlags_ = 512;
 pub const ImGuiSliderFlags_ClampZeroRange: ImGuiSliderFlags_ = 1024;
 pub const ImGuiSliderFlags_AlwaysClamp: ImGuiSliderFlags_ = 1536;
 pub const ImGuiSliderFlags_InvalidMask_: ImGuiSliderFlags_ = 1879048207;
-pub type ImGuiSliderFlags_ = cty::c_uint;
+pub type ImGuiSliderFlags_ = core::ffi::c_uint;
 pub const ImGuiMouseButton_Left: ImGuiMouseButton_ = 0;
 pub const ImGuiMouseButton_Right: ImGuiMouseButton_ = 1;
 pub const ImGuiMouseButton_Middle: ImGuiMouseButton_ = 2;
 pub const ImGuiMouseButton_COUNT: ImGuiMouseButton_ = 5;
-pub type ImGuiMouseButton_ = cty::c_uint;
+pub type ImGuiMouseButton_ = core::ffi::c_uint;
 pub const ImGuiMouseCursor_None: ImGuiMouseCursor_ = -1;
 pub const ImGuiMouseCursor_Arrow: ImGuiMouseCursor_ = 0;
 pub const ImGuiMouseCursor_TextInput: ImGuiMouseCursor_ = 1;
@@ -736,18 +736,18 @@ pub const ImGuiMouseCursor_ResizeNWSE: ImGuiMouseCursor_ = 6;
 pub const ImGuiMouseCursor_Hand: ImGuiMouseCursor_ = 7;
 pub const ImGuiMouseCursor_NotAllowed: ImGuiMouseCursor_ = 8;
 pub const ImGuiMouseCursor_COUNT: ImGuiMouseCursor_ = 9;
-pub type ImGuiMouseCursor_ = cty::c_int;
+pub type ImGuiMouseCursor_ = core::ffi::c_int;
 pub const ImGuiMouseSource_Mouse: ImGuiMouseSource = 0;
 pub const ImGuiMouseSource_TouchScreen: ImGuiMouseSource = 1;
 pub const ImGuiMouseSource_Pen: ImGuiMouseSource = 2;
 pub const ImGuiMouseSource_COUNT: ImGuiMouseSource = 3;
-pub type ImGuiMouseSource = cty::c_uint;
+pub type ImGuiMouseSource = core::ffi::c_uint;
 pub const ImGuiCond_None: ImGuiCond_ = 0;
 pub const ImGuiCond_Always: ImGuiCond_ = 1;
 pub const ImGuiCond_Once: ImGuiCond_ = 2;
 pub const ImGuiCond_FirstUseEver: ImGuiCond_ = 4;
 pub const ImGuiCond_Appearing: ImGuiCond_ = 8;
-pub type ImGuiCond_ = cty::c_uint;
+pub type ImGuiCond_ = core::ffi::c_uint;
 pub const ImGuiTableFlags_None: ImGuiTableFlags_ = 0;
 pub const ImGuiTableFlags_Resizable: ImGuiTableFlags_ = 1;
 pub const ImGuiTableFlags_Reorderable: ImGuiTableFlags_ = 2;
@@ -785,7 +785,7 @@ pub const ImGuiTableFlags_SortMulti: ImGuiTableFlags_ = 67108864;
 pub const ImGuiTableFlags_SortTristate: ImGuiTableFlags_ = 134217728;
 pub const ImGuiTableFlags_HighlightHoveredColumn: ImGuiTableFlags_ = 268435456;
 pub const ImGuiTableFlags_SizingMask_: ImGuiTableFlags_ = 57344;
-pub type ImGuiTableFlags_ = cty::c_uint;
+pub type ImGuiTableFlags_ = core::ffi::c_uint;
 pub const ImGuiTableColumnFlags_None: ImGuiTableColumnFlags_ = 0;
 pub const ImGuiTableColumnFlags_Disabled: ImGuiTableColumnFlags_ = 1;
 pub const ImGuiTableColumnFlags_DefaultHide: ImGuiTableColumnFlags_ = 2;
@@ -814,20 +814,20 @@ pub const ImGuiTableColumnFlags_WidthMask_: ImGuiTableColumnFlags_ = 24;
 pub const ImGuiTableColumnFlags_IndentMask_: ImGuiTableColumnFlags_ = 196608;
 pub const ImGuiTableColumnFlags_StatusMask_: ImGuiTableColumnFlags_ = 251658240;
 pub const ImGuiTableColumnFlags_NoDirectResize_: ImGuiTableColumnFlags_ = 1073741824;
-pub type ImGuiTableColumnFlags_ = cty::c_uint;
+pub type ImGuiTableColumnFlags_ = core::ffi::c_uint;
 pub const ImGuiTableRowFlags_None: ImGuiTableRowFlags_ = 0;
 pub const ImGuiTableRowFlags_Headers: ImGuiTableRowFlags_ = 1;
-pub type ImGuiTableRowFlags_ = cty::c_uint;
+pub type ImGuiTableRowFlags_ = core::ffi::c_uint;
 pub const ImGuiTableBgTarget_None: ImGuiTableBgTarget_ = 0;
 pub const ImGuiTableBgTarget_RowBg0: ImGuiTableBgTarget_ = 1;
 pub const ImGuiTableBgTarget_RowBg1: ImGuiTableBgTarget_ = 2;
 pub const ImGuiTableBgTarget_CellBg: ImGuiTableBgTarget_ = 3;
-pub type ImGuiTableBgTarget_ = cty::c_uint;
+pub type ImGuiTableBgTarget_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTableSortSpecs {
     pub Specs: *const ImGuiTableColumnSortSpecs,
-    pub SpecsCount: cty::c_int,
+    pub SpecsCount: core::ffi::c_int,
     pub SpecsDirty: bool,
 }
 impl Default for ImGuiTableSortSpecs {
@@ -933,8 +933,8 @@ pub struct ImGuiKeyData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImWchar {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImWchar,
 }
 impl Default for ImVector_ImWchar {
@@ -954,9 +954,9 @@ pub struct ImGuiIO {
     pub DisplaySize: ImVec2,
     pub DeltaTime: f32,
     pub IniSavingRate: f32,
-    pub IniFilename: *const cty::c_char,
-    pub LogFilename: *const cty::c_char,
-    pub UserData: *mut cty::c_void,
+    pub IniFilename: *const core::ffi::c_char,
+    pub LogFilename: *const core::ffi::c_char,
+    pub UserData: *mut core::ffi::c_void,
     pub Fonts: *mut ImFontAtlas,
     pub FontGlobalScale: f32,
     pub FontAllowUserScaling: bool,
@@ -988,11 +988,11 @@ pub struct ImGuiIO {
     pub ConfigDebugBeginReturnValueLoop: bool,
     pub ConfigDebugIgnoreFocusLoss: bool,
     pub ConfigDebugIniSettings: bool,
-    pub BackendPlatformName: *const cty::c_char,
-    pub BackendRendererName: *const cty::c_char,
-    pub BackendPlatformUserData: *mut cty::c_void,
-    pub BackendRendererUserData: *mut cty::c_void,
-    pub BackendLanguageUserData: *mut cty::c_void,
+    pub BackendPlatformName: *const core::ffi::c_char,
+    pub BackendRendererName: *const core::ffi::c_char,
+    pub BackendPlatformUserData: *mut core::ffi::c_void,
+    pub BackendRendererUserData: *mut core::ffi::c_void,
+    pub BackendLanguageUserData: *mut core::ffi::c_void,
     pub WantCaptureMouse: bool,
     pub WantCaptureKeyboard: bool,
     pub WantTextInput: bool,
@@ -1001,10 +1001,10 @@ pub struct ImGuiIO {
     pub NavActive: bool,
     pub NavVisible: bool,
     pub Framerate: f32,
-    pub MetricsRenderVertices: cty::c_int,
-    pub MetricsRenderIndices: cty::c_int,
-    pub MetricsRenderWindows: cty::c_int,
-    pub MetricsActiveWindows: cty::c_int,
+    pub MetricsRenderVertices: core::ffi::c_int,
+    pub MetricsRenderIndices: core::ffi::c_int,
+    pub MetricsRenderWindows: core::ffi::c_int,
+    pub MetricsActiveWindows: core::ffi::c_int,
     pub MouseDelta: ImVec2,
     pub Ctx: *mut ImGuiContext,
     pub MousePos: ImVec2,
@@ -1057,16 +1057,16 @@ pub struct ImGuiInputTextCallbackData {
     pub Ctx: *mut ImGuiContext,
     pub EventFlag: ImGuiInputTextFlags,
     pub Flags: ImGuiInputTextFlags,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub EventChar: ImWchar,
     pub EventKey: ImGuiKey,
-    pub Buf: *mut cty::c_char,
-    pub BufTextLen: cty::c_int,
-    pub BufSize: cty::c_int,
+    pub Buf: *mut core::ffi::c_char,
+    pub BufTextLen: core::ffi::c_int,
+    pub BufSize: core::ffi::c_int,
     pub BufDirty: bool,
-    pub CursorPos: cty::c_int,
-    pub SelectionStart: cty::c_int,
-    pub SelectionEnd: cty::c_int,
+    pub CursorPos: core::ffi::c_int,
+    pub SelectionStart: core::ffi::c_int,
+    pub SelectionEnd: core::ffi::c_int,
 }
 impl Default for ImGuiInputTextCallbackData {
     fn default() -> Self {
@@ -1080,7 +1080,7 @@ impl Default for ImGuiInputTextCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiSizeCallbackData {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub Pos: ImVec2,
     pub CurrentSize: ImVec2,
     pub DesiredSize: ImVec2,
@@ -1097,12 +1097,12 @@ impl Default for ImGuiSizeCallbackData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPayload {
-    pub Data: *mut cty::c_void,
-    pub DataSize: cty::c_int,
+    pub Data: *mut core::ffi::c_void,
+    pub DataSize: core::ffi::c_int,
     pub SourceId: ImGuiID,
     pub SourceParentId: ImGuiID,
-    pub DataFrameCount: cty::c_int,
-    pub DataType: [cty::c_char; 33usize],
+    pub DataFrameCount: core::ffi::c_int,
+    pub DataType: [core::ffi::c_char; 33usize],
     pub Preview: bool,
     pub Delivery: bool,
 }
@@ -1118,13 +1118,13 @@ impl Default for ImGuiPayload {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiOnceUponAFrame {
-    pub RefFrame: cty::c_int,
+    pub RefFrame: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextRange {
-    pub b: *const cty::c_char,
-    pub e: *const cty::c_char,
+    pub b: *const core::ffi::c_char,
+    pub e: *const core::ffi::c_char,
 }
 impl Default for ImGuiTextRange {
     fn default() -> Self {
@@ -1138,8 +1138,8 @@ impl Default for ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiTextRange {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiTextRange,
 }
 impl Default for ImVector_ImGuiTextRange {
@@ -1154,9 +1154,9 @@ impl Default for ImVector_ImGuiTextRange {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiTextFilter {
-    pub InputBuf: [cty::c_char; 256usize],
+    pub InputBuf: [core::ffi::c_char; 256usize],
     pub Filters: ImVector_ImGuiTextRange,
-    pub CountGrep: cty::c_int,
+    pub CountGrep: core::ffi::c_int,
 }
 impl Default for ImGuiTextFilter {
     fn default() -> Self {
@@ -1170,9 +1170,9 @@ impl Default for ImGuiTextFilter {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_char {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
-    pub Data: *mut cty::c_char,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
+    pub Data: *mut core::ffi::c_char,
 }
 impl Default for ImVector_char {
     fn default() -> Self {
@@ -1206,9 +1206,9 @@ pub struct ImGuiStoragePair {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ImGuiStoragePair__bindgen_ty_1 {
-    pub val_i: cty::c_int,
+    pub val_i: core::ffi::c_int,
     pub val_f: f32,
-    pub val_p: *mut cty::c_void,
+    pub val_p: *mut core::ffi::c_void,
 }
 impl Default for ImGuiStoragePair__bindgen_ty_1 {
     fn default() -> Self {
@@ -1245,8 +1245,8 @@ impl ::core::fmt::Debug for ImGuiStoragePair {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiStoragePair {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiStoragePair,
 }
 impl Default for ImVector_ImGuiStoragePair {
@@ -1276,13 +1276,13 @@ impl Default for ImGuiStorage {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiListClipper {
     pub Ctx: *mut ImGuiContext,
-    pub DisplayStart: cty::c_int,
-    pub DisplayEnd: cty::c_int,
-    pub ItemsCount: cty::c_int,
+    pub DisplayStart: core::ffi::c_int,
+    pub DisplayEnd: core::ffi::c_int,
+    pub ItemsCount: core::ffi::c_int,
     pub ItemsHeight: f32,
     pub StartPosY: f32,
     pub StartSeekOffsetY: f64,
-    pub TempData: *mut cty::c_void,
+    pub TempData: *mut core::ffi::c_void,
 }
 impl Default for ImGuiListClipper {
     fn default() -> Self {
@@ -1315,12 +1315,12 @@ pub const ImGuiMultiSelectFlags_ScopeRect: ImGuiMultiSelectFlags_ = 4096;
 pub const ImGuiMultiSelectFlags_SelectOnClick: ImGuiMultiSelectFlags_ = 8192;
 pub const ImGuiMultiSelectFlags_SelectOnClickRelease: ImGuiMultiSelectFlags_ = 16384;
 pub const ImGuiMultiSelectFlags_NavWrapX: ImGuiMultiSelectFlags_ = 65536;
-pub type ImGuiMultiSelectFlags_ = cty::c_uint;
+pub type ImGuiMultiSelectFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImGuiSelectionRequest {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImGuiSelectionRequest,
 }
 impl Default for ImVector_ImGuiSelectionRequest {
@@ -1340,7 +1340,7 @@ pub struct ImGuiMultiSelectIO {
     pub NavIdItem: ImGuiSelectionUserData,
     pub NavIdSelected: bool,
     pub RangeSrcReset: bool,
-    pub ItemsCount: cty::c_int,
+    pub ItemsCount: core::ffi::c_int,
 }
 impl Default for ImGuiMultiSelectIO {
     fn default() -> Self {
@@ -1354,7 +1354,7 @@ impl Default for ImGuiMultiSelectIO {
 pub const ImGuiSelectionRequestType_None: ImGuiSelectionRequestType = 0;
 pub const ImGuiSelectionRequestType_SetAll: ImGuiSelectionRequestType = 1;
 pub const ImGuiSelectionRequestType_SetRange: ImGuiSelectionRequestType = 2;
-pub type ImGuiSelectionRequestType = cty::c_uint;
+pub type ImGuiSelectionRequestType = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionRequest {
@@ -1376,13 +1376,16 @@ impl Default for ImGuiSelectionRequest {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionBasicStorage {
-    pub Size: cty::c_int,
+    pub Size: core::ffi::c_int,
     pub PreserveOrder: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterIndexToStorageId: ::core::option::Option<
-        unsafe extern "C" fn(self_: *mut ImGuiSelectionBasicStorage, idx: cty::c_int) -> ImGuiID,
+        unsafe extern "C" fn(
+            self_: *mut ImGuiSelectionBasicStorage,
+            idx: core::ffi::c_int,
+        ) -> ImGuiID,
     >,
-    pub _SelectionOrder: cty::c_int,
+    pub _SelectionOrder: core::ffi::c_int,
     pub _Storage: ImGuiStorage,
 }
 impl Default for ImGuiSelectionBasicStorage {
@@ -1397,11 +1400,11 @@ impl Default for ImGuiSelectionBasicStorage {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiSelectionExternalStorage {
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub AdapterSetItemSelected: ::core::option::Option<
         unsafe extern "C" fn(
             self_: *mut ImGuiSelectionExternalStorage,
-            idx: cty::c_int,
+            idx: core::ffi::c_int,
             selected: bool,
         ),
     >,
@@ -1423,11 +1426,11 @@ pub type ImDrawCallback = ::core::option::Option<
 pub struct ImDrawCmd {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
-    pub IdxOffset: cty::c_uint,
-    pub ElemCount: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
+    pub IdxOffset: core::ffi::c_uint,
+    pub ElemCount: core::ffi::c_uint,
     pub UserCallback: ImDrawCallback,
-    pub UserCallbackData: *mut cty::c_void,
+    pub UserCallbackData: *mut core::ffi::c_void,
 }
 impl Default for ImDrawCmd {
     fn default() -> Self {
@@ -1450,7 +1453,7 @@ pub struct ImDrawVert {
 pub struct ImDrawCmdHeader {
     pub ClipRect: ImVec4,
     pub TextureId: ImTextureID,
-    pub VtxOffset: cty::c_uint,
+    pub VtxOffset: core::ffi::c_uint,
 }
 impl Default for ImDrawCmdHeader {
     fn default() -> Self {
@@ -1464,8 +1467,8 @@ impl Default for ImDrawCmdHeader {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawCmd {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawCmd,
 }
 impl Default for ImVector_ImDrawCmd {
@@ -1480,8 +1483,8 @@ impl Default for ImVector_ImDrawCmd {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawIdx {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawIdx,
 }
 impl Default for ImVector_ImDrawIdx {
@@ -1511,8 +1514,8 @@ impl Default for ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawChannel {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawChannel,
 }
 impl Default for ImVector_ImDrawChannel {
@@ -1527,8 +1530,8 @@ impl Default for ImVector_ImDrawChannel {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImDrawListSplitter {
-    pub _Current: cty::c_int,
-    pub _Count: cty::c_int,
+    pub _Current: core::ffi::c_int,
+    pub _Count: core::ffi::c_int,
     pub _Channels: ImVector_ImDrawChannel,
 }
 impl Default for ImDrawListSplitter {
@@ -1554,18 +1557,18 @@ pub const ImDrawFlags_RoundCornersRight: ImDrawFlags_ = 160;
 pub const ImDrawFlags_RoundCornersAll: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersDefault_: ImDrawFlags_ = 240;
 pub const ImDrawFlags_RoundCornersMask_: ImDrawFlags_ = 496;
-pub type ImDrawFlags_ = cty::c_uint;
+pub type ImDrawFlags_ = core::ffi::c_uint;
 pub const ImDrawListFlags_None: ImDrawListFlags_ = 0;
 pub const ImDrawListFlags_AntiAliasedLines: ImDrawListFlags_ = 1;
 pub const ImDrawListFlags_AntiAliasedLinesUseTex: ImDrawListFlags_ = 2;
 pub const ImDrawListFlags_AntiAliasedFill: ImDrawListFlags_ = 4;
 pub const ImDrawListFlags_AllowVtxOffset: ImDrawListFlags_ = 8;
-pub type ImDrawListFlags_ = cty::c_uint;
+pub type ImDrawListFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawVert {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImDrawVert,
 }
 impl Default for ImVector_ImDrawVert {
@@ -1580,8 +1583,8 @@ impl Default for ImVector_ImDrawVert {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec2 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec2,
 }
 impl Default for ImVector_ImVec2 {
@@ -1596,8 +1599,8 @@ impl Default for ImVector_ImVec2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImVec4 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImVec4,
 }
 impl Default for ImVector_ImVec4 {
@@ -1612,8 +1615,8 @@ impl Default for ImVector_ImVec4 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImTextureID {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImTextureID,
 }
 impl Default for ImVector_ImTextureID {
@@ -1632,7 +1635,7 @@ pub struct ImDrawList {
     pub IdxBuffer: ImVector_ImDrawIdx,
     pub VtxBuffer: ImVector_ImDrawVert,
     pub Flags: ImDrawListFlags,
-    pub _VtxCurrentIdx: cty::c_uint,
+    pub _VtxCurrentIdx: core::ffi::c_uint,
     pub _Data: *mut ImDrawListSharedData,
     pub _VtxWritePtr: *mut ImDrawVert,
     pub _IdxWritePtr: *mut ImDrawIdx,
@@ -1642,7 +1645,7 @@ pub struct ImDrawList {
     pub _ClipRectStack: ImVector_ImVec4,
     pub _TextureIdStack: ImVector_ImTextureID,
     pub _FringeScale: f32,
-    pub _OwnerName: *const cty::c_char,
+    pub _OwnerName: *const core::ffi::c_char,
 }
 impl Default for ImDrawList {
     fn default() -> Self {
@@ -1656,8 +1659,8 @@ impl Default for ImDrawList {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImDrawListPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImDrawList,
 }
 impl Default for ImVector_ImDrawListPtr {
@@ -1673,9 +1676,9 @@ impl Default for ImVector_ImDrawListPtr {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImDrawData {
     pub Valid: bool,
-    pub CmdListsCount: cty::c_int,
-    pub TotalIdxCount: cty::c_int,
-    pub TotalVtxCount: cty::c_int,
+    pub CmdListsCount: core::ffi::c_int,
+    pub TotalIdxCount: core::ffi::c_int,
+    pub TotalVtxCount: core::ffi::c_int,
     pub CmdLists: ImVector_ImDrawListPtr,
     pub DisplayPos: ImVec2,
     pub DisplaySize: ImVec2,
@@ -1694,13 +1697,13 @@ impl Default for ImDrawData {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontConfig {
-    pub FontData: *mut cty::c_void,
-    pub FontDataSize: cty::c_int,
+    pub FontData: *mut core::ffi::c_void,
+    pub FontDataSize: core::ffi::c_int,
     pub FontDataOwnedByAtlas: bool,
-    pub FontNo: cty::c_int,
+    pub FontNo: core::ffi::c_int,
     pub SizePixels: f32,
-    pub OversampleH: cty::c_int,
-    pub OversampleV: cty::c_int,
+    pub OversampleH: core::ffi::c_int,
+    pub OversampleV: core::ffi::c_int,
     pub PixelSnapH: bool,
     pub GlyphExtraSpacing: ImVec2,
     pub GlyphOffset: ImVec2,
@@ -1708,11 +1711,11 @@ pub struct ImFontConfig {
     pub GlyphMinAdvanceX: f32,
     pub GlyphMaxAdvanceX: f32,
     pub MergeMode: bool,
-    pub FontBuilderFlags: cty::c_uint,
+    pub FontBuilderFlags: core::ffi::c_uint,
     pub RasterizerMultiply: f32,
     pub RasterizerDensity: f32,
     pub EllipsisChar: ImWchar,
-    pub Name: [cty::c_char; 40usize],
+    pub Name: [core::ffi::c_char; 40usize],
     pub DstFont: *mut ImFont,
 }
 impl Default for ImFontConfig {
@@ -1741,33 +1744,33 @@ pub struct ImFontGlyph {
 }
 impl ImFontGlyph {
     #[inline]
-    pub fn Colored(&self) -> cty::c_uint {
+    pub fn Colored(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Colored(&mut self, val: cty::c_uint) {
+    pub fn set_Colored(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Visible(&self) -> cty::c_uint {
+    pub fn Visible(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_Visible(&mut self, val: cty::c_uint) {
+    pub fn set_Visible(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(1usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn Codepoint(&self) -> cty::c_uint {
+    pub fn Codepoint(&self) -> core::ffi::c_uint {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
     }
     #[inline]
-    pub fn set_Codepoint(&mut self, val: cty::c_uint) {
+    pub fn set_Codepoint(&mut self, val: core::ffi::c_uint) {
         unsafe {
             let val: u32 = ::core::mem::transmute(val);
             self._bitfield_1.set(2usize, 30u8, val as u64)
@@ -1775,9 +1778,9 @@ impl ImFontGlyph {
     }
     #[inline]
     pub fn new_bitfield_1(
-        Colored: cty::c_uint,
-        Visible: cty::c_uint,
-        Codepoint: cty::c_uint,
+        Colored: core::ffi::c_uint,
+        Visible: core::ffi::c_uint,
+        Codepoint: core::ffi::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1798,8 +1801,8 @@ impl ImFontGlyph {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImU32 {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImU32,
 }
 impl Default for ImVector_ImU32 {
@@ -1828,11 +1831,11 @@ impl Default for ImFontGlyphRangesBuilder {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImFontAtlasCustomRect {
-    pub Width: cty::c_ushort,
-    pub Height: cty::c_ushort,
-    pub X: cty::c_ushort,
-    pub Y: cty::c_ushort,
-    pub GlyphID: cty::c_uint,
+    pub Width: core::ffi::c_ushort,
+    pub Height: core::ffi::c_ushort,
+    pub X: core::ffi::c_ushort,
+    pub Y: core::ffi::c_ushort,
+    pub GlyphID: core::ffi::c_uint,
     pub GlyphAdvanceX: f32,
     pub GlyphOffset: ImVec2,
     pub Font: *mut ImFont,
@@ -1850,12 +1853,12 @@ pub const ImFontAtlasFlags_None: ImFontAtlasFlags_ = 0;
 pub const ImFontAtlasFlags_NoPowerOfTwoHeight: ImFontAtlasFlags_ = 1;
 pub const ImFontAtlasFlags_NoMouseCursors: ImFontAtlasFlags_ = 2;
 pub const ImFontAtlasFlags_NoBakedLines: ImFontAtlasFlags_ = 4;
-pub type ImFontAtlasFlags_ = cty::c_uint;
+pub type ImFontAtlasFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontPtr {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut *mut ImFont,
 }
 impl Default for ImVector_ImFontPtr {
@@ -1870,8 +1873,8 @@ impl Default for ImVector_ImFontPtr {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontAtlasCustomRect {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontAtlasCustomRect,
 }
 impl Default for ImVector_ImFontAtlasCustomRect {
@@ -1886,8 +1889,8 @@ impl Default for ImVector_ImFontAtlasCustomRect {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontConfig {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontConfig,
 }
 impl Default for ImVector_ImFontConfig {
@@ -1904,16 +1907,16 @@ impl Default for ImVector_ImFontConfig {
 pub struct ImFontAtlas {
     pub Flags: ImFontAtlasFlags,
     pub TexID: ImTextureID,
-    pub TexDesiredWidth: cty::c_int,
-    pub TexGlyphPadding: cty::c_int,
+    pub TexDesiredWidth: core::ffi::c_int,
+    pub TexGlyphPadding: core::ffi::c_int,
     pub Locked: bool,
-    pub UserData: *mut cty::c_void,
+    pub UserData: *mut core::ffi::c_void,
     pub TexReady: bool,
     pub TexPixelsUseColors: bool,
-    pub TexPixelsAlpha8: *mut cty::c_uchar,
-    pub TexPixelsRGBA32: *mut cty::c_uint,
-    pub TexWidth: cty::c_int,
-    pub TexHeight: cty::c_int,
+    pub TexPixelsAlpha8: *mut core::ffi::c_uchar,
+    pub TexPixelsRGBA32: *mut core::ffi::c_uint,
+    pub TexWidth: core::ffi::c_int,
+    pub TexHeight: core::ffi::c_int,
     pub TexUvScale: ImVec2,
     pub TexUvWhitePixel: ImVec2,
     pub Fonts: ImVector_ImFontPtr,
@@ -1921,9 +1924,9 @@ pub struct ImFontAtlas {
     pub ConfigData: ImVector_ImFontConfig,
     pub TexUvLines: [ImVec4; 64usize],
     pub FontBuilderIO: *const ImFontBuilderIO,
-    pub FontBuilderFlags: cty::c_uint,
-    pub PackIdMouseCursors: cty::c_int,
-    pub PackIdLines: cty::c_int,
+    pub FontBuilderFlags: core::ffi::c_uint,
+    pub PackIdMouseCursors: core::ffi::c_int,
+    pub PackIdLines: core::ffi::c_int,
 }
 impl Default for ImFontAtlas {
     fn default() -> Self {
@@ -1937,8 +1940,8 @@ impl Default for ImFontAtlas {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_float {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut f32,
 }
 impl Default for ImVector_float {
@@ -1953,8 +1956,8 @@ impl Default for ImVector_float {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImVector_ImFontGlyph {
-    pub Size: cty::c_int,
-    pub Capacity: cty::c_int,
+    pub Size: core::ffi::c_int,
+    pub Capacity: core::ffi::c_int,
     pub Data: *mut ImFontGlyph,
 }
 impl Default for ImVector_ImFontGlyph {
@@ -1977,17 +1980,17 @@ pub struct ImFont {
     pub FallbackGlyph: *const ImFontGlyph,
     pub ContainerAtlas: *mut ImFontAtlas,
     pub ConfigData: *const ImFontConfig,
-    pub ConfigDataCount: cty::c_short,
+    pub ConfigDataCount: core::ffi::c_short,
     pub FallbackChar: ImWchar,
     pub EllipsisChar: ImWchar,
-    pub EllipsisCharCount: cty::c_short,
+    pub EllipsisCharCount: core::ffi::c_short,
     pub EllipsisWidth: f32,
     pub EllipsisCharStep: f32,
     pub DirtyLookupTables: bool,
     pub Scale: f32,
     pub Ascent: f32,
     pub Descent: f32,
-    pub MetricsTotalSurface: cty::c_int,
+    pub MetricsTotalSurface: core::ffi::c_int,
     pub Used4kPagesMap: [ImU8; 34usize],
 }
 impl Default for ImFont {
@@ -2003,7 +2006,7 @@ pub const ImGuiViewportFlags_None: ImGuiViewportFlags_ = 0;
 pub const ImGuiViewportFlags_IsPlatformWindow: ImGuiViewportFlags_ = 1;
 pub const ImGuiViewportFlags_IsPlatformMonitor: ImGuiViewportFlags_ = 2;
 pub const ImGuiViewportFlags_OwnedByApp: ImGuiViewportFlags_ = 4;
-pub type ImGuiViewportFlags_ = cty::c_uint;
+pub type ImGuiViewportFlags_ = core::ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ImGuiViewport {
@@ -2013,8 +2016,8 @@ pub struct ImGuiViewport {
     pub Size: ImVec2,
     pub WorkPos: ImVec2,
     pub WorkSize: ImVec2,
-    pub PlatformHandle: *mut cty::c_void,
-    pub PlatformHandleRaw: *mut cty::c_void,
+    pub PlatformHandle: *mut core::ffi::c_void,
+    pub PlatformHandleRaw: *mut core::ffi::c_void,
 }
 impl Default for ImGuiViewport {
     fn default() -> Self {
@@ -2028,16 +2031,17 @@ impl Default for ImGuiViewport {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ImGuiPlatformIO {
-    pub Platform_GetClipboardTextFn:
-        ::core::option::Option<unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const cty::c_char>,
+    pub Platform_GetClipboardTextFn: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ImGuiContext) -> *const core::ffi::c_char,
+    >,
     pub Platform_SetClipboardTextFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const cty::c_char),
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, text: *const core::ffi::c_char),
     >,
-    pub Platform_ClipboardUserData: *mut cty::c_void,
+    pub Platform_ClipboardUserData: *mut core::ffi::c_void,
     pub Platform_OpenInShellFn: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const cty::c_char) -> bool,
+        unsafe extern "C" fn(ctx: *mut ImGuiContext, path: *const core::ffi::c_char) -> bool,
     >,
-    pub Platform_OpenInShellUserData: *mut cty::c_void,
+    pub Platform_OpenInShellUserData: *mut core::ffi::c_void,
     pub Platform_SetImeDataFn: ::core::option::Option<
         unsafe extern "C" fn(
             ctx: *mut ImGuiContext,
@@ -2045,7 +2049,7 @@ pub struct ImGuiPlatformIO {
             data: *mut ImGuiPlatformImeData,
         ),
     >,
-    pub Platform_ImeUserData: *mut cty::c_void,
+    pub Platform_ImeUserData: *mut core::ffi::c_void,
     pub Platform_LocaleDecimalPoint: ImWchar,
 }
 impl Default for ImGuiPlatformIO {
@@ -2074,7 +2078,7 @@ pub const ImGuiFreeTypeBuilderFlags_Oblique: ImGuiFreeTypeBuilderFlags = 64;
 pub const ImGuiFreeTypeBuilderFlags_Monochrome: ImGuiFreeTypeBuilderFlags = 128;
 pub const ImGuiFreeTypeBuilderFlags_LoadColor: ImGuiFreeTypeBuilderFlags = 256;
 pub const ImGuiFreeTypeBuilderFlags_Bitmap: ImGuiFreeTypeBuilderFlags = 512;
-pub type ImGuiFreeTypeBuilderFlags = cty::c_uint;
+pub type ImGuiFreeTypeBuilderFlags = core::ffi::c_uint;
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImVec2_ImVec2_Nil() -> *mut ImVec2;
@@ -2169,11 +2173,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShowStyleSelector(label: *const cty::c_char) -> bool;
+    pub fn igShowStyleSelector(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igShowFontSelector(label: *const cty::c_char);
+    pub fn igShowFontSelector(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2181,7 +2185,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetVersion() -> *const cty::c_char;
+    pub fn igGetVersion() -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2197,7 +2201,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBegin(name: *const cty::c_char, p_open: *mut bool, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBegin(
+        name: *const core::ffi::c_char,
+        p_open: *mut bool,
+        flags: ImGuiWindowFlags,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2206,7 +2214,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginChild_Str(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         child_flags: ImGuiChildFlags,
         window_flags: ImGuiWindowFlags,
@@ -2275,7 +2283,7 @@ extern "C" {
         size_min: ImVec2,
         size_max: ImVec2,
         custom_callback: ImGuiSizeCallback,
-        custom_callback_data: *mut cty::c_void,
+        custom_callback_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -2320,19 +2328,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowPos_Str(name: *const cty::c_char, pos: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowPos_Str(name: *const core::ffi::c_char, pos: ImVec2, cond: ImGuiCond);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowSize_Str(name: *const cty::c_char, size: ImVec2, cond: ImGuiCond);
+    pub fn igSetWindowSize_Str(name: *const core::ffi::c_char, size: ImVec2, cond: ImGuiCond);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowCollapsed_Str(name: *const cty::c_char, collapsed: bool, cond: ImGuiCond);
+    pub fn igSetWindowCollapsed_Str(
+        name: *const core::ffi::c_char,
+        collapsed: bool,
+        cond: ImGuiCond,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetWindowFocus_Str(name: *const cty::c_char);
+    pub fn igSetWindowFocus_Str(name: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2392,7 +2404,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPopStyleColor(count: cty::c_int);
+    pub fn igPopStyleColor(count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2412,7 +2424,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPopStyleVar(count: cty::c_int);
+    pub fn igPopStyleVar(count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2572,19 +2584,22 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Str(str_id: *const cty::c_char);
+    pub fn igPushID_Str(str_id: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_StrStr(str_id_begin: *const cty::c_char, str_id_end: *const cty::c_char);
+    pub fn igPushID_StrStr(
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Ptr(ptr_id: *const cty::c_void);
+    pub fn igPushID_Ptr(ptr_id: *const core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igPushID_Int(int_id: cty::c_int);
+    pub fn igPushID_Int(int_id: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2592,110 +2607,110 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Str(str_id: *const cty::c_char) -> ImGuiID;
+    pub fn igGetID_Str(str_id: *const core::ffi::c_char) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igGetID_StrStr(
-        str_id_begin: *const cty::c_char,
-        str_id_end: *const cty::c_char,
+        str_id_begin: *const core::ffi::c_char,
+        str_id_end: *const core::ffi::c_char,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Ptr(ptr_id: *const cty::c_void) -> ImGuiID;
+    pub fn igGetID_Ptr(ptr_id: *const core::ffi::c_void) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetID_Int(int_id: cty::c_int) -> ImGuiID;
+    pub fn igGetID_Int(int_id: core::ffi::c_int) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextUnformatted(text: *const cty::c_char, text_end: *const cty::c_char);
+    pub fn igTextUnformatted(text: *const core::ffi::c_char, text_end: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igText(fmt: *const cty::c_char, ...);
+    pub fn igText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextColored(col: ImVec4, fmt: *const cty::c_char, ...);
+    pub fn igTextColored(col: ImVec4, fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextDisabled(fmt: *const cty::c_char, ...);
+    pub fn igTextDisabled(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextWrapped(fmt: *const cty::c_char, ...);
+    pub fn igTextWrapped(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLabelText(label: *const cty::c_char, fmt: *const cty::c_char, ...);
+    pub fn igLabelText(label: *const core::ffi::c_char, fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBulletText(fmt: *const cty::c_char, ...);
+    pub fn igBulletText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSeparatorText(label: *const cty::c_char);
+    pub fn igSeparatorText(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igButton(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igButton(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSmallButton(label: *const cty::c_char) -> bool;
+    pub fn igSmallButton(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInvisibleButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         size: ImVec2,
         flags: ImGuiButtonFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igArrowButton(str_id: *const cty::c_char, dir: ImGuiDir) -> bool;
+    pub fn igArrowButton(str_id: *const core::ffi::c_char, dir: ImGuiDir) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igCheckbox(label: *const cty::c_char, v: *mut bool) -> bool;
+    pub fn igCheckbox(label: *const core::ffi::c_char, v: *mut bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_IntPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_int,
-        flags_value: cty::c_int,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_int,
+        flags_value: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCheckboxFlags_UintPtr(
-        label: *const cty::c_char,
-        flags: *mut cty::c_uint,
-        flags_value: cty::c_uint,
+        label: *const core::ffi::c_char,
+        flags: *mut core::ffi::c_uint,
+        flags_value: core::ffi::c_uint,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igRadioButton_Bool(label: *const cty::c_char, active: bool) -> bool;
+    pub fn igRadioButton_Bool(label: *const core::ffi::c_char, active: bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igRadioButton_IntPtr(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_button: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_button: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const cty::c_char);
+    pub fn igProgressBar(fraction: f32, size_arg: ImVec2, overlay: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2703,11 +2718,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextLink(label: *const cty::c_char) -> bool;
+    pub fn igTextLink(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTextLinkOpenURL(label: *const cty::c_char, url: *const cty::c_char);
+    pub fn igTextLinkOpenURL(label: *const core::ffi::c_char, url: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -2723,7 +2738,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igImageButton(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         user_texture_id: ImTextureID,
         image_size: ImVec2,
         uv0: ImVec2,
@@ -2735,8 +2750,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginCombo(
-        label: *const cty::c_char,
-        preview_value: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        preview_value: *const core::ffi::c_char,
         flags: ImGuiComboFlags,
     ) -> bool;
 }
@@ -2747,497 +2762,497 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_Str(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items_separated_by_zeros: *const cty::c_char,
-        popup_max_height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items_separated_by_zeros: *const core::ffi::c_char,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCombo_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        popup_max_height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        popup_max_height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragFloatRange2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_current_min: *mut f32,
         v_current_max: *mut f32,
         v_speed: f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragIntRange2(
-        label: *const cty::c_char,
-        v_current_min: *mut cty::c_int,
-        v_current_max: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v_current_min: *mut core::ffi::c_int,
+        v_current_max: *mut core::ffi::c_int,
         v_speed: f32,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
-        format_max: *const cty::c_char,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
+        format_max: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
+        p_data: *mut core::ffi::c_void,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDragScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
         v_speed: f32,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderAngle(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v_rad: *mut f32,
         v_degrees_min: f32,
         v_degrees_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSliderScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         v: *mut f32,
         v_min: f32,
         v_max: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderInt(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
-        v: *mut cty::c_int,
-        v_min: cty::c_int,
-        v_max: cty::c_int,
-        format: *const cty::c_char,
+        v: *mut core::ffi::c_int,
+        v_min: core::ffi::c_int,
+        v_max: core::ffi::c_int,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igVSliderScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         size: ImVec2,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_min: *const cty::c_void,
-        p_max: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_min: *const core::ffi::c_void,
+        p_max: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiSliderFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputText(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextMultiline(
-        label: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         size: ImVec2,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputTextWithHint(
-        label: *const cty::c_char,
-        hint: *const cty::c_char,
-        buf: *mut cty::c_char,
+        label: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+        buf: *mut core::ffi::c_char,
         buf_size: usize,
         flags: ImGuiInputTextFlags,
         callback: ImGuiInputTextCallback,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
         step: f32,
         step_fast: f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat2(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputFloat4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f32,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
-        step: cty::c_int,
-        step_fast: cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
+        step: core::ffi::c_int,
+        step_fast: core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt2(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt3(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputInt4(
-        label: *const cty::c_char,
-        v: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        v: *mut core::ffi::c_int,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputDouble(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         v: *mut f64,
         step: f64,
         step_fast: f64,
-        format: *const cty::c_char,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputScalar(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igInputScalarN(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         data_type: ImGuiDataType,
-        p_data: *mut cty::c_void,
-        components: cty::c_int,
-        p_step: *const cty::c_void,
-        p_step_fast: *const cty::c_void,
-        format: *const cty::c_char,
+        p_data: *mut core::ffi::c_void,
+        components: core::ffi::c_int,
+        p_step: *const core::ffi::c_void,
+        p_step_fast: *const core::ffi::c_void,
+        format: *const core::ffi::c_char,
         flags: ImGuiInputTextFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorEdit3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -3245,7 +3260,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorEdit4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -3253,7 +3268,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorPicker3(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
     ) -> bool;
@@ -3261,7 +3276,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorPicker4(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         col: *mut f32,
         flags: ImGuiColorEditFlags,
         ref_col: *const f32,
@@ -3270,7 +3285,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igColorButton(
-        desc_id: *const cty::c_char,
+        desc_id: *const core::ffi::c_char,
         col: ImVec4,
         flags: ImGuiColorEditFlags,
         size: ImVec2,
@@ -3282,45 +3297,53 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_Str(label: *const cty::c_char) -> bool;
+    pub fn igTreeNode_Str(label: *const core::ffi::c_char) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_StrStr(str_id: *const cty::c_char, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_StrStr(
+        str_id: *const core::ffi::c_char,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNode_Ptr(ptr_id: *const cty::c_void, fmt: *const cty::c_char, ...) -> bool;
+    pub fn igTreeNode_Ptr(
+        ptr_id: *const core::ffi::c_void,
+        fmt: *const core::ffi::c_char,
+        ...
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreeNodeEx_Str(label: *const cty::c_char, flags: ImGuiTreeNodeFlags) -> bool;
+    pub fn igTreeNodeEx_Str(label: *const core::ffi::c_char, flags: ImGuiTreeNodeFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTreeNodeEx_StrStr(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTreeNodeEx_Ptr(
-        ptr_id: *const cty::c_void,
+        ptr_id: *const core::ffi::c_void,
         flags: ImGuiTreeNodeFlags,
-        fmt: *const cty::c_char,
+        fmt: *const core::ffi::c_char,
         ...
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreePush_Str(str_id: *const cty::c_char);
+    pub fn igTreePush_Str(str_id: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTreePush_Ptr(ptr_id: *const cty::c_void);
+    pub fn igTreePush_Ptr(ptr_id: *const core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3333,14 +3356,14 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCollapsingHeader_TreeNodeFlags(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igCollapsingHeader_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_visible: *mut bool,
         flags: ImGuiTreeNodeFlags,
     ) -> bool;
@@ -3356,7 +3379,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSelectable_Bool(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         selected: bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -3365,7 +3388,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSelectable_BoolPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_selected: *mut bool,
         flags: ImGuiSelectableFlags,
         size: ImVec2,
@@ -3375,8 +3398,8 @@ extern "C" {
 extern "C" {
     pub fn igBeginMultiSelect(
         flags: ImGuiMultiSelectFlags,
-        selection_size: cty::c_int,
-        items_count: cty::c_int,
+        selection_size: core::ffi::c_int,
+        items_count: core::ffi::c_int,
     ) -> *mut ImGuiMultiSelectIO;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -3393,7 +3416,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginListBox(label: *const cty::c_char, size: ImVec2) -> bool;
+    pub fn igBeginListBox(label: *const core::ffi::c_char, size: ImVec2) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3402,54 +3425,54 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igListBox_Str_arr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
-        items: *const *const cty::c_char,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
+        items: *const *const core::ffi::c_char,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igListBox_FnStrPtr(
-        label: *const cty::c_char,
-        current_item: *mut cty::c_int,
+        label: *const core::ffi::c_char,
+        current_item: *mut core::ffi::c_int,
         getter: ::core::option::Option<
             unsafe extern "C" fn(
-                user_data: *mut cty::c_void,
-                idx: cty::c_int,
-            ) -> *const cty::c_char,
+                user_data: *mut core::ffi::c_void,
+                idx: core::ffi::c_int,
+            ) -> *const core::ffi::c_char,
         >,
-        user_data: *mut cty::c_void,
-        items_count: cty::c_int,
-        height_in_items: cty::c_int,
+        user_data: *mut core::ffi::c_void,
+        items_count: core::ffi::c_int,
+        height_in_items: core::ffi::c_int,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotLines_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotLines_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -3458,28 +3481,28 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotHistogram_FloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values: *const f32,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
-        stride: cty::c_int,
+        stride: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igPlotHistogram_FnFloatPtr(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         values_getter: ::core::option::Option<
-            unsafe extern "C" fn(data: *mut cty::c_void, idx: cty::c_int) -> f32,
+            unsafe extern "C" fn(data: *mut core::ffi::c_void, idx: core::ffi::c_int) -> f32,
         >,
-        data: *mut cty::c_void,
-        values_count: cty::c_int,
-        values_offset: cty::c_int,
-        overlay_text: *const cty::c_char,
+        data: *mut core::ffi::c_void,
+        values_count: core::ffi::c_int,
+        values_offset: core::ffi::c_int,
+        overlay_text: *const core::ffi::c_char,
         scale_min: f32,
         scale_max: f32,
         graph_size: ImVec2,
@@ -3487,19 +3510,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Bool(prefix: *const cty::c_char, b: bool);
+    pub fn igValue_Bool(prefix: *const core::ffi::c_char, b: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Int(prefix: *const cty::c_char, v: cty::c_int);
+    pub fn igValue_Int(prefix: *const core::ffi::c_char, v: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Uint(prefix: *const cty::c_char, v: cty::c_uint);
+    pub fn igValue_Uint(prefix: *const core::ffi::c_char, v: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igValue_Float(prefix: *const cty::c_char, v: f32, float_format: *const cty::c_char);
+    pub fn igValue_Float(
+        prefix: *const core::ffi::c_char,
+        v: f32,
+        float_format: *const core::ffi::c_char,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3519,7 +3546,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginMenu(label: *const cty::c_char, enabled: bool) -> bool;
+    pub fn igBeginMenu(label: *const core::ffi::c_char, enabled: bool) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3528,8 +3555,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItem_Bool(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         selected: bool,
         enabled: bool,
     ) -> bool;
@@ -3537,8 +3564,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igMenuItem_BoolPtr(
-        label: *const cty::c_char,
-        shortcut: *const cty::c_char,
+        label: *const core::ffi::c_char,
+        shortcut: *const core::ffi::c_char,
         p_selected: *mut bool,
         enabled: bool,
     ) -> bool;
@@ -3553,7 +3580,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetTooltip(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3561,16 +3588,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetItemTooltip(fmt: *const cty::c_char, ...);
+    pub fn igSetItemTooltip(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginPopup(str_id: *const cty::c_char, flags: ImGuiWindowFlags) -> bool;
+    pub fn igBeginPopup(str_id: *const core::ffi::c_char, flags: ImGuiWindowFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupModal(
-        name: *const cty::c_char,
+        name: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiWindowFlags,
     ) -> bool;
@@ -3581,7 +3608,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igOpenPopup_Str(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopup_Str(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3589,7 +3616,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igOpenPopupOnItemClick(str_id: *const cty::c_char, popup_flags: ImGuiPopupFlags);
+    pub fn igOpenPopupOnItemClick(str_id: *const core::ffi::c_char, popup_flags: ImGuiPopupFlags);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3598,33 +3625,33 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextItem(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextWindow(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginPopupContextVoid(
-        str_id: *const cty::c_char,
+        str_id: *const core::ffi::c_char,
         popup_flags: ImGuiPopupFlags,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igIsPopupOpen(str_id: *const cty::c_char, flags: ImGuiPopupFlags) -> bool;
+    pub fn igIsPopupOpen(str_id: *const core::ffi::c_char, flags: ImGuiPopupFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTable(
-        str_id: *const cty::c_char,
-        columns: cty::c_int,
+        str_id: *const core::ffi::c_char,
+        columns: core::ffi::c_int,
         flags: ImGuiTableFlags,
         outer_size: ImVec2,
         inner_width: f32,
@@ -3644,12 +3671,12 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnIndex(column_n: cty::c_int) -> bool;
+    pub fn igTableSetColumnIndex(column_n: core::ffi::c_int) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igTableSetupColumn(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         flags: ImGuiTableColumnFlags,
         init_width_or_weight: f32,
         user_id: ImGuiID,
@@ -3657,11 +3684,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetupScrollFreeze(cols: cty::c_int, rows: cty::c_int);
+    pub fn igTableSetupScrollFreeze(cols: core::ffi::c_int, rows: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableHeader(label: *const cty::c_char);
+    pub fn igTableHeader(label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3677,39 +3704,39 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnCount() -> cty::c_int;
+    pub fn igTableGetColumnCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnIndex() -> cty::c_int;
+    pub fn igTableGetColumnIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetRowIndex() -> cty::c_int;
+    pub fn igTableGetRowIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnName(column_n: cty::c_int) -> *const cty::c_char;
+    pub fn igTableGetColumnName(column_n: core::ffi::c_int) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetColumnFlags(column_n: cty::c_int) -> ImGuiTableColumnFlags;
+    pub fn igTableGetColumnFlags(column_n: core::ffi::c_int) -> ImGuiTableColumnFlags;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetColumnEnabled(column_n: cty::c_int, v: bool);
+    pub fn igTableSetColumnEnabled(column_n: core::ffi::c_int, v: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableGetHoveredColumn() -> cty::c_int;
+    pub fn igTableGetHoveredColumn() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: cty::c_int);
+    pub fn igTableSetBgColor(target: ImGuiTableBgTarget, color: ImU32, column_n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igColumns(count: cty::c_int, id: *const cty::c_char, borders: bool);
+    pub fn igColumns(count: core::ffi::c_int, id: *const core::ffi::c_char, borders: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3717,31 +3744,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnIndex() -> cty::c_int;
+    pub fn igGetColumnIndex() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnWidth(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnWidth(column_index: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetColumnWidth(column_index: cty::c_int, width: f32);
+    pub fn igSetColumnWidth(column_index: core::ffi::c_int, width: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnOffset(column_index: cty::c_int) -> f32;
+    pub fn igGetColumnOffset(column_index: core::ffi::c_int) -> f32;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetColumnOffset(column_index: cty::c_int, offset_x: f32);
+    pub fn igSetColumnOffset(column_index: core::ffi::c_int, offset_x: f32);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetColumnsCount() -> cty::c_int;
+    pub fn igGetColumnsCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igBeginTabBar(str_id: *const cty::c_char, flags: ImGuiTabBarFlags) -> bool;
+    pub fn igBeginTabBar(str_id: *const core::ffi::c_char, flags: ImGuiTabBarFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3750,7 +3777,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igBeginTabItem(
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         p_open: *mut bool,
         flags: ImGuiTabItemFlags,
     ) -> bool;
@@ -3761,23 +3788,23 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igTabItemButton(label: *const cty::c_char, flags: ImGuiTabItemFlags) -> bool;
+    pub fn igTabItemButton(label: *const core::ffi::c_char, flags: ImGuiTabItemFlags) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const cty::c_char);
+    pub fn igSetTabItemClosed(tab_or_docked_window_label: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToTTY(auto_open_depth: cty::c_int);
+    pub fn igLogToTTY(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToFile(auto_open_depth: cty::c_int, filename: *const cty::c_char);
+    pub fn igLogToFile(auto_open_depth: core::ffi::c_int, filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogToClipboard(auto_open_depth: cty::c_int);
+    pub fn igLogToClipboard(auto_open_depth: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3794,8 +3821,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSetDragDropPayload(
-        type_: *const cty::c_char,
-        data: *const cty::c_void,
+        type_: *const core::ffi::c_char,
+        data: *const core::ffi::c_void,
         sz: usize,
         cond: ImGuiCond,
     ) -> bool;
@@ -3811,7 +3838,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igAcceptDragDropPayload(
-        type_: *const cty::c_char,
+        type_: *const core::ffi::c_char,
         flags: ImGuiDragDropFlags,
     ) -> *const ImGuiPayload;
 }
@@ -3849,7 +3876,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetKeyboardFocusHere(offset: cty::c_int);
+    pub fn igSetKeyboardFocusHere(offset: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3949,7 +3976,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetFrameCount() -> cty::c_int;
+    pub fn igGetFrameCount() -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3957,7 +3984,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const cty::c_char;
+    pub fn igGetStyleColorName(idx: ImGuiCol) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -3971,8 +3998,8 @@ extern "C" {
 extern "C" {
     pub fn igCalcTextSize(
         pOut: *mut ImVec2,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         hide_text_after_double_hash: bool,
         wrap_width: f32,
     );
@@ -4025,11 +4052,11 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> cty::c_int;
+    pub fn igGetKeyPressedAmount(key: ImGuiKey, repeat_delay: f32, rate: f32) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetKeyName(key: ImGuiKey) -> *const cty::c_char;
+    pub fn igGetKeyName(key: ImGuiKey) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4065,7 +4092,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> cty::c_int;
+    pub fn igGetMouseClickedCount(button: ImGuiMouseButton) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4113,31 +4140,31 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igGetClipboardText() -> *const cty::c_char;
+    pub fn igGetClipboardText() -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSetClipboardText(text: *const cty::c_char);
+    pub fn igSetClipboardText(text: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLoadIniSettingsFromDisk(ini_filename: *const cty::c_char);
+    pub fn igLoadIniSettingsFromDisk(ini_filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLoadIniSettingsFromMemory(ini_data: *const cty::c_char, ini_size: usize);
+    pub fn igLoadIniSettingsFromMemory(ini_data: *const core::ffi::c_char, ini_size: usize);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSaveIniSettingsToDisk(ini_filename: *const cty::c_char);
+    pub fn igSaveIniSettingsToDisk(ini_filename: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const cty::c_char;
+    pub fn igSaveIniSettingsToMemory(out_ini_size: *mut usize) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugTextEncoding(text: *const cty::c_char);
+    pub fn igDebugTextEncoding(text: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4150,7 +4177,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igDebugCheckVersionAndDataLayout(
-        version_str: *const cty::c_char,
+        version_str: *const core::ffi::c_char,
         sz_io: usize,
         sz_style: usize,
         sz_vec2: usize,
@@ -4161,14 +4188,14 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igDebugLog(fmt: *const cty::c_char, ...);
+    pub fn igDebugLog(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn igSetAllocatorFunctions(
         alloc_func: ImGuiMemAllocFunc,
         free_func: ImGuiMemFreeFunc,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4176,16 +4203,16 @@ extern "C" {
     pub fn igGetAllocatorFunctions(
         p_alloc_func: *mut ImGuiMemAllocFunc,
         p_free_func: *mut ImGuiMemFreeFunc,
-        p_user_data: *mut *mut cty::c_void,
+        p_user_data: *mut *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igMemAlloc(size: usize) -> *mut cty::c_void;
+    pub fn igMemAlloc(size: usize) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igMemFree(ptr: *mut cty::c_void);
+    pub fn igMemFree(ptr: *mut core::ffi::c_void);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4229,7 +4256,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: cty::c_int, down: bool);
+    pub fn ImGuiIO_AddMouseButtonEvent(self_: *mut ImGuiIO, button: core::ffi::c_int, down: bool);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4245,7 +4272,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: cty::c_uint);
+    pub fn ImGuiIO_AddInputCharacter(self_: *mut ImGuiIO, c: core::ffi::c_uint);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4253,16 +4280,16 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const cty::c_char);
+    pub fn ImGuiIO_AddInputCharactersUTF8(self_: *mut ImGuiIO, str_: *const core::ffi::c_char);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiIO_SetKeyEventNativeData(
         self_: *mut ImGuiIO,
         key: ImGuiKey,
-        native_keycode: cty::c_int,
-        native_scancode: cty::c_int,
-        native_legacy_index: cty::c_int,
+        native_keycode: core::ffi::c_int,
+        native_scancode: core::ffi::c_int,
+        native_legacy_index: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4301,17 +4328,17 @@ extern "C" {
 extern "C" {
     pub fn ImGuiInputTextCallbackData_DeleteChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        bytes_count: cty::c_int,
+        pos: core::ffi::c_int,
+        bytes_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiInputTextCallbackData_InsertChars(
         self_: *mut ImGuiInputTextCallbackData,
-        pos: cty::c_int,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        pos: core::ffi::c_int,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4340,7 +4367,10 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiPayload_IsDataType(self_: *mut ImGuiPayload, type_: *const cty::c_char) -> bool;
+    pub fn ImGuiPayload_IsDataType(
+        self_: *mut ImGuiPayload,
+        type_: *const core::ffi::c_char,
+    ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4361,7 +4391,7 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextFilter_ImGuiTextFilter(
-        default_filter: *const cty::c_char,
+        default_filter: *const core::ffi::c_char,
     ) -> *mut ImGuiTextFilter;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4372,7 +4402,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_Draw(
         self_: *mut ImGuiTextFilter,
-        label: *const cty::c_char,
+        label: *const core::ffi::c_char,
         width: f32,
     ) -> bool;
 }
@@ -4380,8 +4410,8 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextFilter_PassFilter(
         self_: *mut ImGuiTextFilter,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4407,8 +4437,8 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextRange_ImGuiTextRange_Str(
-        _b: *const cty::c_char,
-        _e: *const cty::c_char,
+        _b: *const core::ffi::c_char,
+        _e: *const core::ffi::c_char,
     ) -> *mut ImGuiTextRange;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4419,7 +4449,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiTextRange_split(
         self_: *mut ImGuiTextRange,
-        separator: cty::c_char,
+        separator: core::ffi::c_char,
         out: *mut ImVector_ImGuiTextRange,
     );
 }
@@ -4433,15 +4463,15 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_begin(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_end(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> cty::c_int;
+    pub fn ImGuiTextBuffer_size(self_: *mut ImGuiTextBuffer) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4453,25 +4483,25 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: cty::c_int);
+    pub fn ImGuiTextBuffer_reserve(self_: *mut ImGuiTextBuffer, capacity: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const cty::c_char;
+    pub fn ImGuiTextBuffer_c_str(self_: *mut ImGuiTextBuffer) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiTextBuffer_append(
         self_: *mut ImGuiTextBuffer,
-        str_: *const cty::c_char,
-        str_end: *const cty::c_char,
+        str_: *const core::ffi::c_char,
+        str_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Int(
         _key: ImGuiID,
-        _val: cty::c_int,
+        _val: core::ffi::c_int,
     ) -> *mut ImGuiStoragePair;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4489,7 +4519,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiStoragePair_ImGuiStoragePair_Ptr(
         _key: ImGuiID,
-        _val: *mut cty::c_void,
+        _val: *mut core::ffi::c_void,
     ) -> *mut ImGuiStoragePair;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4501,12 +4531,12 @@ extern "C" {
     pub fn ImGuiStorage_GetInt(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: cty::c_int);
+    pub fn ImGuiStorage_SetInt(self_: *mut ImGuiStorage, key: ImGuiID, val: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4526,19 +4556,26 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_GetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID) -> *mut cty::c_void;
+    pub fn ImGuiStorage_GetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+    ) -> *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetVoidPtr(self_: *mut ImGuiStorage, key: ImGuiID, val: *mut cty::c_void);
+    pub fn ImGuiStorage_SetVoidPtr(
+        self_: *mut ImGuiStorage,
+        key: ImGuiID,
+        val: *mut core::ffi::c_void,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiStorage_GetIntRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: cty::c_int,
-    ) -> *mut cty::c_int;
+        default_val: core::ffi::c_int,
+    ) -> *mut core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4561,8 +4598,8 @@ extern "C" {
     pub fn ImGuiStorage_GetVoidPtrRef(
         self_: *mut ImGuiStorage,
         key: ImGuiID,
-        default_val: *mut cty::c_void,
-    ) -> *mut *mut cty::c_void;
+        default_val: *mut core::ffi::c_void,
+    ) -> *mut *mut core::ffi::c_void;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4570,7 +4607,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: cty::c_int);
+    pub fn ImGuiStorage_SetAllInt(self_: *mut ImGuiStorage, val: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4584,7 +4621,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_Begin(
         self_: *mut ImGuiListClipper,
-        items_count: cty::c_int,
+        items_count: core::ffi::c_int,
         items_height: f32,
     );
 }
@@ -4600,20 +4637,23 @@ extern "C" {
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemByIndex(
         self_: *mut ImGuiListClipper,
-        item_index: cty::c_int,
+        item_index: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImGuiListClipper_IncludeItemsByIndex(
         self_: *mut ImGuiListClipper,
-        item_begin: cty::c_int,
-        item_end: cty::c_int,
+        item_begin: core::ffi::c_int,
+        item_end: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiListClipper_SeekCursorForItem(self_: *mut ImGuiListClipper, item_index: cty::c_int);
+    pub fn ImGuiListClipper_SeekCursorForItem(
+        self_: *mut ImGuiListClipper,
+        item_index: core::ffi::c_int,
+    );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -4634,10 +4674,10 @@ extern "C" {
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImColor_ImColor_Int(
-        r: cty::c_int,
-        g: cty::c_int,
-        b: cty::c_int,
-        a: cty::c_int,
+        r: core::ffi::c_int,
+        g: core::ffi::c_int,
+        b: core::ffi::c_int,
+        a: core::ffi::c_int,
     ) -> *mut ImColor;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4697,7 +4737,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetNextSelectedItem(
         self_: *mut ImGuiSelectionBasicStorage,
-        opaque_it: *mut *mut cty::c_void,
+        opaque_it: *mut *mut core::ffi::c_void,
         out_id: *mut ImGuiID,
     ) -> bool;
 }
@@ -4705,7 +4745,7 @@ extern "C" {
 extern "C" {
     pub fn ImGuiSelectionBasicStorage_GetStorageIdFromIndex(
         self_: *mut ImGuiSelectionBasicStorage,
-        idx: cty::c_int,
+        idx: core::ffi::c_int,
     ) -> ImGuiID;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4757,7 +4797,7 @@ extern "C" {
     pub fn ImDrawListSplitter_Split(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        count: cty::c_int,
+        count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4769,7 +4809,7 @@ extern "C" {
     pub fn ImDrawListSplitter_SetCurrentChannel(
         self_: *mut ImDrawListSplitter,
         draw_list: *mut ImDrawList,
-        channel_idx: cty::c_int,
+        channel_idx: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4909,7 +4949,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4920,7 +4960,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4930,7 +4970,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4941,7 +4981,7 @@ extern "C" {
         center: ImVec2,
         radius: f32,
         col: ImU32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4952,7 +4992,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
         thickness: f32,
     );
 }
@@ -4964,7 +5004,7 @@ extern "C" {
         radius: ImVec2,
         col: ImU32,
         rot: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4973,8 +5013,8 @@ extern "C" {
         self_: *mut ImDrawList,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -4985,8 +5025,8 @@ extern "C" {
         font_size: f32,
         pos: ImVec2,
         col: ImU32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip_rect: *const ImVec4,
     );
@@ -5001,7 +5041,7 @@ extern "C" {
         p4: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5013,7 +5053,7 @@ extern "C" {
         p3: ImVec2,
         col: ImU32,
         thickness: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5021,7 +5061,7 @@ extern "C" {
     pub fn ImDrawList_AddPolyline(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
         flags: ImDrawFlags,
         thickness: f32,
@@ -5032,7 +5072,7 @@ extern "C" {
     pub fn ImDrawList_AddConvexPolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -5041,7 +5081,7 @@ extern "C" {
     pub fn ImDrawList_AddConcavePolyFilled(
         self_: *mut ImDrawList,
         points: *const ImVec2,
-        num_points: cty::c_int,
+        num_points: core::ffi::c_int,
         col: ImU32,
     );
 }
@@ -5124,7 +5164,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5133,8 +5173,8 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_of_12: cty::c_int,
-        a_max_of_12: cty::c_int,
+        a_min_of_12: core::ffi::c_int,
+        a_max_of_12: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5146,7 +5186,7 @@ extern "C" {
         rot: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5156,7 +5196,7 @@ extern "C" {
         p2: ImVec2,
         p3: ImVec2,
         p4: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5165,7 +5205,7 @@ extern "C" {
         self_: *mut ImDrawList,
         p2: ImVec2,
         p3: ImVec2,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5183,7 +5223,7 @@ extern "C" {
     pub fn ImDrawList_AddCallback(
         self_: *mut ImDrawList,
         callback: ImDrawCallback,
-        callback_data: *mut cty::c_void,
+        callback_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5196,7 +5236,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: cty::c_int);
+    pub fn ImDrawList_ChannelsSplit(self_: *mut ImDrawList, count: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5204,22 +5244,22 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: cty::c_int);
+    pub fn ImDrawList_ChannelsSetCurrent(self_: *mut ImDrawList, n: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImDrawList_PrimReserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImDrawList_PrimUnreserve(
         self_: *mut ImDrawList,
-        idx_count: cty::c_int,
-        vtx_count: cty::c_int,
+        idx_count: core::ffi::c_int,
+        vtx_count: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5301,7 +5341,7 @@ extern "C" {
     pub fn ImDrawList__CalcCircleAutoSegmentCount(
         self_: *mut ImDrawList,
         radius: f32,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5309,9 +5349,9 @@ extern "C" {
         self_: *mut ImDrawList,
         center: ImVec2,
         radius: f32,
-        a_min_sample: cty::c_int,
-        a_max_sample: cty::c_int,
-        a_step: cty::c_int,
+        a_min_sample: core::ffi::c_int,
+        a_max_sample: core::ffi::c_int,
+        a_step: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5322,7 +5362,7 @@ extern "C" {
         radius: f32,
         a_min: f32,
         a_max: f32,
-        num_segments: cty::c_int,
+        num_segments: core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5385,8 +5425,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontGlyphRangesBuilder_AddText(
         self_: *mut ImFontGlyphRangesBuilder,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5441,7 +5481,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromFileTTF(
         self_: *mut ImFontAtlas,
-        filename: *const cty::c_char,
+        filename: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -5451,8 +5491,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryTTF(
         self_: *mut ImFontAtlas,
-        font_data: *mut cty::c_void,
-        font_data_size: cty::c_int,
+        font_data: *mut core::ffi::c_void,
+        font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -5462,8 +5502,8 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedTTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data: *const cty::c_void,
-        compressed_font_data_size: cty::c_int,
+        compressed_font_data: *const core::ffi::c_void,
+        compressed_font_data_size: core::ffi::c_int,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -5473,7 +5513,7 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(
         self_: *mut ImFontAtlas,
-        compressed_font_data_base85: *const cty::c_char,
+        compressed_font_data_base85: *const core::ffi::c_char,
         size_pixels: f32,
         font_cfg: *const ImFontConfig,
         glyph_ranges: *const ImWchar,
@@ -5503,20 +5543,20 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsAlpha8(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImFontAtlas_GetTexDataAsRGBA32(
         self_: *mut ImFontAtlas,
-        out_pixels: *mut *mut cty::c_uchar,
-        out_width: *mut cty::c_int,
-        out_height: *mut cty::c_int,
-        out_bytes_per_pixel: *mut cty::c_int,
+        out_pixels: *mut *mut core::ffi::c_uchar,
+        out_width: *mut core::ffi::c_int,
+        out_height: *mut core::ffi::c_int,
+        out_bytes_per_pixel: *mut core::ffi::c_int,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5569,9 +5609,9 @@ extern "C" {
 extern "C" {
     pub fn ImFontAtlas_AddCustomRectRegular(
         self_: *mut ImFontAtlas,
-        width: cty::c_int,
-        height: cty::c_int,
-    ) -> cty::c_int;
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5579,17 +5619,17 @@ extern "C" {
         self_: *mut ImFontAtlas,
         font: *mut ImFont,
         id: ImWchar,
-        width: cty::c_int,
-        height: cty::c_int,
+        width: core::ffi::c_int,
+        height: core::ffi::c_int,
         advance_x: f32,
         offset: ImVec2,
-    ) -> cty::c_int;
+    ) -> core::ffi::c_int;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
     pub fn ImFontAtlas_GetCustomRectByIndex(
         self_: *mut ImFontAtlas,
-        index: cty::c_int,
+        index: core::ffi::c_int,
     ) -> *mut ImFontAtlasCustomRect;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5638,7 +5678,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const cty::c_char;
+    pub fn ImFont_GetDebugName(self_: *mut ImFont) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5648,9 +5688,9 @@ extern "C" {
         size: f32,
         max_width: f32,
         wrap_width: f32,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
-        remaining: *mut *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
+        remaining: *mut *const core::ffi::c_char,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5658,10 +5698,10 @@ extern "C" {
     pub fn ImFont_CalcWordWrapPositionA(
         self_: *mut ImFont,
         scale: f32,
-        text: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
-    ) -> *const cty::c_char;
+    ) -> *const core::ffi::c_char;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5683,8 +5723,8 @@ extern "C" {
         pos: ImVec2,
         col: ImU32,
         clip_rect: ImVec4,
-        text_begin: *const cty::c_char,
-        text_end: *const cty::c_char,
+        text_begin: *const core::ffi::c_char,
+        text_end: *const core::ffi::c_char,
         wrap_width: f32,
         cpu_fine_clip: bool,
     );
@@ -5699,7 +5739,7 @@ extern "C" {
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: cty::c_int);
+    pub fn ImFont_GrowIndex(self_: *mut ImFont, new_size: core::ffi::c_int);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
@@ -5730,8 +5770,8 @@ extern "C" {
 extern "C" {
     pub fn ImFont_IsGlyphRangeUnused(
         self_: *mut ImFont,
-        c_begin: cty::c_uint,
-        c_last: cty::c_uint,
+        c_begin: core::ffi::c_uint,
+        c_last: core::ffi::c_uint,
     ) -> bool;
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
@@ -5774,19 +5814,26 @@ extern "C" {
 extern "C" {
     pub fn ImGuiFreeType_SetAllocatorFunctions(
         alloc_func: ::core::option::Option<
-            unsafe extern "C" fn(sz: usize, user_data: *mut cty::c_void) -> *mut cty::c_void,
+            unsafe extern "C" fn(
+                sz: usize,
+                user_data: *mut core::ffi::c_void,
+            ) -> *mut core::ffi::c_void,
         >,
         free_func: ::core::option::Option<
-            unsafe extern "C" fn(ptr: *mut cty::c_void, user_data: *mut cty::c_void),
+            unsafe extern "C" fn(ptr: *mut core::ffi::c_void, user_data: *mut core::ffi::c_void),
         >,
-        user_data: *mut cty::c_void,
+        user_data: *mut core::ffi::c_void,
     );
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn igLogText(fmt: *const cty::c_char, ...);
+    pub fn igLogText(fmt: *const core::ffi::c_char, ...);
 }
 #[link(wasm_import_module = "imgui-sys-v0")]
 extern "C" {
-    pub fn ImGuiTextBuffer_appendf(buffer: *mut ImGuiTextBuffer, fmt: *const cty::c_char, ...);
+    pub fn ImGuiTextBuffer_appendf(
+        buffer: *mut ImGuiTextBuffer,
+        fmt: *const core::ffi::c_char,
+        ...
+    );
 }

--- a/imgui/src/input_widget.rs
+++ b/imgui/src/input_widget.rs
@@ -304,7 +304,7 @@ where
                 sys::igInputTextWithHint(
                     label,
                     hint,
-                    ptr as *mut sys::cty::c_char,
+                    ptr as *mut core::ffi::c_char,
                     capacity,
                     self.flags.bits() as i32,
                     Some(callback::<T>),
@@ -315,7 +315,7 @@ where
 
                 sys::igInputText(
                     label,
-                    ptr as *mut sys::cty::c_char,
+                    ptr as *mut core::ffi::c_char,
                     capacity,
                     self.flags.bits() as i32,
                     Some(callback::<T>),
@@ -461,7 +461,7 @@ impl<'ui, 'p, T: InputTextCallbackHandler, L: AsRef<str>> InputTextMultiline<'ui
         let o = unsafe {
             sys::igInputTextMultiline(
                 self.ui.scratch_txt(self.label),
-                ptr as *mut sys::cty::c_char,
+                ptr as *mut core::ffi::c_char,
                 capacity,
                 self.size.into(),
                 self.flags.bits() as i32,

--- a/imgui/src/lib.rs
+++ b/imgui/src/lib.rs
@@ -236,7 +236,7 @@ impl Ui {
     }
 
     /// Internal method to push a single text to our scratch buffer.
-    fn scratch_txt(&self, txt: impl AsRef<str>) -> *const sys::cty::c_char {
+    fn scratch_txt(&self, txt: impl AsRef<str>) -> *const core::ffi::c_char {
         unsafe {
             let handle = &mut *self.buffer.get();
             handle.scratch_txt(txt)
@@ -244,7 +244,7 @@ impl Ui {
     }
 
     /// Internal method to push an option text to our scratch buffer.
-    fn scratch_txt_opt(&self, txt: Option<impl AsRef<str>>) -> *const sys::cty::c_char {
+    fn scratch_txt_opt(&self, txt: Option<impl AsRef<str>>) -> *const core::ffi::c_char {
         unsafe {
             let handle = &mut *self.buffer.get();
             handle.scratch_txt_opt(txt)
@@ -255,7 +255,7 @@ impl Ui {
         &self,
         txt_0: impl AsRef<str>,
         txt_1: impl AsRef<str>,
-    ) -> (*const sys::cty::c_char, *const sys::cty::c_char) {
+    ) -> (*const core::ffi::c_char, *const core::ffi::c_char) {
         unsafe {
             let handle = &mut *self.buffer.get();
             handle.scratch_txt_two(txt_0, txt_1)
@@ -266,7 +266,7 @@ impl Ui {
         &self,
         txt_0: impl AsRef<str>,
         txt_1: Option<impl AsRef<str>>,
-    ) -> (*const sys::cty::c_char, *const sys::cty::c_char) {
+    ) -> (*const core::ffi::c_char, *const core::ffi::c_char) {
         unsafe {
             let handle = &mut *self.buffer.get();
             handle.scratch_txt_with_opt(txt_0, txt_1)
@@ -418,7 +418,7 @@ impl Ui {
 
     /// Create [`Id`] from a pointer
     pub fn new_id_ptr<T>(&self, input: &T) -> Id {
-        let p = input as *const T as *const sys::cty::c_void;
+        let p = input as *const T as *const core::ffi::c_void;
         let value = unsafe { sys::igGetID_Ptr(p) };
         Id(value)
     }

--- a/imgui/src/string.rs
+++ b/imgui/src/string.rs
@@ -22,7 +22,7 @@ impl UiBuffer {
     }
 
     /// Internal method to push a single text to our scratch buffer.
-    pub fn scratch_txt(&mut self, txt: impl AsRef<str>) -> *const sys::cty::c_char {
+    pub fn scratch_txt(&mut self, txt: impl AsRef<str>) -> *const core::ffi::c_char {
         self.refresh_buffer();
 
         let start_of_substr = self.push(txt);
@@ -30,7 +30,7 @@ impl UiBuffer {
     }
 
     /// Internal method to push an option text to our scratch buffer.
-    pub fn scratch_txt_opt(&mut self, txt: Option<impl AsRef<str>>) -> *const sys::cty::c_char {
+    pub fn scratch_txt_opt(&mut self, txt: Option<impl AsRef<str>>) -> *const core::ffi::c_char {
         match txt {
             Some(v) => self.scratch_txt(v),
             None => ptr::null(),
@@ -42,7 +42,7 @@ impl UiBuffer {
         &mut self,
         txt_0: impl AsRef<str>,
         txt_1: impl AsRef<str>,
-    ) -> (*const sys::cty::c_char, *const sys::cty::c_char) {
+    ) -> (*const core::ffi::c_char, *const core::ffi::c_char) {
         self.refresh_buffer();
 
         let first_offset = self.push(txt_0);
@@ -56,7 +56,7 @@ impl UiBuffer {
         &mut self,
         txt_0: impl AsRef<str>,
         txt_1: Option<impl AsRef<str>>,
-    ) -> (*const sys::cty::c_char, *const sys::cty::c_char) {
+    ) -> (*const core::ffi::c_char, *const core::ffi::c_char) {
         match txt_1 {
             Some(value) => self.scratch_txt_two(txt_0, value),
             None => (self.scratch_txt(txt_0), ptr::null()),
@@ -76,7 +76,7 @@ impl UiBuffer {
     /// # Safety
     /// This can return a pointer to undefined data if given a `pos >= self.buffer.len()`.
     /// This is marked as unsafe to reflect that.
-    pub unsafe fn offset(&self, pos: usize) -> *const sys::cty::c_char {
+    pub unsafe fn offset(&self, pos: usize) -> *const core::ffi::c_char {
         self.buffer.as_ptr().add(pos) as *const _
     }
 

--- a/imgui/src/text_filter.rs
+++ b/imgui/src/text_filter.rs
@@ -22,7 +22,7 @@ impl TextFilter {
         let ptr = filter.as_mut_ptr();
         Self {
             id: label,
-            raw: unsafe { sys::ImGuiTextFilter_ImGuiTextFilter(ptr as *mut sys::cty::c_char) },
+            raw: unsafe { sys::ImGuiTextFilter_ImGuiTextFilter(ptr as *mut core::ffi::c_char) },
         }
     }
 
@@ -51,7 +51,7 @@ impl TextFilter {
             let mut id = self.id.clone();
             id.push('\0');
             let ptr = id.as_mut_ptr();
-            sys::ImGuiTextFilter_Draw(self.raw, ptr as *mut sys::cty::c_char, size);
+            sys::ImGuiTextFilter_Draw(self.raw, ptr as *mut core::ffi::c_char, size);
         }
     }
 
@@ -68,7 +68,7 @@ impl TextFilter {
         buf.push('\0');
         let ptr = buf.as_mut_ptr();
         unsafe {
-            sys::ImGuiTextFilter_PassFilter(self.raw, ptr as *mut sys::cty::c_char, ptr::null())
+            sys::ImGuiTextFilter_PassFilter(self.raw, ptr as *mut core::ffi::c_char, ptr::null())
         }
     }
 
@@ -81,8 +81,8 @@ impl TextFilter {
         unsafe {
             sys::ImGuiTextFilter_PassFilter(
                 self.raw,
-                b_ptr as *mut sys::cty::c_char,
-                e_ptr as *mut sys::cty::c_char,
+                b_ptr as *mut core::ffi::c_char,
+                e_ptr as *mut core::ffi::c_char,
             )
         }
     }


### PR DESCRIPTION
Hello!

It appears that you're currently still using the `chlorine` crate. While I do love the dedication, since those definitions were added to `core::ffi` in 1.64, and since your readme has an msrv listed of 1.70, I've gone ahead and deleted your use of `chlorine` and moved you over to just using `core::ffi`. I hope everything has been set right, it passed a local `cargo test`.