### PR TITLE
move platform and renderer backends out of Dear Imgui

### DIFF
--- a/imgui/src/context.rs
+++ b/imgui/src/context.rs
@@ -664,7 +664,7 @@ impl Context {
             backend: Box::new(backend),
         };
 
-        crate::PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|c| *c = Some(ctx));
+        crate::PLATFORM_VIEWPORT_CONTEXT.set(ctx);
 
         let pio = self.platform_io_mut();
         pio.platform_create_window = Some(docking_utils::platform_create_window);
@@ -703,7 +703,7 @@ impl Context {
             backend: Box::new(backend),
         };
 
-        crate::RENDERER_VIEWPORT_CONTEXT.with_borrow_mut(|c| *c = Some(ctx));
+        crate::RENDERER_VIEWPORT_CONTEXT.set(ctx);
 
         let pio = self.platform_io_mut();
         pio.renderer_create_window = Some(docking_utils::renderer_create_window);

--- a/imgui/src/context.rs
+++ b/imgui/src/context.rs
@@ -683,12 +683,11 @@ impl Context {
     /// Installs a [`PlatformViewportBackend`](crate::PlatformViewportBackend) that is used to
     /// create platform windows on demand if a window is dragged outside of the main viewport.
     pub fn set_platform_backend<T: crate::PlatformViewportBackend>(&mut self, backend: T) {
-        let ctx = Box::new(UnsafeCell::new(crate::PlatformViewportContext {
+        let ctx = crate::PlatformViewportContext {
             backend: Box::new(backend),
-        }));
+        };
 
-        let io = self.io_mut();
-        io.backend_platform_user_data = ctx.get() as *mut _;
+        *crate::PLATFORM_VIEWPORT_BACKEND.lock().unwrap() = Some(ctx);
 
         let pio = self.platform_io_mut();
         pio.platform_create_window = Some(docking_utils::platform_create_window);
@@ -719,18 +718,15 @@ impl Context {
         pio.platform_render_window = Some(docking_utils::platform_render_window);
         pio.platform_swap_buffers = Some(docking_utils::platform_swap_buffers);
         pio.platform_create_vk_surface = Some(docking_utils::platform_create_vk_surface);
-
-        self.platform_viewport_ctx = ctx;
     }
     /// Installs a [`RendererViewportBackend`](crate::RendererViewportBackend) that is used to
     /// render extra viewports created by ImGui.
     pub fn set_renderer_backend<T: crate::RendererViewportBackend>(&mut self, backend: T) {
-        let ctx = Box::new(UnsafeCell::new(crate::RendererViewportContext {
+        let ctx = crate::RendererViewportContext {
             backend: Box::new(backend),
-        }));
+        };
 
-        let io = self.io_mut();
-        io.backend_renderer_user_data = ctx.get() as *mut _;
+        *crate::RENDERER_VIEWPORT_BACKEND.lock().unwrap() = Some(ctx);
 
         let pio = self.platform_io_mut();
         pio.renderer_create_window = Some(docking_utils::renderer_create_window);
@@ -738,8 +734,6 @@ impl Context {
         pio.renderer_set_window_size = Some(docking_utils::renderer_set_window_size);
         pio.renderer_render_window = Some(docking_utils::renderer_render_window);
         pio.renderer_swap_buffers = Some(docking_utils::renderer_swap_buffers);
-
-        self.renderer_viewport_ctx = ctx;
     }
     /// Updates the extra Viewports created by ImGui.
     /// Has to be called every frame if Viewports are enabled.

--- a/imgui/src/context.rs
+++ b/imgui/src/context.rs
@@ -664,7 +664,7 @@ impl Context {
             backend: Box::new(backend),
         };
 
-        *crate::PLATFORM_VIEWPORT_BACKEND.lock().unwrap() = Some(ctx);
+        crate::PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|c| *c = Some(ctx));
 
         let pio = self.platform_io_mut();
         pio.platform_create_window = Some(docking_utils::platform_create_window);
@@ -703,7 +703,7 @@ impl Context {
             backend: Box::new(backend),
         };
 
-        *crate::RENDERER_VIEWPORT_BACKEND.lock().unwrap() = Some(ctx);
+        crate::RENDERER_VIEWPORT_CONTEXT.with_borrow_mut(|c| *c = Some(ctx));
 
         let pio = self.platform_io_mut();
         pio.renderer_create_window = Some(docking_utils::renderer_create_window);

--- a/imgui/src/context.rs
+++ b/imgui/src/context.rs
@@ -63,13 +63,6 @@ pub struct Context {
     // imgui a mutable pointer to it.
     clipboard_ctx: Box<UnsafeCell<ClipboardContext>>,
 
-    // we need to store an owning reference to our PlatformViewportBackend and PlatformRendererBackend,
-    // so that it is ensured that PlatformIo::backend_platform_user_data and PlatformIo::backend_renderer_user_data remain valid
-    #[cfg(feature = "docking")]
-    platform_viewport_ctx: Box<UnsafeCell<crate::PlatformViewportContext>>,
-    #[cfg(feature = "docking")]
-    renderer_viewport_ctx: Box<UnsafeCell<crate::RendererViewportContext>>,
-
     ui: Ui,
 }
 
@@ -253,14 +246,6 @@ impl Context {
             platform_name: None,
             renderer_name: None,
             clipboard_ctx: Box::new(ClipboardContext::dummy().into()),
-            #[cfg(feature = "docking")]
-            platform_viewport_ctx: Box::new(UnsafeCell::new(
-                crate::PlatformViewportContext::dummy(),
-            )),
-            #[cfg(feature = "docking")]
-            renderer_viewport_ctx: Box::new(UnsafeCell::new(
-                crate::RendererViewportContext::dummy(),
-            )),
             ui: Ui {
                 buffer: UnsafeCell::new(crate::string::UiBuffer::new(1024)),
             },
@@ -350,14 +335,6 @@ impl SuspendedContext {
             platform_name: None,
             renderer_name: None,
             clipboard_ctx: Box::new(ClipboardContext::dummy().into()),
-            #[cfg(feature = "docking")]
-            platform_viewport_ctx: Box::new(UnsafeCell::new(
-                crate::PlatformViewportContext::dummy(),
-            )),
-            #[cfg(feature = "docking")]
-            renderer_viewport_ctx: Box::new(UnsafeCell::new(
-                crate::RendererViewportContext::dummy(),
-            )),
             ui: Ui {
                 buffer: UnsafeCell::new(crate::string::UiBuffer::new(1024)),
             },

--- a/imgui/src/docking_utils.rs
+++ b/imgui/src/docking_utils.rs
@@ -7,10 +7,10 @@ use std::{
 use crate::{PlatformIo, Viewport};
 
 thread_local!(
-    pub(crate) static PLATFORM_VIEWPORT_CONTEXT: RefCell<Option<crate::PlatformViewportContext>> = const { RefCell::new(None) });
+    pub(crate) static PLATFORM_VIEWPORT_CONTEXT: RefCell<crate::PlatformViewportContext> = RefCell::new(PlatformViewportContext::dummy()));
 
 thread_local!(
-    pub(crate) static RENDERER_VIEWPORT_CONTEXT: RefCell<Option<crate::RendererViewportContext>> = const { RefCell::new(None) });
+    pub(crate) static RENDERER_VIEWPORT_CONTEXT: RefCell<crate::RendererViewportContext> = RefCell::new(RendererViewportContext::dummy()));
 
 /// Trait holding functions needed when the platform integration supports viewports.
 ///
@@ -72,39 +72,26 @@ pub trait PlatformViewportBackend: 'static {
     ) -> i32;
 }
 
-#[inline]
-fn get_platform(
-    ctx: &mut Option<PlatformViewportContext>,
-) -> &mut Box<dyn PlatformViewportBackend> {
-    &mut ctx.as_mut().unwrap().backend
-}
-
-#[inline]
-fn get_renderer(
-    ctx: &mut Option<RendererViewportContext>,
-) -> &mut Box<dyn RendererViewportBackend> {
-    &mut ctx.as_mut().unwrap().backend
-}
-
 pub(crate) extern "C" fn platform_create_window(viewport: *mut Viewport) {
-    PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx: &mut Option<crate::PlatformViewportContext>| {
-        get_platform(ctx).create_window(unsafe { &mut *viewport });
+    PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx: &mut crate::PlatformViewportContext| {
+        ctx.backend.create_window(unsafe { &mut *viewport });
     })
 }
 pub(crate) extern "C" fn platform_destroy_window(viewport: *mut Viewport) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_platform(ctx).destroy_window(unsafe { &mut *viewport });
+        ctx.backend.destroy_window(unsafe { &mut *viewport });
     })
 }
 
 pub(crate) extern "C" fn platform_show_window(viewport: *mut Viewport) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_platform(ctx).show_window(unsafe { &mut *viewport });
+        ctx.backend.show_window(unsafe { &mut *viewport });
     })
 }
 pub(crate) extern "C" fn platform_set_window_pos(viewport: *mut Viewport, pos: sys::ImVec2) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_platform(ctx).set_window_pos(unsafe { &mut *viewport }, [pos.x, pos.y]);
+        ctx.backend
+            .set_window_pos(unsafe { &mut *viewport }, [pos.x, pos.y]);
     })
 }
 pub(crate) extern "C" fn platform_get_window_pos(
@@ -112,7 +99,7 @@ pub(crate) extern "C" fn platform_get_window_pos(
     out_pos: *mut sys::ImVec2,
 ) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        let pos = get_platform(ctx).get_window_pos(unsafe { &mut *viewport });
+        let pos = ctx.backend.get_window_pos(unsafe { &mut *viewport });
         unsafe {
             *out_pos = sys::ImVec2::new(pos[0], pos[1]);
         }
@@ -120,59 +107,60 @@ pub(crate) extern "C" fn platform_get_window_pos(
 }
 pub(crate) extern "C" fn platform_set_window_size(viewport: *mut Viewport, size: sys::ImVec2) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_platform(ctx).set_window_size(unsafe { &mut *viewport }, [size.x, size.y]);
+        ctx.backend
+            .set_window_size(unsafe { &mut *viewport }, [size.x, size.y]);
     })
 }
 pub(crate) extern "C" fn platform_get_window_size(
     viewport: *mut Viewport,
     out_size: *mut sys::ImVec2,
 ) {
-    PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx: &mut Option<crate::PlatformViewportContext>| {
-        let size = get_platform(ctx).get_window_size(unsafe { &mut *viewport });
+    PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
+        let size = ctx.backend.get_window_size(unsafe { &mut *viewport });
         unsafe {
             *out_size = sys::ImVec2::new(size[0], size[1]);
         }
     })
 }
 pub(crate) extern "C" fn platform_set_window_focus(viewport: *mut Viewport) {
-    PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx: &mut Option<crate::PlatformViewportContext>| {
-        get_platform(ctx).set_window_focus(unsafe { &mut *viewport });
+    PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
+        ctx.backend.set_window_focus(unsafe { &mut *viewport });
     })
 }
 pub(crate) extern "C" fn platform_get_window_focus(viewport: *mut Viewport) -> bool {
-    PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx: &mut Option<crate::PlatformViewportContext>| {
-        get_platform(ctx).get_window_focus(unsafe { &mut *viewport })
-    })
+    PLATFORM_VIEWPORT_CONTEXT
+        .with_borrow_mut(|ctx| ctx.backend.get_window_focus(unsafe { &mut *viewport }))
 }
 pub(crate) extern "C" fn platform_get_window_minimized(viewport: *mut Viewport) -> bool {
-    PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx: &mut Option<crate::PlatformViewportContext>| {
-        get_platform(ctx).get_window_minimized(unsafe { &mut *viewport })
-    })
+    PLATFORM_VIEWPORT_CONTEXT
+        .with_borrow_mut(|ctx| ctx.backend.get_window_minimized(unsafe { &mut *viewport }))
 }
 pub(crate) extern "C" fn platform_set_window_title(viewport: *mut Viewport, title: *const c_char) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
         let title = unsafe { CStr::from_ptr(title).to_str().unwrap() };
-        get_platform(ctx).set_window_title(unsafe { &mut *viewport }, title);
+        ctx.backend
+            .set_window_title(unsafe { &mut *viewport }, title);
     })
 }
 pub(crate) extern "C" fn platform_set_window_alpha(viewport: *mut Viewport, alpha: f32) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_platform(ctx).set_window_alpha(unsafe { &mut *viewport }, alpha);
+        ctx.backend
+            .set_window_alpha(unsafe { &mut *viewport }, alpha);
     })
 }
 pub(crate) extern "C" fn platform_update_window(viewport: *mut Viewport) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_platform(ctx).update_window(unsafe { &mut *viewport });
+        ctx.backend.update_window(unsafe { &mut *viewport });
     })
 }
 pub(crate) extern "C" fn platform_render_window(viewport: *mut Viewport, _arg: *mut c_void) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_platform(ctx).render_window(unsafe { &mut *viewport });
+        ctx.backend.render_window(unsafe { &mut *viewport });
     })
 }
 pub(crate) extern "C" fn platform_swap_buffers(viewport: *mut Viewport, _arg: *mut c_void) {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_platform(ctx).swap_buffers(unsafe { &mut *viewport });
+        ctx.backend.swap_buffers(unsafe { &mut *viewport });
     })
 }
 pub(crate) extern "C" fn platform_create_vk_surface(
@@ -182,9 +170,10 @@ pub(crate) extern "C" fn platform_create_vk_surface(
     out_surface: *mut u64,
 ) -> c_int {
     PLATFORM_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_platform(ctx).create_vk_surface(unsafe { &mut *viewport }, instance, unsafe {
-            &mut *out_surface
-        })
+        ctx.backend
+            .create_vk_surface(unsafe { &mut *viewport }, instance, unsafe {
+                &mut *out_surface
+            })
     })
 }
 
@@ -290,27 +279,28 @@ pub trait RendererViewportBackend: 'static {
 
 pub(crate) extern "C" fn renderer_create_window(viewport: *mut Viewport) {
     RENDERER_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_renderer(ctx).create_window(unsafe { &mut *viewport });
+        ctx.backend.create_window(unsafe { &mut *viewport });
     })
 }
 pub(crate) extern "C" fn renderer_destroy_window(viewport: *mut Viewport) {
     RENDERER_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_renderer(ctx).destroy_window(unsafe { &mut *viewport });
+        ctx.backend.destroy_window(unsafe { &mut *viewport });
     })
 }
 pub(crate) extern "C" fn renderer_set_window_size(viewport: *mut Viewport, size: sys::ImVec2) {
     RENDERER_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_renderer(ctx).set_window_size(unsafe { &mut *viewport }, [size.x, size.y]);
+        ctx.backend
+            .set_window_size(unsafe { &mut *viewport }, [size.x, size.y]);
     })
 }
 pub(crate) extern "C" fn renderer_render_window(viewport: *mut Viewport, _arg: *mut c_void) {
     RENDERER_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_renderer(ctx).render_window(unsafe { &mut *viewport });
+        ctx.backend.render_window(unsafe { &mut *viewport });
     })
 }
 pub(crate) extern "C" fn renderer_swap_buffers(viewport: *mut Viewport, _arg: *mut c_void) {
     RENDERER_VIEWPORT_CONTEXT.with_borrow_mut(|ctx| {
-        get_renderer(ctx).swap_buffers(unsafe { &mut *viewport });
+        ctx.backend.swap_buffers(unsafe { &mut *viewport });
     })
 }
 
@@ -350,8 +340,6 @@ impl RendererViewportContext {
         }
     }
 }
-
-unsafe impl Send for RendererViewportContext {}
 
 /// Describes a monitor that can be used by ImGui.
 #[repr(C)]

--- a/imgui/src/docking_utils.rs
+++ b/imgui/src/docking_utils.rs
@@ -188,9 +188,90 @@ pub(crate) extern "C" fn platform_create_vk_surface(
     })
 }
 
+/// The default [`PlatformViewportBackend`], does nothing.
+pub(crate) struct DummyPlatformViewportBackend {}
+impl PlatformViewportBackend for DummyPlatformViewportBackend {
+    fn create_window(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn destroy_window(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn show_window(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn set_window_pos(&mut self, _viewport: &mut Viewport, _pos: [f32; 2]) {
+        unimplemented!()
+    }
+
+    fn get_window_pos(&mut self, _viewport: &mut Viewport) -> [f32; 2] {
+        unimplemented!()
+    }
+
+    fn set_window_size(&mut self, _viewport: &mut Viewport, _size: [f32; 2]) {
+        unimplemented!()
+    }
+
+    fn get_window_size(&mut self, _viewport: &mut Viewport) -> [f32; 2] {
+        unimplemented!()
+    }
+
+    fn set_window_focus(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn get_window_focus(&mut self, _viewport: &mut Viewport) -> bool {
+        unimplemented!()
+    }
+
+    fn get_window_minimized(&mut self, _viewport: &mut Viewport) -> bool {
+        unimplemented!()
+    }
+
+    fn set_window_title(&mut self, _viewport: &mut Viewport, _title: &str) {
+        unimplemented!()
+    }
+
+    fn set_window_alpha(&mut self, _viewport: &mut Viewport, _alpha: f32) {
+        unimplemented!()
+    }
+
+    fn update_window(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn render_window(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn swap_buffers(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn create_vk_surface(
+        &mut self,
+        _viewport: &mut Viewport,
+        _instance: u64,
+        _out_surface: &mut u64,
+    ) -> i32 {
+        unimplemented!()
+    }
+}
+
 /// Just holds a [`PlatformViewportBackend`].
 pub(crate) struct PlatformViewportContext {
     pub(crate) backend: Box<dyn PlatformViewportBackend>,
+}
+
+impl PlatformViewportContext {
+    pub(crate) fn dummy() -> Self {
+        Self {
+            backend: Box::new(DummyPlatformViewportBackend {}),
+        }
+    }
 }
 
 /// Trait that holds optional functions for a rendering backend to support multiple viewports.
@@ -233,10 +314,44 @@ pub(crate) extern "C" fn renderer_swap_buffers(viewport: *mut Viewport, _arg: *m
     })
 }
 
+/// The default [`RendererViewportBackend`], does nothing.
+pub(crate) struct DummyRendererViewportBackend {}
+impl RendererViewportBackend for DummyRendererViewportBackend {
+    fn create_window(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn destroy_window(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn set_window_size(&mut self, _viewport: &mut Viewport, _size: [f32; 2]) {
+        unimplemented!()
+    }
+
+    fn render_window(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+
+    fn swap_buffers(&mut self, _viewport: &mut Viewport) {
+        unimplemented!()
+    }
+}
+
 /// Just holds a [`RendererViewportBackend`].
 pub(crate) struct RendererViewportContext {
     pub(crate) backend: Box<dyn RendererViewportBackend>,
 }
+
+impl RendererViewportContext {
+    pub(crate) fn dummy() -> Self {
+        Self {
+            backend: Box::new(DummyRendererViewportBackend {}),
+        }
+    }
+}
+
+unsafe impl Send for RendererViewportContext {}
 
 /// Describes a monitor that can be used by ImGui.
 #[repr(C)]

--- a/imgui/src/docking_utils.rs
+++ b/imgui/src/docking_utils.rs
@@ -2,7 +2,7 @@ use std::{
     cell::UnsafeCell,
     ffi::{c_void, CStr},
     os::raw::{c_char, c_int},
-    sync::{Mutex, MutexGuard},
+    sync::Mutex,
 };
 
 use crate::{PlatformIo, Viewport};
@@ -175,90 +175,9 @@ pub(crate) extern "C" fn platform_create_vk_surface(
         })
 }
 
-/// The default [`PlatformViewportBackend`], does nothing.
-pub(crate) struct DummyPlatformViewportBackend {}
-impl PlatformViewportBackend for DummyPlatformViewportBackend {
-    fn create_window(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn destroy_window(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn show_window(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn set_window_pos(&mut self, _viewport: &mut Viewport, _pos: [f32; 2]) {
-        unimplemented!()
-    }
-
-    fn get_window_pos(&mut self, _viewport: &mut Viewport) -> [f32; 2] {
-        unimplemented!()
-    }
-
-    fn set_window_size(&mut self, _viewport: &mut Viewport, _size: [f32; 2]) {
-        unimplemented!()
-    }
-
-    fn get_window_size(&mut self, _viewport: &mut Viewport) -> [f32; 2] {
-        unimplemented!()
-    }
-
-    fn set_window_focus(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn get_window_focus(&mut self, _viewport: &mut Viewport) -> bool {
-        unimplemented!()
-    }
-
-    fn get_window_minimized(&mut self, _viewport: &mut Viewport) -> bool {
-        unimplemented!()
-    }
-
-    fn set_window_title(&mut self, _viewport: &mut Viewport, _title: &str) {
-        unimplemented!()
-    }
-
-    fn set_window_alpha(&mut self, _viewport: &mut Viewport, _alpha: f32) {
-        unimplemented!()
-    }
-
-    fn update_window(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn render_window(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn swap_buffers(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn create_vk_surface(
-        &mut self,
-        _viewport: &mut Viewport,
-        _instance: u64,
-        _out_surface: &mut u64,
-    ) -> i32 {
-        unimplemented!()
-    }
-}
-
 /// Just holds a [`PlatformViewportBackend`].
 pub(crate) struct PlatformViewportContext {
     pub(crate) backend: Box<dyn PlatformViewportBackend>,
-}
-
-impl PlatformViewportContext {
-    pub(crate) fn dummy() -> Self {
-        Self {
-            backend: Box::new(DummyPlatformViewportBackend {}),
-        }
-    }
 }
 
 unsafe impl Send for PlatformViewportContext {}
@@ -299,41 +218,9 @@ pub(crate) extern "C" fn renderer_swap_buffers(viewport: *mut Viewport, _arg: *m
     ctx.backend.swap_buffers(unsafe { &mut *viewport });
 }
 
-/// The default [`RendererViewportBackend`], does nothing.
-pub(crate) struct DummyRendererViewportBackend {}
-impl RendererViewportBackend for DummyRendererViewportBackend {
-    fn create_window(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn destroy_window(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn set_window_size(&mut self, _viewport: &mut Viewport, _size: [f32; 2]) {
-        unimplemented!()
-    }
-
-    fn render_window(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-
-    fn swap_buffers(&mut self, _viewport: &mut Viewport) {
-        unimplemented!()
-    }
-}
-
 /// Just holds a [`RendererViewportBackend`].
 pub(crate) struct RendererViewportContext {
     pub(crate) backend: Box<dyn RendererViewportBackend>,
-}
-
-impl RendererViewportContext {
-    pub(crate) fn dummy() -> Self {
-        Self {
-            backend: Box::new(DummyRendererViewportBackend {}),
-        }
-    }
 }
 
 unsafe impl Send for RendererViewportContext {}


### PR DESCRIPTION
Store the objects containing the callback methods for multi viewport
support in two crate globals that are managed by imgui-rs, instead of using
BackendPlatformUserdata and BackendRendererUserData

fixes https://github.com/imgui-rs/imgui-rs/issues/820